### PR TITLE
Fixup namespaces tests

### DIFF
--- a/pact-core-tests/pact-tests/namespaces.repl
+++ b/pact-core-tests/pact-tests/namespaces.repl
@@ -278,7 +278,7 @@
 
 (begin-tx)
 
-(env-exec-config [])
+(env-exec-config ['RequireKeysetNs])
 
 (expect
   "Setting namespace back to root namespace post-Pact 4.7 fork succeeds"


### PR DESCRIPTION
The tests were written assuming namespaced keysets are the default behavior (since legacy pact has a negative flag for that, `DisablePact44`), and ported assuming namespaced keysets aren't implemented yet.

This brings these tests more in line with the pact-core flags/semantics.