### PR TITLE
Expect-failure error mesage check

### DIFF
--- a/pact-tests/pact-tests/caps.repl
+++ b/pact-tests/pact-tests/caps.repl
@@ -525,7 +525,7 @@
 (install-capability (C "alice" 0 true))
 (expect-failure
  "Autonomous install on unscoped user sig cannot acquire"
- "Keyset failure"
+ "Keyset enforce failure"
  (go "alice" 0))
 
 ;; scenario: autonomous install, but fails anyway because call is not from module.
@@ -552,7 +552,7 @@
 (install-capability (C "bob" 1 true))
 (expect-failure
  "Attack with different parameters than signature cap fails"
- "Keyset failure"
+ "Keyset enforce failure"
  (go "bob" 1))
 
 (commit-tx)
@@ -584,7 +584,7 @@
 ;; scenario: alice signs caps, only works in non-managed cap
 (env-sigs [{ "key": "alice", "caps": [(GUARD "alice-keyset")]}])
 (expect "cap-scoped works with cap" true (enforce-cap "alice-keyset"))
-(expect-failure "cap-scoped does not work without cap" "Keyset failure"
+(expect-failure "cap-scoped does not work without cap" "Keyset enforce failure"
                 (enforce-wo-cap "alice-keyset"))
 
 
@@ -644,7 +644,7 @@
 
 (expect-failure
  "auto managed fails after first time"
- "Capability already fired"
+ "Automanaged capability used more than once"
  (doA "auto-a"))
 
 (expect
@@ -815,7 +815,7 @@
 
 (expect-failure
  "cap guard fails on wrong cap"
- "Capability not acquired"
+ "Capability guard enforce failure cap not in scope"
  (test-cap-guard "A" "B"))
 
 (env-hash (hash 1))
@@ -832,7 +832,7 @@
 (cg-pact 'k2 'k2 "D" "E")
 (expect-failure
  "cap pact guard fails on wrong cap"
- "Capability not acquired"
+ "Capability guard enforce failure cap not in scope"
  (continue-pact 1))
 
 (pact-state true)
@@ -841,7 +841,7 @@
 (cg-pact 'k3 'k1 "C" "C")
 (expect-failure
  "cap pact guard fails on wrong pact id"
- "Invalid Pact ID"
+ "Capability pact guard failed: invalid pact id"
  (continue-pact 1))
 (commit-tx)
 
@@ -915,7 +915,7 @@
 
 (expect-failure
   "out-of-band call fails"
-  "Capability not acquired"
+  "Capability guard enforce failure cap not in scope"
   (call-op1 "hello" 2))
 (expect
    "normal case succeeds for both callees post-fork"

--- a/pact-tests/pact-tests/coin-v1.repl
+++ b/pact-tests/pact-tests/coin-v1.repl
@@ -58,22 +58,22 @@
 ; accounts conform to account structure
 (expect-failure
   "non-latin1+ascii account names fail to create"
-  "charset"
+  "Account does not conform to the coin contract charset"
   (create-account "emilyπ" (read-keyset 'emily)))
 
 (expect-failure
   "empty account names fail to create"
-  "min length"
+  "Account name does not conform to the min length"
   (create-account "" (read-keyset 'doug)))
 
 (expect-failure
   "account names not >= 3 chars fail"
-  "min length"
+  "Account name does not conform to the min length"
   (create-account "jo" (read-keyset 'stuart)))
 
 (expect-failure
   "account names not <= 256 chars fail"
-  "max length"
+  "Account name does not conform to the max length"
   (create-account
     "Before getting down to business, let us ask why it should be that category theory has such far-reaching applications. \
     \Well, we said that it's the abstract theory of functions; so the answer is simply this: Functions are everywhere! \
@@ -114,12 +114,12 @@
 ; w/o capability
 (expect-failure
   "direct call to credit fails"
-  "not granted"
+  "cap not in scope"
   (credit 'emily (read-keyset 'emily) 1.0))
 
 (expect-failure
   "direct call to debit fails"
-  "not granted"
+  "cap not in scope"
   (debit 'emily 1.0))
 
 (env-gas 0) (env-gaslog)
@@ -132,12 +132,12 @@
 ; debit tests
 (expect-failure
   "debit not > 0.0 quantities fail fast"
-  "must be positive"
+  "debit amount must be positive"
   (debit 'emily 0.0))
 
 (expect-failure
   "debit not > 0.0 quantities fail fast"
-  "must be positive"
+  "debit amount must be positive"
   (debit 'emily (- 1.0)))
 
 (expect-failure
@@ -147,17 +147,17 @@
 
 (expect-failure
   "cannot debit to poorly formatted accounts: charset"
-  "charset"
+  "Account does not conform to the coin contract charset"
   (debit "emilyπ" 1.0))
 
 (expect-failure
   "cannot debit to poorly formatted accounts: min length"
-  "min length"
+  "Account name does not conform to the min length"
   (debit "l" 1.0))
 
 (expect-failure
   "cannot debit to poorly formatted accounts: max length"
-  "max length"
+  "Account name does not conform to the max length"
   (debit "a mathematical object X is best thought of in the context of a category surrounding it, \
   \and is determined by the network of relations it enjoys with all the objects of that category. \
   \Moreover, to understand X it might be more germane to deal directly with the functor representing it" 1.0))
@@ -173,17 +173,17 @@
 
 (expect-failure
   "cannot credit to poorly formatted accounts: charset"
-  "charset"
+  "Account does not conform to the coin contract charset"
   (credit "emilyπ" (read-keyset 'emily) 1.0))
 
 (expect-failure
   "cannot credit to poorly formatted accounts: min length"
-  "min length"
+  "Account name does not conform to the min length"
   (credit "l" (read-keyset 'emily) 1.0))
 
 (expect-failure
   "cannot credit to poorly formatted accounts: max length"
-  "max length"
+  "Account name does not conform to the max length"
   (credit "The aim of theory really is, to a great extent, that of systematically organizing past experience in such a way that the next generation, our students and their students and so on, will be able to absorb the essential aspects in as painless a way as possible, and this is the only way in which you can go on cumulatively building up any kind of scientific activity without eventually coming to a dead end." (read-keyset 'emily) 1.0))
 
 (test-capability (DEBIT "emily"))
@@ -199,12 +199,12 @@
 
 (expect-failure
   "crediting trivial or negative funds fails fast"
-  "positive"
+  "credit amount must be positive"
   (credit 'stuart (read-keyset 'stuart) 0.0))
 
 (expect-failure
   "crediting trivial or negative funds fails fast"
-  "positive"
+  "credit amount must be positive"
   (credit 'stuart (read-keyset 'stuart) (- 1.0)))
 
 (credit 'stuart (read-keyset 'stuart) 1.0)
@@ -230,7 +230,7 @@
 
 (expect-failure
  "fund-tx should fail when GAS is not in scope"
- "not granted: (coin.GAS)"
+ "cap not in scope coin.GAS"
  (fund-tx 'emily 'doug (read-keyset 'doug) 1.0))
 
 (test-capability (GAS))
@@ -238,24 +238,24 @@
 
 (expect-failure
   "fund-tx fails without signature"
-  "Keyset failure"
+  "Keyset enforce failure"
   (fund-tx 'emily 'doug (read-keyset 'doug) 1.0))
 
 (env-sigs [{"key": "keys1", "caps": [(TRANSFER "emily" "doug" 1.0)]}])
 
 (expect-failure
   "fund-tx fails for no gas cap"
-  "Keyset failure"
+  "Keyset enforce failure"
   (fund-tx 'emily 'doug (read-keyset 'doug) 1.0))
 
 (expect-failure
   "fund-tx fails for trivial or negative quantities"
-  "positive"
+  "gas supply must be a positive quantity"
   (fund-tx 'emily 'doug (read-keyset 'doug) 0.0))
 
 (expect-failure
   "fund-tx fails for trivial or negative quantities"
-  "positive"
+  "gas supply must be a positive quantity"
   (fund-tx 'emily 'doug (read-keyset 'doug) (- 1.0)))
 
 (env-sigs [{"key": "keys1", "caps": [(GAS)]}])
@@ -375,7 +375,7 @@
 
 (expect-failure
   "transfers of trivial or negative quantities fails fast"
-  "positive"
+  "transfer amount must be positive"
   (transfer 'emily 'doug 0.0))
 
 (expect-failure "can't install negative"
@@ -422,7 +422,7 @@
   (transfer 'emily 'doug 1.0))
 
 (expect-failure "No account for will"
-  "row not found"
+  "no such read object"
   (get-balance 'will))
 
 (test-capability (TRANSFER 'doug 'will 1.0))
@@ -458,7 +458,7 @@
 
 (expect-failure
   "coinbase fails when capability is not in scope"
-  "not granted: (coin.COINBASE)"
+  "cap not in scope"
   (coinbase 'emily (read-keyset 'emily) 0.0))
 
 (test-capability (COINBASE))
@@ -467,12 +467,12 @@
 
 (expect-failure
   "coinbasing trivial or negative amounts fails fast"
-  "positive"
+  "credit amount must be positive"
   (coinbase 'emily (read-keyset 'emily) 0.0))
 
 (expect-failure
   "coinbasing trivial or negative amounts fails fast"
-  "positive"
+  "credit amount must be positive"
   (coinbase 'emily (read-keyset 'emily) (- 1.0)))
 
 (expect
@@ -484,7 +484,7 @@
 (env-data { "miner2": ["miner2"] })
 
 (expect-failure "no account for miner2"
-  "row not found"
+  "no such read object"
   (get-balance 'miner2))
 
 (coinbase 'miner2 (read-keyset 'miner2) 1.0)
@@ -506,12 +506,12 @@
 
 (expect-failure
   "cross-chain transfers fail for trivial or negative quantities"
-  "positive"
+  "transfer quantity must be positive"
   (transfer-crosschain 'emily 'doug (read-keyset 'doug) "1" 0.0))
 
 (expect-failure
   "cross-chain transfers fail for trivial or negative quantities"
-  "positive"
+  "transfer quantity must be positive"
   (transfer-crosschain 'emily 'doug (read-keyset 'doug) "1" (- 1.0)))
 
 (expect
@@ -587,12 +587,12 @@
 
 (expect-failure
   "invalid precision"
-  "minimum precision"
+  "Amount violates minimum precision"
   (enforce-unit 1.1234567890123))
 
 (expect-failure
   "too small"
-  "minimum precision"
+  "Amount violates minimum precision"
   (enforce-unit UNIT_BAD))
 
 (expect
@@ -610,7 +610,7 @@
 
  (expect-failure
    "bad transfer fails"
-   "precision"
+   "Amount violates minimum precision"
    (transfer 'emily 'doug UNIT_BAD))
 
 ;; transfer-create
@@ -629,7 +629,7 @@
   (transfer-create 'emily 'doug (read-keyset 'doug) UNIT_GOOD))
  (expect-failure
    "bad transfer-create fails"
-   "minimum precision"
+   "Amount violates minimum precision"
    (transfer-create 'emily 'doug (read-keyset 'doug) UNIT_BAD))
 
 ;;transfer-crosschain (step 0 only covered)
@@ -644,7 +644,7 @@
 
 (expect-failure
   "bad transfer-crosschain fails"
-  "minimum precision"
+  "Amount violates minimum precision"
   (transfer-crosschain 'emily 'doug (read-keyset 'doug) "chain" UNIT_BAD))
 
 ;;coinbase
@@ -656,7 +656,7 @@
 
 (expect-failure
   "bad coinbase fails"
-  "minimum precision"
+  "Amount violates minimum precision"
   (coinbase 'doug (read-keyset 'doug) UNIT_BAD))
 ;;buy-gas
 (test-capability (GAS))
@@ -667,7 +667,7 @@
 
 (expect-failure
   "bad buy-gas fails"
-  "minimum precision"
+  "Amount violates minimum precision"
   (buy-gas 'emily UNIT_BAD))
 
 ;;redeem-gas
@@ -682,7 +682,7 @@
 
 (expect-failure
   "bad redeem-gas fails"
-  "minimum precision"
+  "Amount violates minimum precision"
   (redeem-gas 'doug (read-keyset 'doug) 'emily UNIT_BAD))
 (commit-tx)
 
@@ -696,23 +696,23 @@
 
 (expect-failure
   "allocation account creation only occurs at genesis"
-  "not granted: (coin.GENESIS)"
+  "cap not in scope coin.GENESIS"
   (create-allocation-account "brandon" (time "1900-10-31T00:00:00Z") "brandon" 200000.0))
 (test-capability (GENESIS))
 
 (expect-failure
   "all allocation amounts must be positive"
-  "non-negative"
+  "allocation amount must be non-negative"
   (create-allocation-account "brandon" (time "1900-10-31T00:00:00Z") "brandon" -200000.0))
 
 (expect-failure
   "all allocation accounts must satisfy coin contract account min chars"
-  "min length"
+  "Account name does not conform to the min length"
   (create-allocation-account "br" (time "1900-10-31T00:00:00Z") "brandon" 200000.0))
 
 (expect-failure
   "all allocation accounts must satisfy coin contract account max chars"
-  "max length"
+  "Account name does not conform to the max length"
   (create-allocation-account
     "There he met Saunders Mac Lane. Mac Lane, then visiting Paris, was anxious \
     \to learn from Yoneda, and commenced an interview with Yoneda in a cafe at \
@@ -723,7 +723,7 @@
 
 (expect-failure
  "account creation fails when no keyset corresponds with keyset ref"
- "Keyset reference"
+ "no such keyset defined"
  (create-allocation-account "brandon" (time "2020-10-31T00:00:00Z") "brandon" 200000.0))
 
 ; successful keyset refs require defined keyset
@@ -751,7 +751,7 @@
 
 (expect-failure
   "allocation release fails when keys are not in scope"
-  "Keyset failure"
+  "Keyset enforce failure"
   (release-allocation "brandon"))
 
 (env-keys ["brandon"])
@@ -763,7 +763,7 @@
 
 (expect-failure
  "releases fail when funds have been redeemed"
- "funds have already been redeemed"
+ "allocation funds have already been redeemed"
  (release-allocation "brandon"))
 
 (expect
@@ -778,12 +778,12 @@
 
 (expect-failure
   "gas-only fails without the presence of GAS"
-  "not granted: (coin.GAS)"
+  "cap not in scope coin.GAS"
   (gas-only))
 
 (expect-failure
   "gas-guard fails when GAS is not present"
-  "Failure: Tx Failed: Enforce either the presence of a GAS cap or keyset"
+  "Enforce either the presence of a GAS cap or keyset"
   (gas-guard (keyset-ref-guard "emily")))
 
 (test-capability (GAS))

--- a/pact-tests/pact-tests/coin-v5.repl
+++ b/pact-tests/pact-tests/coin-v5.repl
@@ -70,22 +70,22 @@
 ; accounts conform to account structure
 (expect-failure
   "non-latin1+ascii account names fail to create"
-  "charset"
+  "Account does not conform to the coin contract charset"
   (create-account "emilyπ" (read-keyset 'emily)))
 
 (expect-failure
   "empty account names fail to create"
-  "min length"
+  "Account name does not conform to the min length"
   (create-account "" (read-keyset 'doug)))
 
 (expect-failure
   "account names not >= 3 chars fail"
-  "min length"
+  "Account name does not conform to the min length"
   (create-account "jo" (read-keyset 'stuart)))
 
 (expect-failure
   "account names not <= 256 chars fail"
-  "max length"
+  "Account name does not conform to the max length"
   (create-account
     "Before getting down to business, let us ask why it should be that category theory has such far-reaching applications. \
     \Well, we said that it's the abstract theory of functions; so the answer is simply this: Functions are everywhere! \
@@ -126,12 +126,12 @@
 ; w/o capability
 (expect-failure
   "direct call to credit fails"
-  "not granted"
+  "cap not in scope"
   (credit 'emily (read-keyset 'emily) 1.0))
 
 (expect-failure
   "direct call to debit fails"
-  "not granted"
+  "cap not in scope"
   (debit 'emily 1.0))
 
 (env-gas 0) (env-gaslog)
@@ -144,12 +144,12 @@
 ; debit tests
 (expect-failure
   "debit not > 0.0 quantities fail fast"
-  "must be positive"
+  "debit amount must be positive"
   (debit 'emily 0.0))
 
 (expect-failure
   "debit not > 0.0 quantities fail fast"
-  "must be positive"
+  "debit amount must be positive"
   (debit 'emily (- 1.0)))
 
 (expect-failure
@@ -159,17 +159,17 @@
 
 (expect-failure
   "cannot debit to poorly formatted accounts: charset"
-  "charset"
+  "Account does not conform to the coin contract charset"
   (debit "emilyπ" 1.0))
 
 (expect-failure
   "cannot debit to poorly formatted accounts: min length"
-  "min length"
+  "Account name does not conform to the min length"
   (debit "l" 1.0))
 
 (expect-failure
   "cannot debit to poorly formatted accounts: max length"
-  "max length"
+  "Account name does not conform to the max length"
   (debit "a mathematical object X is best thought of in the context of a category surrounding it, \
   \and is determined by the network of relations it enjoys with all the objects of that category. \
   \Moreover, to understand X it might be more germane to deal directly with the functor representing it" 1.0))
@@ -185,17 +185,17 @@
 
 (expect-failure
   "cannot credit to poorly formatted accounts: charset"
-  "charset"
+  "Account does not conform to the coin contract charset"
   (credit "emilyπ" (read-keyset 'emily) 1.0))
 
 (expect-failure
   "cannot credit to poorly formatted accounts: min length"
-  "min length"
+  "Account name does not conform to the min length"
   (credit "l" (read-keyset 'emily) 1.0))
 
 (expect-failure
   "cannot credit to poorly formatted accounts: max length"
-  "max length"
+  "Account name does not conform to the max length"
   (credit "The aim of theory really is, to a great extent, that of systematically organizing past experience in such a way that the next generation, our students and their students and so on, will be able to absorb the essential aspects in as painless a way as possible, and this is the only way in which you can go on cumulatively building up any kind of scientific activity without eventually coming to a dead end." (read-keyset 'emily) 1.0))
 
 (test-capability (DEBIT "emily"))
@@ -211,12 +211,12 @@
 
 (expect-failure
   "crediting trivial or negative funds fails fast"
-  "positive"
+  "credit amount must be positive"
   (credit 'stuart (read-keyset 'stuart) 0.0))
 
 (expect-failure
   "crediting trivial or negative funds fails fast"
-  "positive"
+  "credit amount must be positive"
   (credit 'stuart (read-keyset 'stuart) (- 1.0)))
 
 (credit 'stuart (read-keyset 'stuart) 1.0)
@@ -242,7 +242,7 @@
 
 (expect-failure
  "fund-tx should fail when GAS is not in scope"
- "not granted: (coin.GAS)"
+ "cap not in scope coin.GAS"
  (fund-tx 'emily 'doug (read-keyset 'doug) 1.0))
 
 (test-capability (GAS))
@@ -250,24 +250,24 @@
 
 (expect-failure
   "fund-tx fails without signature"
-  "Keyset failure"
+  "Keyset enforce failure"
   (fund-tx 'emily 'doug (read-keyset 'doug) 1.0))
 
 (env-sigs [{"key": "keys1", "caps": [(TRANSFER "emily" "doug" 1.0)]}])
 
 (expect-failure
   "fund-tx fails for no gas cap"
-  "Keyset failure"
+  "Keyset enforce failure"
   (fund-tx 'emily 'doug (read-keyset 'doug) 1.0))
 
 (expect-failure
   "fund-tx fails for trivial or negative quantities"
-  "positive"
+  "gas supply must be a positive"
   (fund-tx 'emily 'doug (read-keyset 'doug) 0.0))
 
 (expect-failure
   "fund-tx fails for trivial or negative quantities"
-  "positive"
+  "gas supply must be a positive"
   (fund-tx 'emily 'doug (read-keyset 'doug) (- 1.0)))
 
 (env-sigs [{"key": "keys1", "caps": [(GAS)]}])
@@ -387,7 +387,7 @@
 
 (expect-failure
   "transfers of trivial or negative quantities fails fast"
-  "positive"
+  "transfer amount must be positive"
   (transfer 'emily 'doug 0.0))
 
 (expect-failure "can't install negative"
@@ -434,7 +434,7 @@
   (transfer 'emily 'doug 1.0))
 
 (expect-failure "No account for will"
-  "row not found"
+  "no such read object"
   (get-balance 'will))
 
 (test-capability (TRANSFER 'doug 'will 1.0))
@@ -470,7 +470,7 @@
 
 (expect-failure
   "coinbase fails when capability is not in scope"
-  "not granted"
+  "cap not in scope coin.COINBASE"
   (coinbase 'emily (read-keyset 'emily) 0.0))
 
 (test-capability (COINBASE))
@@ -480,13 +480,13 @@
 (test-capability (COINBASE))
 (expect-failure
   "coinbasing trivial or negative amounts fails fast"
-  "positive"
+  "credit amount must be positive"
   (coinbase 'emily (read-keyset 'emily) 0.0))
 
 (test-capability (COINBASE))
 (expect-failure
   "coinbasing trivial or negative amounts fails fast"
-  "positive"
+  "credit amount must be positive"
   (coinbase 'emily (read-keyset 'emily) (- 1.0)))
 
 (expect
@@ -498,7 +498,7 @@
 (env-data { "miner2": ["miner2"] })
 
 (expect-failure "no account for miner2"
-  "row not found"
+  "no such read object"
   (get-balance 'miner2))
 
 (test-capability (COINBASE))
@@ -528,19 +528,19 @@
 
 (expect-failure
   "cross-chain transfers fail wrong key"
-  "Keyset failure"
-  (transfer-crosschain 'emily 'doug (read-keyset 'doug) "1" 0.0))
+  "Keyset enforce failure"
+  (transfer-crosschain 'emily 'doug (read-keyset 'doug) "1" 1.0))
 
 (env-sigs [{ 'key: "keys1", 'caps: [(coin.TRANSFER_XCHAIN 'emily 'doug 1.0 "1")]}])
 
 (expect-failure
   "cross-chain transfers fail for trivial or negative quantities"
-  "positive"
+  "Cross-chain transfers require a positive amount"
   (transfer-crosschain 'emily 'doug (read-keyset 'doug) "1" 0.0))
 
 (expect-failure
   "cross-chain transfers fail for trivial or negative quantities"
-  "positive"
+  "Cross-chain transfers require a positive amount"
   (transfer-crosschain 'emily 'doug (read-keyset 'doug) "1" (- 1.0)))
 
 (expect
@@ -629,12 +629,12 @@
 
 (expect-failure
   "invalid precision"
-  "minimum precision"
+  "Amount violates minimum precision"
   (enforce-unit 1.1234567890123))
 
 (expect-failure
   "too small"
-  "minimum precision"
+  "Amount violates minimum precision"
   (enforce-unit UNIT_BAD))
 
 (expect
@@ -653,7 +653,7 @@
 
  (expect-failure
    "bad transfer fails"
-   "precision"
+   "Amount violates minimum precision"
    (transfer 'emily 'doug UNIT_BAD))
 
 ;; transfer-create
@@ -675,7 +675,7 @@
 
 (expect-failure
    "bad transfer-create fails"
-   "minimum precision"
+   "Amount violates minimum precision"
    (transfer-create 'emily 'doug (read-keyset 'doug) UNIT_BAD))
 
 ;;transfer-crosschain (step 0 only covered)
@@ -697,7 +697,7 @@
 (test-capability (TRANSFER_XCHAIN "emily" "doug" (* (dec 2) UNIT_GOOD) "0"))
 (expect-failure
   "bad transfer-crosschain fails"
-  "minimum precision"
+  "Amount violates minimum precision"
   (transfer-crosschain 'emily 'doug (read-keyset 'doug) "0" UNIT_BAD))
 
 ;;coinbase
@@ -709,7 +709,7 @@
 
 (expect-failure
   "bad coinbase fails"
-  "minimum precision"
+  "Amount violates minimum precision"
   (coinbase 'doug (read-keyset 'doug) UNIT_BAD))
 
 ;;buy-gas
@@ -721,7 +721,7 @@
 
 (expect-failure
   "bad buy-gas fails"
-  "minimum precision"
+  "Amount violates minimum precision"
   (buy-gas 'emily UNIT_BAD))
 
 ;;redeem-gas
@@ -736,7 +736,7 @@
 
 (expect-failure
   "bad redeem-gas fails"
-  "minimum precision"
+  "Amount violates minimum precision"
   (redeem-gas 'doug (read-keyset 'doug) 'emily UNIT_BAD))
 
 (commit-tx)
@@ -751,24 +751,24 @@
 
 (expect-failure
   "allocation account creation only occurs at genesis"
-  "not granted: (coin.GENESIS)"
+  "cap not in scope coin.GENESIS"
   (create-allocation-account "brandon" (time "1900-10-31T00:00:00Z") "brandon" 200000.0))
 
 (test-capability (GENESIS))
 
 (expect-failure
   "all allocation amounts must be positive"
-  "non-negative"
+  "allocation amount must be non-negative"
   (create-allocation-account "brandon" (time "1900-10-31T00:00:00Z") "brandon" -200000.0))
 
 (expect-failure
   "all allocation accounts must satisfy coin contract account min chars"
-  "min length"
+  "Account name does not conform to the min length"
   (create-allocation-account "br" (time "1900-10-31T00:00:00Z") "brandon" 200000.0))
 
 (expect-failure
   "all allocation accounts must satisfy coin contract account max chars"
-  "max length"
+  "Account name does not conform to the max length"
   (create-allocation-account
     "There he met Saunders Mac Lane. Mac Lane, then visiting Paris, was anxious \
     \to learn from Yoneda, and commenced an interview with Yoneda in a cafe at \
@@ -779,7 +779,7 @@
 
 (expect-failure
  "account creation fails when no keyset corresponds with keyset ref"
- "Keyset reference"
+ "no such keyset defined"
  (create-allocation-account "brandon" (time "2020-10-31T00:00:00Z") "brandon" 200000.0))
 
 ; successful keyset refs require defined keyset
@@ -808,7 +808,7 @@
 
 (expect-failure
   "allocation release fails when keys are not in scope"
-  "Keyset failure"
+  "Keyset enforce failure"
   (release-allocation "brandon"))
 
 (env-keys ["brandon"])
@@ -820,7 +820,7 @@
 
 (expect-failure
  "releases fail when funds have been redeemed"
- "funds have already been redeemed"
+ "allocation funds have already been redeemed"
  (release-allocation "brandon"))
 
 (expect
@@ -835,12 +835,12 @@
 
 (expect-failure
   "gas-only fails without the presence of GAS"
-  "not granted: (coin.GAS)"
+  "cap not in scope coin.GAS"
   (gas-only))
 
 (expect-failure
   "gas-guard fails when GAS is not present"
-  "Failure: Tx Failed: Enforce either the presence of a GAS cap or keyset"
+  "Enforce either the presence of a GAS cap or keyset"
   (gas-guard (keyset-ref-guard "emily")))
 
 (test-capability (GAS))
@@ -878,7 +878,7 @@
 
 (expect-failure
   "Remediations fail without the presence of REMEDIATE"
-  "not granted"
+  "cap not in scope"
   (remediate "brandon" 1.0))
 
 (test-capability (REMEDIATE))

--- a/pact-tests/pact-tests/db.repl
+++ b/pact-tests/pact-tests/db.repl
@@ -82,43 +82,43 @@
 (begin-tx)
 (use dbtest)
 (expect-failure
- "write protected by admin key" "Keyset failure (=): 'dbtest-admin"
+ "write protected by admin key" "Keyset enforce failure"
  (write persons "foo" ROW_A))
 (expect-failure
- "update protected by admin key" "Keyset failure (=): 'dbtest-admin"
+ "update protected by admin key" "Keyset enforce failure"
  (update persons "foo" ROW_A))
 (expect-failure
- "insert protected by admin key" "Keyset failure (=): 'dbtest-admin"
+ "insert protected by admin key" "Keyset enforce failure"
  (insert persons "foo" ROW_A))
 (expect-failure
- "keys protected by admin key" "Keyset failure (=): 'dbtest-admin"
+ "keys protected by admin key" "Keyset enforce failure"
  (keys persons))
 (expect-failure
- "txids protected by admin key" "Keyset failure (=): 'dbtest-admin"
+ "txids protected by admin key" "Keyset enforce failure"
  (txids persons 0))
 (expect-failure
- "txlog protected by admin key" "Keyset failure (=): 'dbtest-admin"
+ "txlog protected by admin key" "Keyset enforce failure"
  (txlog persons 2))
 (expect-failure
- "keylogs protected by admin key" "Keyset failure (=): 'dbtest-admin"
+ "keylogs protected by admin key" "Keyset enforce failure"
  (keylog persons "" 2))
 (expect-failure
- "read protected by admin key" "Keyset failure (=): 'dbtest-admin"
+ "read protected by admin key" "Keyset enforce failure"
  (read persons ID_A))
 (expect-failure
- "with-read protected by admin key" "Keyset failure (=): 'dbtest-admin"
+ "with-read protected by admin key" "Keyset enforce failure"
  (with-read persons ID_A { 'name:= name } name))
 (expect-failure
- "with-default-read protected by admin key" "Keyset failure (=): 'dbtest-admin"
+ "with-default-read protected by admin key" "Keyset enforce failure"
  (with-default-read persons ID_A { 'name: "stu" } { 'name:= name } name))
 (expect-failure
- "select protected by admin key" "Keyset failure (=): 'dbtest-admin"
+ "select protected by admin key" "Keyset enforce failure"
  (select persons (constantly true)))
 (expect-failure
- "keys protected by admin key" "Keyset failure (=): 'dbtest-admin"
+ "keys protected by admin key" "Keyset enforce failure"
  (keys persons))
 (expect-failure
- "create-table protected by admin key" "Keyset failure (=): 'dbtest-admin"
+ "create-table protected by admin key" "Keyset enforce failure"
  (create-table persons2))
 
 ;; just making sure this doesn't blow up, output is still TBD on better Term output in general
@@ -129,13 +129,13 @@
 (env-exec-config ["AllowReadInLocal"])
 (use dbtest)
 (expect-failure
- "write protected by admin key in local" "Keyset failure (=): 'dbtest-admin"
+ "write protected by admin key in local" "Keyset enforce failure"
  (write persons "foo" ROW_A))
 (expect-failure
- "update protected by admin key in local" "Keyset failure (=): 'dbtest-admin"
+ "update protected by admin key in local" "Keyset enforce failure"
  (update persons "foo" ROW_A))
 (expect-failure
- "insert protected by admin key in local" "Keyset failure (=): 'dbtest-admin"
+ "insert protected by admin key in local" "Keyset enforce failure"
  (insert persons "foo" ROW_A))
 (expect
  "keys allowed in local" [ID_A]
@@ -165,7 +165,7 @@
  "keys allowed in local" [ID_A]
  (keys persons))
 (expect-failure
- "create-table protected by admin key in local" "Keyset failure (=): 'dbtest-admin"
+ "create-table protected by admin key in local" "Keyset enforce failure"
  (create-table persons2))
 
 ;; test nested commits

--- a/pact-tests/pact-tests/keysets.repl
+++ b/pact-tests/pact-tests/keysets.repl
@@ -130,7 +130,7 @@
 
 (expect-failure
   "keyset definition parsing is not permissive post-pact-4.4 - define-keyset"
-  "namespace"
+  "Cannot define a keyset outside"
   (define-keyset "TEST <2>."))
 
 (expect-failure

--- a/pact/Pact/Core/IR/Eval/CEK.hs
+++ b/pact/Pact/Core/IR/Eval/CEK.hs
@@ -1418,8 +1418,8 @@ applyContToValue (BuiltinC env info frame cont) handler cv = do
       RunKeysetPredC -> case v of
         PBool allow ->
           if allow then returnCEKValue cont handler (VBool True)
-          else returnCEK cont handler (VError "keyset enforce failure" info)
-        _ -> returnCEK cont handler (VError "keyset enforce failure" info)
+          else returnCEK cont handler (VError "Keyset enforce failure" info)
+        _ -> returnCEK cont handler (VError "Keyset enforce failure" info)
       where
       foldDBRead tv queryClo appClo remaining acc =
         case remaining of
@@ -1995,7 +1995,7 @@ isKeysetInSigs info cont handler env (KeySet kskeys ksPred) = do
   count = S.size kskeys
   run p matched =
     if p count matched then returnCEKValue cont handler (VBool True)
-    else returnCEK cont handler (VError "keyset enforce failure" info)
+    else returnCEK cont handler (VError "Keyset enforce failure" info)
   runPred matched =
     case ksPred of
       KeysAll -> run atLeast matched

--- a/pact/Pact/Core/Repl/Runtime/ReplBuiltin.hs
+++ b/pact/Pact/Core/Repl/Runtime/ReplBuiltin.hs
@@ -116,7 +116,7 @@ coreExpectFailure info b cont handler _env = \case
     tryError (applyLamUnsafe vclo [] Mt CEKNoHandler) >>= \case
       Right (VError err _) -> do
         putEvalState es
-        if err == toMatch
+        if toMatch `T.isPrefixOf` err
           then returnCEKValue cont handler $ VLiteral $ LString $ "Expect failure: Success: " <> desc
           else returnCEKValue cont handler $ VLiteral $ LString $
                "FAILURE: " <> desc <> ": expected error message '" <> toMatch <> "', got '" <> err <> "'"

--- a/pact/Pact/Core/Repl/Runtime/ReplBuiltin.hs
+++ b/pact/Pact/Core/Repl/Runtime/ReplBuiltin.hs
@@ -116,7 +116,7 @@ coreExpectFailure info b cont handler _env = \case
     tryError (applyLamUnsafe vclo [] Mt CEKNoHandler) >>= \case
       Right (VError err _) -> do
         putEvalState es
-        if toMatch `T.isPrefixOf` err
+        if toMatch `T.isInfixOf` err
           then returnCEKValue cont handler $ VLiteral $ LString $ "Expect failure: Success: " <> desc
           else returnCEKValue cont handler $ VLiteral $ LString $
                "FAILURE: " <> desc <> ": expected error message '" <> toMatch <> "', got '" <> err <> "'"


### PR DESCRIPTION
closes #91 

With this PR, we check if our expected error matches the raised one.

```
pact>(defun make-error () (enforce false "Error Foo"))
Loaded defun make-error

pact>(expect-failure "Should raise foo" "Error Bar" (make-error))
"FAILURE: Should raise foo: expected error message 'Error Bar', got 'Error Foo'"

pact>(expect-failure "Should raise foo" "Error Foo" (make-error))
"Expect failure: Success: Should raise foo"
```

PR checklist:

* [ ] Test coverage for the proposed changes
* [ ] PR description contains example output from repl interaction or a snippet from unit test output
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact-core/blob/master/CHANGELOG.md)

Additionally, please justify why you should or should not do the following:

* [ ] Confirm replay/back compat
* [ ] Benchmark regressions
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206473309875658