### PR TITLE
Explicitly enforce `describe-table` top-levelness

### DIFF
--- a/pact/Pact/Core/IR/Eval/CoreBuiltin.hs
+++ b/pact/Pact/Core/IR/Eval/CoreBuiltin.hs
@@ -1394,7 +1394,8 @@ describeModule info b cont handler env = \case
 
 dbDescribeTable :: (CEKEval step b i m, MonadEval b i m) => NativeFunction step b i m
 dbDescribeTable info b cont handler _env = \case
-  [VTable (TableValue name _ schema)] ->
+  [VTable (TableValue name _ schema)] -> do
+    enforceTopLevelOnly info b
     returnCEKValue cont handler $ VObject $ M.fromList $ fmap (over _1 Field)
       [("name", PString (_tableName name))
       ,("module", PString (renderModuleName (_tableModuleName name)))


### PR DESCRIPTION
The existing `repl` tests checking that `describe-table` only happens at top-level pass by semi-coincidence: the table isn't considered a pact value, so that check errors out. This PR adds an explicit check that `describe-table` is only called at top-level, instead of relying on what constitutes a pact value.

PR checklist:

* [x] Test coverage for the proposed changes (_in a separate failure tests branch_).
* [ ] PR description contains example output from repl interaction or a snippet from unit test output
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact-core/blob/master/CHANGELOG.md)

Additionally, please justify why you should or should not do the following:

* [ ] Confirm replay/back compat
* [ ] Benchmark regressions
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
