### PR TITLE
Fix take/drop and Obj pretty printing

### DIFF
--- a/pact-tests/pact-tests/ops.repl
+++ b/pact-tests/pact-tests/ops.repl
@@ -508,6 +508,7 @@
 (expect "shift -255 -1" -128 (shift -255 -1))
 
 "===== drop"
+; Drop on lists
 (expect "pos drop within range" [3 4 5] (drop 2 [1 2 3 4 5]))
 (expect "neg drop within range" [1 2 3] (drop -2 [1 2 3 4 5]))
 (expect "pos drop beyond range" [] (drop 10 [1 2 3 4 5]))
@@ -515,10 +516,27 @@
 (expect "pos drop at 63-bit boundary" (drop 9223372036854775807 [1 2 3 4 5]) (drop 9223372036854775808 [1 2 3 4 5]))
 (expect "neg drop at 63-bit boundary" (drop -9223372036854775807 [1 2 3 4 5]) (drop -9223372036854775808 [1 2 3 4 5]))
 
+; Drop on strings
+(expect "pos string drop within range" "345" (drop 2 "12345"))
+(expect "neg string drop within range" "123" (drop -2 "12345"))
+(expect "pos string drop beyond range" "" (drop 10 "12345"))
+(expect "neg string drop beyond range" "" (drop -10 "12345"))
+(expect "pos string drop at 63-bit boundary" (drop 9223372036854775807 "12345") (drop 9223372036854775808 "12345"))
+(expect "neg string drop at 63-bit boundary" (drop -9223372036854775807 "12345") (drop -9223372036854775808 "12345"))
+
 "===== take"
+; Take on lists
 (expect "pos take within range" [1 2] (take 2 [1 2 3 4 5]))
 (expect "neg take within range" [4 5] (take -2 [1 2 3 4 5]))
 (expect "pos take beyond range" [1 2 3 4 5] (take 10 [1 2 3 4 5]))
 (expect "neg take beyond range" [1 2 3 4 5] (take -10 [1 2 3 4 5]))
 (expect "pos take at 63-bit boundary" (take 9223372036854775807 [1 2 3 4 5]) (take 9223372036854775808 [1 2 3 4 5]))
 (expect "neg take at 63-bit boundary" (take -9223372036854775807 [1 2 3 4 5]) (take -9223372036854775808 [1 2 3 4 5]))
+
+; Take on strings
+(expect "pos string take within range" "12" (take 2 "12345"))
+(expect "neg string take within range" "45" (take -2 "12345"))
+(expect "pos string take beyond range" "12345" (take 10 "12345"))
+(expect "neg string take beyond range" "12345" (take -10 "12345"))
+(expect "pos string take at 63-bit boundary" (take 9223372036854775807 "12345") (take 9223372036854775808 "12345"))
+(expect "neg string take at 63-bit boundary" (take -9223372036854775807 "12345") (take -9223372036854775808 "12345"))

--- a/pact/Pact/Core/PactValue.hs
+++ b/pact/Pact/Core/PactValue.hs
@@ -91,10 +91,10 @@ instance Pretty PactValue where
     PObject o ->
       braces $ hsep $ punctuate comma (objPair <$> M.toList o)
       where
-      objPair (f, t) = pretty f <> ":" <> pretty t
+      objPair (f, t) = dquotes (pretty f) <> ":" <> pretty t
     PModRef md -> pretty md
     PCapToken (CapToken fqn args) ->
-      parens (pretty fqn) <> if null args then mempty else hsep (pretty <$> args)
+      parens (pretty (fqnToQualName fqn)) <> if null args then mempty else hsep (pretty <$> args)
     PTime t -> pretty (PactTime.formatTime "%Y-%m-%d %H:%M:%S%Q %Z" t)
 
 synthesizePvType :: PactValue -> Type


### PR DESCRIPTION
See: https://app.asana.com/0/1204069832833999/1206459570889561

Closes #86 
Closes #87 

This PR fixes the following:

Take/drop on strings behaving incorrectly due to incorrect bounds checks. The following is output from the repl after the fixes in this PR.

```
pact>(drop -4 "ABC")
""
pact>(drop -5 "ABC")
""
```

Object pretty printing

```
pact>(format "{}" [{'a:3}])
"{"a":3}"
pact>(print {'a:3})
{"a":3}
()
```

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
