### PR TITLE
Fix doc pretty printing

### DIFF
--- a/gasmodel/Pact/Core/GasModel/Utils.hs
+++ b/gasmodel/Pact/Core/GasModel/Utils.hs
@@ -87,7 +87,7 @@ gmKeysetName :: KeySetName
 gmKeysetName = KeySetName "gasModelKeyset" Nothing
 
 gasModelSampleSchema :: Schema
-gasModelSampleSchema =  Schema $ M.fromList
+gasModelSampleSchema =  Schema (QualifiedName "gasModelSchema" gmModuleName) $ M.fromList
   [(Field "a", TyInt)
   ,(Field "b", TyString)
   ,(Field "c", TyBool)]

--- a/pact-tests/Pact/Core/Gen/Serialise.hs
+++ b/pact-tests/Pact/Core/Gen/Serialise.hs
@@ -153,8 +153,9 @@ fieldGen = Field <$> identGen
 
 schemaGen :: Gen Schema
 schemaGen = do
+  qual <- qualifiedNameGen
   elems <- Gen.list (Range.linear 0 10) $ (,) <$> fieldGen <*> typeGen
-  pure (Schema (fromList elems))
+  pure (Schema qual (fromList elems))
 
 typeGen :: Gen Type
 typeGen = Gen.recursive Gen.choice
@@ -306,7 +307,7 @@ ifDefCapGen i = do
 defSchemaGen :: Gen i -> Gen (DefSchema Type i)
 defSchemaGen i = do
   name <- identGen
-  schema <- _schema <$> schemaGen
+  Schema _ schema <- schemaGen
   DefSchema name schema <$> i
 
 defTableGen :: Gen i -> Gen (DefTable Name i)

--- a/pact-tests/pact-tests/leftpad.repl
+++ b/pact-tests/pact-tests/leftpad.repl
@@ -63,7 +63,7 @@
 
 (module impure 'k
   (defconst VERSION 3)
-  (bless "o_4_FPBGezeMPBBnzTQd0iYLneAKxoKJeDkRpabBYxo")
+  (bless "uJfYhiwPtPfljhFw_y-4F3kNS1eWmY7Y-h8soX6pM_Q")
   (defschema foo-schema value:integer)
   (deftable foo:{foo-schema})
   (defun ins (k v) (insert foo k v)))

