### PR TITLE
fix multi-nested managed cap composition

### DIFF
--- a/pact-tests/pact-tests/caps.repl
+++ b/pact-tests/pact-tests/caps.repl
@@ -923,3 +923,35 @@
    (call-op2 "goodbye" false))
 
 (commit-tx)
+
+(begin-tx)
+"Test managed cap composition"
+(module cap-mgd-compose g
+  (defcap g () true)
+
+  (defun f-mgr:integer (a:integer b:integer) 1)
+
+  (defcap C1 (a:integer)
+    @managed a f-mgr
+    1)
+
+  (defcap C2 (a:integer)
+    @managed a f-mgr
+    (compose-capability (C1 a))
+  )
+
+  (defcap C3 (a:integer)
+    @managed a f-mgr
+    (compose-capability (C2 a))
+  )
+
+  (defun run ()
+    (with-capability (C3 1)
+      (require-capability (C1 1))
+      111
+    )
+  )
+  )
+
+(env-sigs [{"key":"jose", "caps":[(C1 1) (C2 1) (C3 1)]}])
+(expect "managed capabilities compose correctly" 111 (run))

--- a/pact/Pact/Core/IR/Eval/CEK.hs
+++ b/pact/Pact/Core/IR/Eval/CEK.hs
@@ -1464,7 +1464,7 @@ applyContToValue (CapBodyC cappop env info mcap mevent capbody cont) handler _ =
     Just cap -> useEvalState (esCaps . csSlots) >>= \case
       (CapSlot _ tl:rest) -> do
         setEvalState (esCaps . csSlots)  (CapSlot cap tl:rest)
-        let cont' = CapPopC PopCapInvoke cont
+        let cont' = CapPopC cappop cont
         evalCEK cont' handler env capbody
       [] -> failInvariant def "In CapBodyC but with no caps in stack"
 


### PR DESCRIPTION
While working on the gas and a direct-style evaluator, while translating the code from CEK to the direct evaluator, I noticed that we somehow slipped by hard-coding `PopCapInvoke` during `CapPopC`. It causes managed capabilities that are composed with other managed capabilities to be incorrectly popped off the cap stack.

This pr simply passes `cappop` and adds a regression for the behavior

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output


