### PR TITLE
add `pact-version` and `enforce-pact-version` builtin

### DIFF
--- a/pact-tests/pact-tests/pact-version.repl
+++ b/pact-tests/pact-tests/pact-version.repl
@@ -6,9 +6,9 @@
 (expect "min version in history" true (enforce-pact-version "1"))
 (expect "min version in history" true (enforce-pact-version "1.0"))
 (expect "min version in history" true (enforce-pact-version "1.0.100"))
-(expect-failure "min in histoy and max version in future"
-                (enforce-pact-version "1.0" "10.0"))
 
+(expect-failure "min and max version in history"
+                (enforce-pact-version "1.0" "2.0"))
 
 (expect-failure "min version in future" (enforce-pact-version "10.0"))
 (expect-failure "min version in future" (enforce-pact-version "100.0"))

--- a/pact-tests/pact-tests/pact-version.repl
+++ b/pact-tests/pact-tests/pact-version.repl
@@ -1,0 +1,18 @@
+;; tests used to verify the behavior of the `enforce-pact-version`
+;; bultin.
+
+(begin-tx)
+
+(expect "min version in history" true (enforce-pact-version "1"))
+(expect "min version in history" true (enforce-pact-version "1.0"))
+(expect "min version in history" true (enforce-pact-version "1.0.100"))
+(expect-failure "min in histoy and max version in future"
+                (enforce-pact-version "1.0" "10.0"))
+
+
+(expect-failure "min version in future" (enforce-pact-version "10.0"))
+(expect-failure "min version in future" (enforce-pact-version "100.0"))
+(expect-failure "min and max versions in future"
+                (enforce-pact-version "100.0" "1001"))
+
+(commit-tx)

--- a/pact-tests/pact-tests/toplevel.repl
+++ b/pact-tests/pact-tests/toplevel.repl
@@ -23,9 +23,9 @@
   (defun bad-describe-keyset (k) (describe-keyset k))
   (defun bad-describe-module (m) (describe-module m))
   (defun bad-define-keyset (n k) (define-keyset n k))
-  ;  (defun bad-pact-version () (pact-version))
+  (defun bad-pact-version () (pact-version))
   ;  (defun bad-list-modules () (list-modules))
-  ;  (defun bad-enforce-pact-version (v) (enforce-pact-version v))
+  (defun bad-enforce-pact-version (v) (enforce-pact-version v))
   )
 
 ;; Success cases
@@ -47,9 +47,9 @@
 (expect-failure "bad-describe-keyset" (bad-describe-keyset 'k))
 (expect-failure "bad-describe-module" (bad-describe-module "toplevel"))
 (expect-failure "bad-define-keyset" (bad-define-keyset 'j (sig-keyset)))
-;  (expect-failure "bad-pact-version" (bad-pact-version))
+(expect-failure "bad-pact-version" (bad-pact-version))
 ;  (expect-failure "bad-list-modules" (bad-list-modules))
-;  (expect-failure "bad-enforce-pact-version" (bad-enforce-pact-version (pact-version)))
+(expect-failure "bad-enforce-pact-version" (bad-enforce-pact-version (pact-version)))
 
 ; todo: enable repl natives
 ;  (env-enable-repl-natives true)
@@ -67,4 +67,3 @@
  (let ((a 1))
    (env-data { 'b: 2 }) ;; normally would not be in effect until next top-level
    (+ a (read-integer "b"))))
-

--- a/pact-tests/pact-tests/toplevel.repl
+++ b/pact-tests/pact-tests/toplevel.repl
@@ -23,7 +23,6 @@
   (defun bad-describe-keyset (k) (describe-keyset k))
   (defun bad-describe-module (m) (describe-module m))
   (defun bad-define-keyset (n k) (define-keyset n k))
-  (defun bad-pact-version () (pact-version))
   ;  (defun bad-list-modules () (list-modules))
   (defun bad-enforce-pact-version (v) (enforce-pact-version v))
   )
@@ -35,9 +34,9 @@
 (describe-table toplevel.atable)
 (describe-keyset 'k)
 (describe-module "toplevel")
-;  (pact-version)
+(pact-version)
 ;  (list-modules)
-;  (enforce-pact-version (pact-version))
+(enforce-pact-version (pact-version))
 (use toplevel)
 
 ;; failure cases
@@ -47,9 +46,7 @@
 (expect-failure "bad-describe-keyset" (bad-describe-keyset 'k))
 (expect-failure "bad-describe-module" (bad-describe-module "toplevel"))
 (expect-failure "bad-define-keyset" (bad-define-keyset 'j (sig-keyset)))
-(expect-failure "bad-pact-version" (bad-pact-version))
 ;  (expect-failure "bad-list-modules" (bad-list-modules))
-(expect-failure "bad-enforce-pact-version" (bad-enforce-pact-version (pact-version)))
 
 ; todo: enable repl natives
 ;  (env-enable-repl-natives true)

--- a/pact-tng.cabal
+++ b/pact-tng.cabal
@@ -129,6 +129,8 @@ library
     cbits/musl/sqrt.c
     cbits/musl/sqrt_data.c
 
+  other-modules: PackageInfo_pact_tng
+
   exposed-modules:
     Pact.Core.Compile
     Pact.Core.Builtin

--- a/pact/Pact/Core/Builtin.hs
+++ b/pact/Pact/Core/Builtin.hs
@@ -219,6 +219,10 @@ data CoreBuiltin
   -- Misc
   | CoreTypeOf
   | CoreDec
+  -- Pact Version
+  | CorePactVersion
+  | CoreEnforcePactVersionMin
+  | CoreEnforcePactVersionRange
   deriving (Eq, Show, Ord, Bounded, Enum, Generic)
 
 instance NFData CoreBuiltin
@@ -367,6 +371,9 @@ coreBuiltinToText = \case
   CorePactId -> "pact-id"
   CoreTypeOf -> "typeof"
   CoreDec -> "dec"
+  CorePactVersion -> "pact-version"
+  CoreEnforcePactVersionMin -> "enforce-pact-version"
+  CoreEnforcePactVersionRange -> "enforce-pact-version-range"
 
 instance IsBuiltin CoreBuiltin where
   builtinName = NativeName . coreBuiltinToText
@@ -514,6 +521,9 @@ instance IsBuiltin CoreBuiltin where
     CorePactId -> 0
     CoreTypeOf -> 1
     CoreDec -> 1
+    CorePactVersion -> 0
+    CoreEnforcePactVersionMin -> 1
+    CoreEnforcePactVersionRange -> 2
 
 
 

--- a/pact/Pact/Core/Builtin.hs
+++ b/pact/Pact/Core/Builtin.hs
@@ -219,10 +219,6 @@ data CoreBuiltin
   -- Misc
   | CoreTypeOf
   | CoreDec
-  -- Pact Version
-  | CorePactVersion
-  | CoreEnforcePactVersionMin
-  | CoreEnforcePactVersionRange
   deriving (Eq, Show, Ord, Bounded, Enum, Generic)
 
 instance NFData CoreBuiltin
@@ -371,9 +367,6 @@ coreBuiltinToText = \case
   CorePactId -> "pact-id"
   CoreTypeOf -> "typeof"
   CoreDec -> "dec"
-  CorePactVersion -> "pact-version"
-  CoreEnforcePactVersionMin -> "enforce-pact-version"
-  CoreEnforcePactVersionRange -> "enforce-pact-version-range"
 
 instance IsBuiltin CoreBuiltin where
   builtinName = NativeName . coreBuiltinToText
@@ -521,9 +514,6 @@ instance IsBuiltin CoreBuiltin where
     CorePactId -> 0
     CoreTypeOf -> 1
     CoreDec -> 1
-    CorePactVersion -> 0
-    CoreEnforcePactVersionMin -> 1
-    CoreEnforcePactVersionRange -> 2
 
 
 
@@ -574,6 +564,9 @@ data ReplBuiltins
   | RContinuePactRollbackYieldObj
   | RPactState
   | RResetPactState
+  | RPactVersion
+  | REnforcePactVersionMin
+  | REnforcePactVersionRange
   deriving (Show, Enum, Bounded, Eq, Generic)
 
 
@@ -615,6 +608,10 @@ instance IsBuiltin ReplBuiltins where
     REnvGasModel -> 1
     REnvAskGasModel -> 0
     REnvGasModelFixed -> 1
+    RPactVersion -> 0
+    REnforcePactVersionMin -> 1
+    REnforcePactVersionRange -> 2
+
     -- RLoad -> 1
     -- RLoadWithEnv -> 2
 -- Note: commented out natives are
@@ -693,6 +690,9 @@ replBuiltinsToText = \case
   REnvGasModel -> "env-gasmodel"
   REnvAskGasModel -> "env-ask-gasmodel"
   REnvGasModelFixed -> "env-gasmodel-fixed"
+  RPactVersion -> "pact-version"
+  REnforcePactVersionMin -> "enforce-pact-version"
+  REnforcePactVersionRange -> "enforce-pact-version-range"
 
 replBuiltinToText :: (t -> Text) -> ReplBuiltin t -> Text
 replBuiltinToText f = \case

--- a/pact/Pact/Core/Errors.hs
+++ b/pact/Pact/Core/Errors.hs
@@ -25,6 +25,8 @@ import Control.Monad.IO.Class(MonadIO(..))
 import Control.Exception
 import Data.Text(Text)
 import Data.Dynamic (Typeable)
+import qualified Data.Version as V
+import qualified PackageInfo_pact_tng as PI
 
 import Control.DeepSeq
 import GHC.Generics
@@ -333,6 +335,8 @@ data EvalError
   | PointNotOnCurve
   | YieldProvenanceDoesNotMatch Provenance [Provenance]
   | MismatchingKeysetNamespace NamespaceName
+  | EnforcePactVersionFailure V.Version (Maybe V.Version)
+  | EnforcePactVersionParseFailure Text
   deriving (Show, Generic)
 
 instance NFData EvalError
@@ -430,6 +434,16 @@ instance Pretty EvalError where
       , "DefPactId: " <> pretty (_psDefPactId ps)
       , "step: " <> pretty (_psStep ps)
       , "DefPactExec step: " <> pretty (_peStep pe + 1)
+      ]
+    EnforcePactVersionFailure min' max' -> Pretty.hsep
+      [ "Enforce pact-version failed:"
+      , "Current Version: " <> pretty (V.showVersion PI.version)
+      , "Minimum Version: " <> pretty (V.showVersion min')
+      , maybe mempty (\v -> "Maximum Version: " <> pretty (V.showVersion v)) max'
+      ]
+    EnforcePactVersionParseFailure str -> Pretty.hsep
+      [ "Enforce pact-version failed:"
+      , "Could not parse " <> pretty str <> ", expect list of integer seperated by dot"
       ]
     e -> pretty (show e)
 

--- a/pact/Pact/Core/Gas/TableGasModel.hs
+++ b/pact/Pact/Core/Gas/TableGasModel.hs
@@ -472,6 +472,9 @@ nativeGasTable = MilliGas . \case
   -- note: Dec requires less gas overall
   CoreDec ->
     basicWorkGas
+  CorePactVersion -> basicWorkGas
+  CoreEnforcePactVersionMin -> basicWorkGas
+  CoreEnforcePactVersionRange -> basicWorkGas
 
 replNativeGasTable :: ReplBuiltin CoreBuiltin -> MilliGas
 replNativeGasTable = \case

--- a/pact/Pact/Core/Gas/TableGasModel.hs
+++ b/pact/Pact/Core/Gas/TableGasModel.hs
@@ -472,9 +472,6 @@ nativeGasTable = MilliGas . \case
   -- note: Dec requires less gas overall
   CoreDec ->
     basicWorkGas
-  CorePactVersion -> basicWorkGas
-  CoreEnforcePactVersionMin -> basicWorkGas
-  CoreEnforcePactVersionRange -> basicWorkGas
 
 replNativeGasTable :: ReplBuiltin CoreBuiltin -> MilliGas
 replNativeGasTable = \case

--- a/pact/Pact/Core/IR/Desugar.hs
+++ b/pact/Pact/Core/IR/Desugar.hs
@@ -255,6 +255,8 @@ instance DesugarBuiltin (ReplBuiltin CoreBuiltin) where
       App (Builtin (RBuiltinRepl REnvGasModelFixed) i) [e1, e2] i
   desugarAppArity i (RBuiltinRepl RBeginTx) [e1] =
       App (Builtin (RBuiltinRepl RBeginNamedTx) i) [e1] i
+  desugarAppArity i (RBuiltinRepl REnforcePactVersionMin) [e1, e2] =
+      App (Builtin (RBuiltinRepl REnforcePactVersionRange) i) [e1, e2] i
   desugarAppArity i b ne =
     App (Builtin b i) ne i
 

--- a/pact/Pact/Core/IR/Eval/CoreBuiltin.hs
+++ b/pact/Pact/Core/IR/Eval/CoreBuiltin.hs
@@ -29,6 +29,7 @@ import Control.Lens hiding (from, to, op, parts)
 import Control.Monad
 import Control.Monad.IO.Class
 import Data.Attoparsec.Text(parseOnly)
+import qualified Data.Attoparsec.Text as A
 import Data.Containers.ListUtils(nubOrd)
 import Data.Bits
 import Data.Either(isLeft, isRight)
@@ -76,7 +77,8 @@ import Pact.Core.SizeOf
 import qualified Pact.Core.Pretty as Pretty
 import qualified Pact.Core.Principal as Pr
 import qualified Pact.Core.Trans.TOps as Musl
-
+import qualified PackageInfo_pact_tng as PI
+import qualified Data.Version as V
 
 ----------------------------------------------------------------------
 -- Our builtin definitions start here
@@ -1716,6 +1718,42 @@ poseidonHash info b cont handler _env = \case
   args -> argsError info b args
 
 -----------------------------------
+-- Pact Version
+-----------------------------------
+
+coreVersion :: (CEKEval step b i m, MonadEval b i m) => NativeFunction step b i m
+coreVersion info b  cont handler _env = \case
+  [] -> do
+    enforceTopLevelOnly info b
+    let v = T.pack (V.showVersion PI.version)
+    returnCEKValue cont handler (VString v)
+  args -> argsError info b args
+
+
+coreEnforceVersion :: (CEKEval step b i m, MonadEval b i m) => NativeFunction step b i m
+coreEnforceVersion info b cont handler _env = \case
+  [VString lowerBound] -> do
+    enforceTopLevelOnly info b
+    lowerBound' <- mkVersion lowerBound
+    if lowerBound' <= PI.version
+      then returnCEKValue cont handler (VBool True)
+      else throwExecutionError info (EnforcePactVersionFailure lowerBound' Nothing)
+  [VString lowerBound, VString upperBound] -> do
+    enforceTopLevelOnly info b
+    lowerBound' <- mkVersion lowerBound
+    upperBound' <- mkVersion upperBound
+    if lowerBound' <= PI.version && PI.version <= upperBound'
+      then returnCEKValue cont handler (VBool True)
+      else throwExecutionError info (EnforcePactVersionFailure lowerBound' (Just upperBound'))
+  args -> argsError info b args
+  where
+    mkVersion s =
+      case parseOnly ((A.decimal `A.sepBy` A.char '.') <* A.endOfInput) s of
+        Left _msg -> throwExecutionError info (EnforcePactVersionParseFailure s)
+        Right li -> pure (V.makeVersion li)
+
+
+-----------------------------------
 -- Builtin exports
 -----------------------------------
 
@@ -1873,3 +1911,6 @@ coreBuiltinRuntime = \case
   CorePactId -> corePactId
   CoreTypeOf -> coreTypeOf
   CoreDec -> coreDec
+  CorePactVersion -> coreVersion
+  CoreEnforcePactVersionMin -> coreEnforceVersion
+  CoreEnforcePactVersionRange -> coreEnforceVersion

--- a/pact/Pact/Core/Serialise/CBOR_V1.hs
+++ b/pact/Pact/Core/Serialise/CBOR_V1.hs
@@ -674,10 +674,6 @@ instance Serialise CoreBuiltin where
     CoreTypeOfPrincipal -> encodeWord 112
     CoreValidatePrincipal -> encodeWord 113
     CoreCreateDefPactGuard -> encodeWord 114
-
-    CoreRoundPrec -> encodeWord 125
-    CoreCeilingPrec -> encodeWord 126
-    CoreFloorPrec -> encodeWord 127
     CoreYieldToChain -> encodeWord 115
     CoreChainData -> encodeWord 116
     CoreIsCharset -> encodeWord 117
@@ -688,6 +684,12 @@ instance Serialise CoreBuiltin where
     CorePoseidonHashHackachain -> encodeWord 122
     CoreTypeOf -> encodeWord 123
     CoreDec -> encodeWord 124
+    CoreRoundPrec -> encodeWord 125
+    CoreCeilingPrec -> encodeWord 126
+    CoreFloorPrec -> encodeWord 127
+    CorePactVersion -> encodeWord 128
+    CoreEnforcePactVersionMin -> encodeWord 129
+    CoreEnforcePactVersionRange -> encodeWord 130
 
   decode = decodeWord >>= \case
     0 -> pure CoreAdd
@@ -820,6 +822,9 @@ instance Serialise CoreBuiltin where
     125 -> pure CoreRoundPrec
     126 -> pure CoreCeilingPrec
     127 -> pure CoreFloorPrec
+    128 -> pure CorePactVersion
+    129 -> pure CoreEnforcePactVersionMin
+    130 -> pure CoreEnforcePactVersionRange
     _ -> fail "unexpeced decoding"
 
 

--- a/pact/Pact/Core/Serialise/CBOR_V1.hs
+++ b/pact/Pact/Core/Serialise/CBOR_V1.hs
@@ -687,9 +687,6 @@ instance Serialise CoreBuiltin where
     CoreRoundPrec -> encodeWord 125
     CoreCeilingPrec -> encodeWord 126
     CoreFloorPrec -> encodeWord 127
-    CorePactVersion -> encodeWord 128
-    CoreEnforcePactVersionMin -> encodeWord 129
-    CoreEnforcePactVersionRange -> encodeWord 130
 
   decode = decodeWord >>= \case
     0 -> pure CoreAdd
@@ -822,9 +819,6 @@ instance Serialise CoreBuiltin where
     125 -> pure CoreRoundPrec
     126 -> pure CoreCeilingPrec
     127 -> pure CoreFloorPrec
-    128 -> pure CorePactVersion
-    129 -> pure CoreEnforcePactVersionMin
-    130 -> pure CoreEnforcePactVersionRange
     _ -> fail "unexpeced decoding"
 
 


### PR DESCRIPTION
This PR adds the `pact-version` and `enforce-pact-version` builtin.


closes #79 

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact-core/blob/master/CHANGELOG.md)

Additionally, please justify why you should or should not do the following:

* [ ] Confirm replay/back compat
* [ ] Benchmark regressions
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206417680988237