### PR TITLE
Patch (int->string,str->int) and buggy plated instance

### DIFF
--- a/pact-tests/pact-tests/fqns.repl
+++ b/pact-tests/pact-tests/fqns.repl
@@ -96,3 +96,22 @@
 (expect "Demonstrate correct resolution with non-namespace-qualified reference." 1 (f1))
 
 (commit-tx)
+; Regression: the `Plated` instance for
+; `Term` was not correctly traversing all of its subterms (due to an incorrect `nested (plate f)` call)
+; on conditional forms
+(begin-tx)
+(module my-module GOV
+  (defcap GOV () true)
+
+  (defconst CONSTANT true)
+
+  (defun enforce-constant-true:bool ()
+    (enforce CONSTANT "Err: Constant is FALSE"))
+
+  (defun enforce-constant-false:bool ()
+    (enforce (not CONSTANT) "Err: Constant is TRUE"))
+
+)
+(expect "constant true works" true (enforce-constant-true))
+(expect-failure "constant-false worse" (enforce-constant-false))
+(commit-tx)

--- a/pact-tests/pact-tests/strtoint.repl
+++ b/pact-tests/pact-tests/strtoint.repl
@@ -19,3 +19,5 @@
 (expect "int-to-str 16" "12345abcdef" (int-to-str 16 1251004370415))
 (expect "int-to-str 64" "q80" (int-to-str 64 43981))
 (expect-failure "int-to-str 17" (int-to-str 17 3245342))
+(expect-failure "str-to-int on negative number" (str-to-int "-123"))
+(expect-failure "int-to-str on negative numbers" (int-to-str 10 -36))

--- a/pact/Pact/Core/IR/Eval/CoreBuiltin.hs
+++ b/pact/Pact/Core/IR/Eval/CoreBuiltin.hs
@@ -1147,6 +1147,8 @@ createDefPactGuard info b cont handler _env = \case
 coreIntToStr :: (CEKEval step b i m, MonadEval b i m) => NativeFunction step b i m
 coreIntToStr info b cont handler _env = \case
   [VInteger base, VInteger v]
+    | v < 0 ->
+      returnCEK cont handler (VError "int-to-str error: cannot show negative integer" info)
     | base >= 2 && base <= 16 -> do
       let v' = T.pack $ showIntAtBase base Char.intToDigit v ""
       returnCEKValue cont handler (VString v')
@@ -1237,6 +1239,7 @@ baseStrToInt :: Integer -> T.Text -> Either T.Text Integer
 baseStrToInt base t
   | base <= 1 || base > 16 = Left $ "unsupported base: " `T.append` T.pack (show base)
   | T.null t = Left $ "empty text: " `T.append` t
+  | T.any (not . Char.isHexDigit) t = Left "invalid digit: supported digits are 0-9, A-F"
   | otherwise = foldM go 0 $ T.unpack t
   where
       go :: Integer -> Char -> Either T.Text Integer

--- a/pact/Pact/Core/IR/Term.hs
+++ b/pact/Pact/Core/IR/Term.hs
@@ -552,7 +552,7 @@ instance Plated (Term name ty builtin info) where
     Constant l i -> pure (Constant l i)
     Sequence e1 e2 i -> Sequence <$> f e1 <*> f e2 <*> pure i
     Conditional o i ->
-      Conditional <$> traverse (plate f) o <*> pure i
+      Conditional <$> traverse f o <*> pure i
     ListLit m i -> ListLit <$> traverse f m <*> pure i
     Nullary term i ->
       Nullary <$> f term <*> pure i


### PR DESCRIPTION
Closes #98
Closes #97 

This PR Fixes the behavior around invalid inputs in the string->int and int->string conversion functions.

```
pact>(expect-failure "str-to-int on negative number" (str-to-int "-123"))
"Expect failure: Success: str-to-int on negative number"
pact>(expect-failure "int-to-str on negative numbers" (int-to-str 10 -36))
"Expect failure: Success: int-to-str on negative numbers"
```

As well as fixes the regression in #98. Turns out that it was just our `Plated` instance that was traversing `BuiltinForm`s incorrectly. After the fix, we can expect the example in the issue to work, and i've also added it as a regression

PR checklist:
* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output