### PR TITLE
Move parser to use more fv-accurate parsing

### DIFF
--- a/pact-core-tests/pact-tests/meta.repl
+++ b/pact-core-tests/pact-tests/meta.repl
@@ -2,7 +2,7 @@
 
 (module mod 'k
   @doc   "this defines mod"
-  @model [(property (do (crazy stuff)))]
+  @model [(defproperty crazy-stuff (do (crazy stuff))) ]
 
   (defun foo ()
     @doc "foo the town"
@@ -18,7 +18,7 @@
     3)
 
   (defun modeldoc ()
-    @model [(property stuff) (invariant stuff2)]
+    @model [(property stuff) (property stuff2)]
     @doc "stuff"
     4)
 
@@ -27,7 +27,7 @@
   (defconst BAZ 2 "docstrings work without @doc")
 
   (defschema schema
-    @model [(property stuff)] a:integer)
+    @model [(invariant stuff)] a:integer)
 
   (defschema schema2
     "a schema" a:integer)

--- a/pact-core/Pact/Core/Syntax/ParseTree.hs
+++ b/pact-core/Pact/Core/Syntax/ParseTree.hs
@@ -104,7 +104,7 @@ data Defun i
   , _dfunRetType :: Maybe Type
   , _dfunTerm :: Expr i
   , _dfunDocs :: Maybe Text
-  , _dfunModel :: Maybe [FVFunModel i]
+  , _dfunModel :: Maybe [Property i]
   , _dfunInfo :: i
   } deriving Show
 
@@ -129,7 +129,7 @@ data DefCap i
   , _dcapRetType :: Maybe Type
   , _dcapTerm :: Expr i
   , _dcapDocs :: Maybe Text
-  , _dcapModel :: Maybe [FVFunModel i]
+  , _dcapModel :: Maybe [Property i]
   , _dcapMeta :: Maybe DCapMeta
   , _dcapInfo :: i
   } deriving Show
@@ -139,7 +139,7 @@ data DefSchema i
   { _dscName :: Text
   , _dscArgs :: [Arg]
   , _dscDocs :: Maybe Text
-  , _dscModel :: Maybe [FVFunModel i]
+  , _dscModel :: Maybe [Invariant i]
   , _dscInfo :: i
   } deriving Show
 
@@ -152,8 +152,8 @@ data DefTable i
   } deriving Show
 
 data PactStep i
-  = Step (Expr i) (Maybe [FVFunModel i])
-  | StepWithRollback (Expr i) (Expr i) (Maybe [FVFunModel i])
+  = Step (Expr i) (Maybe [Property i])
+  | StepWithRollback (Expr i) (Expr i) (Maybe [Property i])
   deriving Show
 
 data DefPact i
@@ -163,7 +163,7 @@ data DefPact i
   , _dpRetType :: Maybe Type
   , _dpSteps :: [PactStep i]
   , _dpDocs :: Maybe Text
-  , _dpModel :: Maybe [FVFunModel i]
+  , _dpModel :: Maybe [Property i]
   , _dpInfo :: i
   } deriving Show
 
@@ -209,16 +209,6 @@ newtype Invariant i
   = Invariant (Expr i)
   deriving Show
 
-data FVModel i
-  = FVDefProperty (DefProperty i)
-  | FVProperty (Property i)
-  | FVInvariant (Invariant i)
-  deriving Show
-
-data FVFunModel i
-  = FVFunProperty (Property i)
-  | FVFunInvariant (Invariant i)
-  deriving Show
 
 data Module i
   = Module
@@ -227,7 +217,7 @@ data Module i
   , _mExternal :: [ExtDecl]
   , _mDefs :: NonEmpty (Def i)
   , _mDoc :: Maybe Text
-  , _mModel :: [FVModel i]
+  , _mModel :: [DefProperty i]
   , _mInfo :: i
   } deriving Show
 
@@ -244,7 +234,7 @@ data Interface i
   , _ifDefns :: [IfDef i]
   , _ifImports :: [Import]
   , _ifDocs :: Maybe Text
-  , _ifModel :: Maybe [FVFunModel i]
+  , _ifModel :: [DefProperty i]
   , _ifInfo :: i
   } deriving Show
 
@@ -254,7 +244,7 @@ data IfDefun i
   , _ifdArgs :: [MArg]
   , _ifdRetType :: Maybe Type
   , _ifdDocs :: Maybe Text
-  , _ifdModel :: Maybe [FVFunModel i]
+  , _ifdModel :: Maybe [Property i]
   , _ifdInfo :: i
   } deriving Show
 
@@ -264,7 +254,7 @@ data IfDefCap i
   , _ifdcArgs :: [MArg]
   , _ifdcRetType :: Maybe Type
   , _ifdcDocs :: Maybe Text
-  , _ifdcModel :: Maybe [FVFunModel i]
+  , _ifdcModel :: Maybe [Property i]
   , _ifdcMeta :: Maybe DCapMeta
   , _ifdcInfo :: i
   } deriving Show
@@ -275,7 +265,7 @@ data IfDefPact i
   , _ifdpArgs :: [MArg]
   , _ifdpRetType :: Maybe Type
   , _ifdpDocs :: Maybe Text
-  , _ifdpModel :: Maybe [FVFunModel i]
+  , _ifdpModel :: Maybe [Property i]
   , _ifdpInfo :: i
   } deriving Show
 


### PR DESCRIPTION
This PR enforces more strictness on where `property` and `invariant` can show up vs master.

TODO: we have a regression on `meta.repl`... Should we then PR this?