### PR TITLE
Keep the current module type and account for it in `resolve{Module,Interface}Name`

### DIFF
--- a/pact-core/Pact/Core/IR/Desugar.hs
+++ b/pact-core/Pact/Core/IR/Desugar.hs
@@ -81,10 +81,13 @@ import qualified Pact.Core.Syntax.ParseTree as Lisp
 
 type DesugarType = Lisp.Type
 
+data ModuleType = MTModule | MTInterface
+
 data CurrModule
   = CurrModule
   { _cmName :: ModuleName
   , _cmImplements :: [ModuleName]
+  , _cmType :: ModuleType
   }
 makeLenses ''CurrModule
 
@@ -513,7 +516,7 @@ desugarModule
   -> RenamerT b i m (Module ParsedName DesugarType b i)
 desugarModule (Lisp.Module mname mgov extdecls defs _ _ i) = do
   (imports, blessed, implemented) <- splitExts extdecls
-  defs' <- locally reCurrModule (const (Just $ CurrModule mname [])) $ traverse desugarDef (NE.toList defs)
+  defs' <- locally reCurrModule (const (Just $ CurrModule mname [] MTModule)) $ traverse desugarDef (NE.toList defs)
   pure $ Module mname mgov defs' blessed imports implemented placeholderHash i
   where
   splitExts = split ([], S.empty, [])
@@ -781,7 +784,7 @@ resolveModuleName
   -> RenamerT b i m (ModuleName, [ModuleName])
 resolveModuleName i mn =
   view reCurrModule >>= \case
-    Just (CurrModule currMod imps) | currMod == mn -> pure (currMod, imps)
+    Just (CurrModule currMod imps MTModule) | currMod == mn -> pure (currMod, imps)
     _ -> resolveModuleData mn i >>= \case
       ModuleData md _ -> do
         let implementeds = view mImplements md
@@ -794,8 +797,8 @@ resolveModuleName i mn =
 -- including all current
 resolveInterfaceName :: (MonadEval b i m) => i -> ModuleName -> RenamerT b i m (ModuleName)
 resolveInterfaceName i mn =
-  currModuleName >>= \case
-    Just currMod | currMod == mn -> pure currMod
+  view reCurrModule >>= \case
+    Just (CurrModule currMod _ MTInterface) | currMod == mn -> pure currMod
     _ -> resolveModuleData mn i >>= \case
       ModuleData _ _ ->
         throwDesugarError (InvalidModuleReference mn) i
@@ -1185,7 +1188,7 @@ resolveBare (BareName bn) i = views reBinds (M.lookup bn) >>= \case
     Nothing -> do
       let mn = ModuleName bn Nothing
       view reCurrModule >>= \case
-        Just (CurrModule currMod imps) | currMod == mn ->
+        Just (CurrModule currMod imps _type) | currMod == mn ->
           pure (Name bn (NModRef mn imps), Nothing)
         _ -> do
           (mn', imps) <- resolveModuleName i mn
@@ -1262,7 +1265,7 @@ renameModule (Module unmangled mgov defs blessed imports implements mhash i) = d
   go mname (defns, s, m) defn = do
     when (S.member (defName defn) s) $ throwDesugarError (DuplicateDefinition (defName defn)) i
     let dn = defName defn
-    defn' <- local (set reCurrModule (Just $ CurrModule mname implements))
+    defn' <- local (set reCurrModule (Just $ CurrModule mname implements MTModule))
              $ local (set reBinds m) $ renameDef defn
     let dk = defKind defn'
     let depPair = (NTopLevel mname mhash, dk)
@@ -1369,7 +1372,7 @@ renameInterface (Interface unmangled defs imports ih info) = do
     when (S.member dn s) $
       throwDesugarError (DuplicateDefinition dn) info
     d' <- local (set reBinds m) $
-          local (set reCurrModule (Just $ CurrModule ifn [])) $ renameIfDef d
+          local (set reCurrModule (Just $ CurrModule ifn [] MTInterface)) $ renameIfDef d
     let m' = case ifDefToDef d' of
               Just defn ->
                 let dk = defKind defn
@@ -1421,7 +1424,7 @@ runDesugarReplDefun
   -> m (DesugarOutput (Defun Name Type b i))
 runDesugarReplDefun =
   runDesugar
-  . local (set reCurrModule (Just $ CurrModule replModuleName []))
+  . local (set reCurrModule (Just $ CurrModule replModuleName [] MTModule))
   . (desugarDefun >=> renameReplDefun)
 
 runDesugarReplDefConst
@@ -1430,7 +1433,7 @@ runDesugarReplDefConst
   -> m (DesugarOutput (DefConst Name Type b i))
 runDesugarReplDefConst  =
   runDesugar
-  . local (set reCurrModule (Just $ CurrModule replModuleName []))
+  . local (set reCurrModule (Just $ CurrModule replModuleName [] MTModule))
   . (desugarDefConst >=> renameReplDefConst)
 
 runDesugarTopLevel
@@ -1468,4 +1471,4 @@ runDesugarReplTopLevel = \case
 data Unused where Unused :: a -> Unused
 
 _unused :: [Unused]
-_unused = [Unused $ set cmImplements]
+_unused = [Unused $ set cmImplements, Unused $ set cmType]


### PR DESCRIPTION
This helps with the self-referential "interface" refs like
```lisp
(module mod G
  (defcap G () true)

  (defun foo:string (a:string b:module{mod}) a)
  )
```
that currently get accepted but shouldn't.

The tests are being worked on as part of the static-tests branch.