--- a/pact-tests/pact-tests/modulehash.repl
+++ b/pact-tests/pact-tests/modulehash.repl
@@ -1,7 +1,7 @@
 (env-data {'k:1})
 
-(defun check-hash-equivalent (mstring:string mobj:object h:string)
-  (expect (concat ["Hash of module ", mstring, " matches"]) (at "hash" mobj) h)
+(defun check-hash-equivalent (mstring:string h:string mobj:object)
+  (expect (concat ["Hash of module ", mstring, " matches"]) h (at "hash" mobj))
   )
 
 (module m m-gov
@@ -20,7 +20,7 @@
   )
 
 ; base case
-(check-hash-equivalent "m" (describe-module "m") "QCLU54Co9PbQqiqFz1F3M-pPgdn59ANGIG7bwNVFAJk")
+(check-hash-equivalent "m" "D-tSVlEyV_Ash0vvSNNMbETXon2UHZiVBWHYmMe5cuM" (describe-module "m"))
 
 (env-data {'k:2})
 (module m m-gov
@@ -40,7 +40,7 @@
 
 
 ; Defconst changed, ensure hash changed
-(check-hash-equivalent "m" (describe-module "m") "83c6a-9Hmv9yHOkaY1Y2LmHoHvXLWYc_lQ-Oacg8URw")
+(check-hash-equivalent "m" "vUNCMX5aqSPTka1slI3q3DZZUPbQkjoI5CXYk6LXlo8" (describe-module "m"))
 
 (module m m-gov
   (defcap m-gov () true)
@@ -59,7 +59,7 @@
 
 
 ; Basic code changed: hash should change
-(check-hash-equivalent "m" (describe-module "m") "WhYWXrM3oUwXRaiPela_j7d2nF5snW5SPjGUOuuJu7c")
+(check-hash-equivalent "m" "Cv79jToVuuuwFy7_JT94bKRxmQalcyQMDQ8zC-VKJPM" (describe-module "m"))
 
 ; Modules, interfaces and deps
 (module n gg
@@ -72,7 +72,7 @@
 
   )
 
-(check-hash-equivalent "n" (describe-module "n") "v30ra86hQ35kT1k8pdXnGsGU434VD7Ysa7smYhHFPs0")
+(check-hash-equivalent "n" "5QVOIDMpg7JX99D554K6jrXNOpToDiJcqpTnOa6O8J8" (describe-module "n"))
 
 ; Update dependent module, ensure hash changes
 (module m m-gov
@@ -102,7 +102,7 @@
   )
 
 ; m changed, hash should have changed
-(check-hash-equivalent "m" (describe-module "m") "BVrxWuHbjy9heR9AhAZnbusKvSKiyzrEYt8_0LCBRqs")
+(check-hash-equivalent "m" "tpECIytIOCJWkLHbIpUzQPGp5D-mbg3NLQu-FbjT-v8" (describe-module "m"))
 
 ; n did not change, but the dependency hash changed, so it should also change the hash
-(check-hash-equivalent "n" (describe-module "n") "ETUjfmMviiXCyZYxJLzk1uXBQFizGizyqPGz1XIt1lA")
+(check-hash-equivalent "n" "F0U7k7lBAZV3JWBRgCyJkJST4NJb_9Ma4Td_2dc2V-Y" (describe-module "n"))

--- a/pact-tests/pact-tests/repl-toplevels.repl
+++ b/pact-tests/pact-tests/repl-toplevels.repl
@@ -1,0 +1,6 @@
+
+(defconst repl-const1:integer 1)
+
+(defun repl-defun1:integer (a:integer b:integer) (+ a b))
+
+(expect "repl-consts work with repl defuns" 3 (repl-defun1 repl-const1 (repl-defun1 repl-const1 repl-const1)))

--- a/pact-tests/pact-tests/yield.repl
+++ b/pact-tests/pact-tests/yield.repl
@@ -92,7 +92,7 @@
 
 ;; check events
 (expect "step 0 events"
- [{"module-hash": "ODZZeJ9MhRC-x0zwkwLUzwGf41otj5ZbCi8-6dL_e0E"
+ [{"module-hash": "8WSvgxT2PtByagJP3F4uFHmOG8xiHE9sICtMzcEVOnY"
    ,"name": "pact.X_YIELD"
    ,"params": ["1" "yieldtest.cross-chain" ["emily"]]}]
  (env-events true))
@@ -106,7 +106,7 @@
 
 ;; check events
 (expect "step 1 events"
- [{"module-hash": "ODZZeJ9MhRC-x0zwkwLUzwGf41otj5ZbCi8-6dL_e0E"
+ [{"module-hash": "8WSvgxT2PtByagJP3F4uFHmOG8xiHE9sICtMzcEVOnY"
     ,"name": "pact.X_RESUME"
     ,"params": ["0" "yieldtest.cross-chain" ["emily"]]}]
  (env-events true))

--- a/pact/Pact/Core/Compile.hs
+++ b/pact/Pact/Core/Compile.hs
@@ -218,7 +218,7 @@ evalTopLevel bEnv tlFinal deps = do
       liftDbFunction (_mInfo m) (writeModule pdb Write (view mName m) mdata)
       let fqDeps = toFqDep (_mName m) (_mHash m) <$> _mDefs m
           newLoaded = M.fromList fqDeps
-          newTopLevel = M.fromList $ (\(fqn, d) -> (_fqName fqn, (fqn, defKind d))) <$> fqDeps
+          newTopLevel = M.fromList $ (\(fqn, d) -> (_fqName fqn, (fqn, defKind (_mName m) d))) <$> fqDeps
           loadNewModule =
             over loModules (M.insert (_mName m) mdata) .
             over loAllLoaded (M.union newLoaded) .
@@ -235,7 +235,7 @@ evalTopLevel bEnv tlFinal deps = do
                   <$> mapMaybe ifDefToDef (_ifDefns iface)
           newLoaded = M.fromList fqDeps
           newTopLevel = M.fromList
-                        $ (\(fqn, d) -> (_fqName fqn, (fqn, defKind d)))
+                        $ (\(fqn, d) -> (_fqName fqn, (fqn, defKind (_ifName iface) d)))
                         <$> fqDeps
           loadNewModule =
             over loModules (M.insert (_ifName iface) mdata) .

--- a/pact/Pact/Core/IR/ConstEval.hs
+++ b/pact/Pact/Core/IR/ConstEval.hs
@@ -38,7 +38,8 @@ evalModuleDefConsts bEnv (Module mname mgov defs blessed imports implements mhas
       DConst dc -> case _dcTerm dc of
         TermConst term -> do
           pv <- Eval.eval PSysOnly bEnv term
-          pure (DConst (set dcTerm (EvaledConst pv) dc))
+          pv' <- maybeTCType (_dcInfo dc) pv (_dcType dc)
+          pure (DConst (set dcTerm (EvaledConst pv') dc))
         EvaledConst _ -> pure defn
       _ -> pure defn
     let dn = defName defn

--- a/pact/Pact/Core/IR/Term.hs
+++ b/pact/Pact/Core/IR/Term.hs
@@ -28,6 +28,7 @@ import Data.List.NonEmpty (NonEmpty)
 import Data.Map.Strict(Map)
 import qualified Data.Set as Set
 import qualified Data.List.NonEmpty as NE
+import qualified Data.Map.Strict as M
 import Control.DeepSeq
 import GHC.Generics
 
@@ -265,23 +266,22 @@ findDefInModule :: Text -> Module name ty b i -> Maybe (Def name ty b i)
 findDefInModule defnName targetModule =
   find ((==) defnName . defName) (_mDefs targetModule)
 
-defKind :: Def name Type b i -> DefKind
-defKind = \case
+defKind :: ModuleName -> Def name Type b i -> DefKind
+defKind mn = \case
   Dfun{} -> DKDefun
   DConst{} -> DKDefConst
   DCap{} -> DKDefCap
-  DSchema ds -> DKDefSchema (Schema (_dsSchema ds))
+  DSchema ds -> DKDefSchema (Schema (QualifiedName (_dsName ds) mn) (_dsSchema ds))
   DTable{} -> DKDefTable
   DPact{} -> DKDefPact
 
-ifDefKind :: IfDef name Type b i -> Maybe DefKind
-ifDefKind = \case
+ifDefKind :: ModuleName -> IfDef name Type b i -> Maybe DefKind
+ifDefKind mn = \case
   IfDfun{} -> Nothing
   IfDCap{} -> Nothing
   IfDConst{} -> Just DKDefConst
   IfDPact{} -> Nothing
-
-  IfDSchema ds -> Just (DKDefSchema (Schema (_dsSchema ds)))
+  IfDSchema ds -> Just $ DKDefSchema $ (Schema (QualifiedName (_dsName ds) mn) (_dsSchema ds))
 
 ifDefName :: IfDef name ty builtin i -> Text
 ifDefName = \case
@@ -356,6 +356,55 @@ instance (Pretty name, Pretty builtin, Pretty ty) => Pretty (TopLevel name ty bu
   pretty = \case
     TLTerm tm -> pretty tm
     _ -> "todo: pretty defs/modules"
+
+prettyDef :: Pretty ty => Doc ann -> Text -> Maybe ty -> [Arg ty] -> Doc ann
+prettyDef deftoken defname defRTy defArgs =
+  let dfNameArg = Arg defname defRTy
+      argList = parens (hsep (pretty <$> defArgs))
+  in parens $ deftoken <+> pretty dfNameArg <+> argList
+
+instance Pretty ty => Pretty (Defun name ty b i) where
+  pretty (Defun name args rty _ _) =
+    prettyDef "defun" name rty args
+
+instance Pretty ty => Pretty (DefPact name ty b i) where
+  pretty (DefPact name args rty _ _) =
+    prettyDef "defpact" name rty args
+
+instance Pretty ty => Pretty (DefCap name ty b i) where
+  pretty (DefCap name args rty _ _ _) =
+    prettyDef "defcap" name rty args
+
+instance Pretty ty => Pretty (DefSchema ty info) where
+  pretty (DefSchema n schema _) =
+    let argList = [pretty arg | (Field k, t) <- M.toList schema, let arg = Arg k (Just t)]
+    in parens $ "defschema" <+> pretty n <> (if null argList then mempty else " " <> hsep argList)
+
+instance Pretty (TableSchema name) where
+  pretty (DesugaredTable pn) = pretty pn
+  pretty (ResolvedTable (Schema pn _)) = pretty pn
+
+instance Pretty (DefTable name info) where
+  pretty (DefTable tblname schema _) =
+    parens $ "deftable" <+> pretty tblname <> ":" <> pretty schema
+
+instance Pretty term => Pretty (ConstVal term) where
+  pretty = \case
+    TermConst t -> pretty t
+    EvaledConst v -> pretty v
+
+instance (Pretty name, Pretty ty, Pretty b) => Pretty (DefConst name ty b i) where
+  pretty (DefConst n ty term _) =
+    parens $ "defconst" <+> pretty n <> maybe mempty ((":" <>) . pretty) ty <+> pretty term
+
+instance (Pretty name, Pretty ty, Pretty b) => Pretty (Def name ty b i) where
+  pretty = \case
+    Dfun d -> pretty d
+    DConst d -> pretty d
+    DCap d -> pretty d
+    DSchema d -> pretty d
+    DTable d -> pretty d
+    DPact d -> pretty d
 
 
 -----------------------------------------

--- a/pact/Pact/Core/PactValue.hs
+++ b/pact/Pact/Core/PactValue.hs
@@ -120,13 +120,13 @@ checkPvType ty = \case
     | otherwise -> Nothing
   PObject o -> case ty of
     -- Todo: gas
-    TyObject (Schema sc) ->
+    TyObject (Schema n sc) ->
       let tyList = M.toList sc
           oList = M.toList o
       in tcObj oList tyList
       where
       tcObj l1 l2
-        | length l1 == length l2 = TyObject . Schema . M.fromList <$> zipWithM mcheck l1 l2
+        | length l1 == length l2 = TyObject . Schema n . M.fromList <$> zipWithM mcheck l1 l2
         | otherwise = Nothing
       mcheck (f1, pv) (f2, t)
         | f1 == f2 = (f1,) <$> checkPvType t pv

--- a/pact/Pact/Core/Repl.hs
+++ b/pact/Pact/Core/Repl.hs
@@ -68,7 +68,7 @@ runRepl = do
         "Loaded defconst" <+> pretty mn
     RBuiltinDoc doc -> outputStrLn (show $ pretty doc)
     RUserDoc qn doc -> outputStrLn $ show $
-      vsep ["function" <+> pretty qn <> ":", maybe mempty pretty doc]
+      vsep [pretty qn, "Docs:", maybe mempty pretty doc]
   catch' ma = catchAll ma (\e -> outputStrLn (show e) *> loop)
   defaultSrc = SourceCode "(interactive)" mempty
   loop = do

--- a/pact/Pact/Core/Repl/Compile.hs
+++ b/pact/Pact/Core/Repl/Compile.hs
@@ -162,8 +162,9 @@ interpretReplProgram' replEnv (SourceCode _ source) display = do
         displayValue $ RLoadedDefun $ _dfunName df
       RTLDefConst dc -> case _dcTerm dc of
         TermConst term -> do
-          v <- CEK.eval PSysOnly replEnv term
-          let dc' = set dcTerm (EvaledConst v) dc
+          pv <- CEK.eval PSysOnly replEnv term
+          pv' <- maybeTCType (_dcInfo dc) pv (_dcType dc)
+          let dc' = set dcTerm (EvaledConst pv') dc
           let fqn = FullyQualifiedName replModuleName (_dcName dc) replModuleHash
           loaded . loAllLoaded %= M.insert fqn (DConst dc')
           displayValue $ RLoadedDefConst $ _dcName dc'

--- a/pact/Pact/Core/Repl/Compile.hs
+++ b/pact/Pact/Core/Repl/Compile.hs
@@ -140,12 +140,6 @@ interpretReplProgram' replEnv (SourceCode _ source) display = do
           TLTerm (Var (Name n (NTopLevel mn mh)) varI) -> do
             let fqn = FullyQualifiedName mn n mh
             lookupFqName fqn >>= \case
-              -- Just (DConst d) -> do
-              --   case _dcTerm d of
-              --     TermConst _ ->
-              --       failInvariant varI "Defconst not fully evaluated"
-              --     EvaledConst v ->
-              --       displayValue (RCompileValue (InterpretValue v varI))
               Just d -> do
                 let qn = QualifiedName n mn
                 docs <- uses replUserDocs (M.lookup qn)

--- a/pact/Pact/Core/Serialise/CBOR_V1.hs
+++ b/pact/Pact/Core/Serialise/CBOR_V1.hs
@@ -452,8 +452,9 @@ instance Serialise PrimType where
     _ -> fail "unexpected decoding"
 
 instance Serialise Schema where
-  encode (Schema m) = encode m
-  decode = Schema <$> decode
+  encode (Schema sc m) =
+    encode sc <> encode m
+  decode = Schema <$> decode <*> decode
 
 instance Serialise Type where
   encode (TyPrim pt) = encodeWord 0 <> encode pt

--- a/pact/Pact/Core/SizeOf.hs
+++ b/pact/Pact/Core/SizeOf.hs
@@ -310,7 +310,7 @@ instance SizeOf FullyQualifiedName
 
 -- Type
 instance SizeOf PrimType
-deriving newtype instance SizeOf Schema
+instance SizeOf Schema
 instance SizeOf Type
 
 -- defpacts


### PR DESCRIPTION
In this pr, the following in a repl script

```

(module m g
  (defcap g ()
    @doc "bloop"
    true)

  (defun dfun-example:integer (a:integer)
    @doc "these are the defun docs"
    (+ a 1)
  )

  (defcap dcap-example:integer (a:integer)
    @doc "these are the defcap docs"
    (+ a 1)
  )

  (defpact dpact-example:integer (a:integer)
    @doc "these are the defpact docs"
    (step 1)
  )

  (defconst dconst-example:integer 1
    @doc "this is the defconst example"
    )

  (defschema schema-example
    @doc "this is the schema doc"
    a:integer)

  (deftable tbl-example:{schema-example}
    @doc "this is the table docs"
    )
  )

dconst-example
dfun-example
dcap-example
dpact-example
tbl-example
```

Produces
```
Loaded module m, hash LmLumnFm1auzfNPEMEbK8Q0FufFJ2sMqTGsuq2wfuqw
(defconst dconst-example:integer 1)
Docs:
this is the defconst example
(defun dfun-example:integer (a:integer))
Docs:
these are the defun docs
(defcap dcap-example:integer (a:integer))
Docs:
these are the defcap docs
(defpact dpact-example:integer (a:integer))
Docs:
these are the defpact docs
(deftable tbl-example:m.schema-example)
Docs:
this is the table docs
```

Closes #85 

Note: schema docs are currently not being spit out because we fail at compile-time for them, as they are invalid in variable positions. We should maybe turn this into a runtime failure.

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact