### PR TITLE
Derive `Data` and avoid hand-writing `Plated Term` instance

### DIFF
--- a/pact/Pact/Core/Builtin.hs
+++ b/pact/Pact/Core/Builtin.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 
 module Pact.Core.Builtin
  ( CoreBuiltin(..)
@@ -21,6 +22,7 @@ module Pact.Core.Builtin
  , ReplBuiltins(..)
  )where
 
+import Data.Data(Data)
 import Data.Text(Text)
 import Data.Map.Strict(Map)
 import Control.DeepSeq
@@ -42,7 +44,7 @@ data BuiltinForm o
   | CIf o o o
   | CEnforceOne o [o]
   | CEnforce o o
-  deriving (Show, Eq, Functor, Foldable, Traversable, Generic)
+  deriving (Show, Eq, Functor, Foldable, Traversable, Generic, Data)
 
 instance NFData o => NFData (BuiltinForm o)
 
@@ -211,7 +213,7 @@ data CoreBuiltin
   | CoreTypeOf
   | CoreDec
   | CoreCond
-  deriving (Eq, Show, Ord, Bounded, Enum, Generic)
+  deriving (Eq, Show, Ord, Bounded, Enum, Generic, Data)
 
 instance NFData CoreBuiltin
 
@@ -728,7 +730,7 @@ data ReplBuiltins
   | RPactVersion
   | REnforcePactVersionMin
   | REnforcePactVersionRange
-  deriving (Show, Enum, Bounded, Eq, Generic)
+  deriving (Show, Enum, Bounded, Eq, Generic, Data)
 
 
 instance IsBuiltin ReplBuiltins where
@@ -780,7 +782,7 @@ instance IsBuiltin ReplBuiltins where
 data ReplBuiltin b
   = RBuiltinWrap b
   | RBuiltinRepl ReplBuiltins
-  deriving (Eq, Show, Generic)
+  deriving (Eq, Show, Generic, Data)
 
 -- NOTE: Maybe `ReplBuiltin` is not a great abstraction, given
 -- expect arity changes based on whether it's corebuiltin or rawbuiltin
@@ -884,7 +886,7 @@ replCoreBuiltinMap =
 
 -- Todo: is not a great abstraction.
 -- In particular: the arity could be gathered from the type.
-class Show b => IsBuiltin b where
+class (Show b, Data b) => IsBuiltin b where
   builtinArity :: b -> Int
   builtinName :: b -> NativeName
 

--- a/pact/Pact/Core/Capabilities.hs
+++ b/pact/Pact/Core/Capabilities.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE GADTs #-}
@@ -27,6 +28,7 @@ module Pact.Core.Capabilities
 
 import Control.Lens
 import Control.DeepSeq
+import Data.Data(Data)
 import Data.Text(Text)
 import Data.Set(Set)
 import Data.Default
@@ -58,7 +60,7 @@ dcMetaFqName f = \case
 data CapForm name e
   = WithCapability e e
   | CreateUserGuard name [e]
-  deriving (Show, Functor, Foldable, Traversable, Eq, Generic)
+  deriving (Show, Functor, Foldable, Traversable, Eq, Generic, Data)
 
 
 capFormName :: Traversal (CapForm name e) (CapForm name' e) name name'

--- a/pact/Pact/Core/Compile.hs
+++ b/pact/Pact/Core/Compile.hs
@@ -19,6 +19,7 @@ module Pact.Core.Compile
 import Control.Lens
 import Control.Monad.Except
 import Control.Monad
+import Data.Data(Data)
 import Data.Maybe(mapMaybe)
 import Data.Text(Text)
 import qualified Data.Map.Strict as M
@@ -155,7 +156,7 @@ evalModuleGovernance bEnv tl = do
 
 compileDesugarOnly
   :: forall step b i m
-  .  (HasCompileEnv step b i m)
+  .  (HasCompileEnv step b i m, Data i)
   => BuiltinEnv step b i m
   -> Lisp.TopLevel i
   -> m (EvalTopLevel b i, S.Set ModuleName)
@@ -171,7 +172,7 @@ compileDesugarOnly bEnv tl = do
 
 interpretTopLevel
   :: forall step b i m
-  .  (HasCompileEnv step b i m)
+  .  (HasCompileEnv step b i m, Data i)
   => BuiltinEnv step b i m
   -> Lisp.TopLevel i
   -> m (CompileValue i)

--- a/pact/Pact/Core/Hash.hs
+++ b/pact/Pact/Core/Hash.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -33,6 +34,7 @@ module Pact.Core.Hash
 import Control.DeepSeq
 import Data.ByteString.Short (ShortByteString, fromShort, toShort)
 import Data.ByteString (ByteString)
+import Data.Data (Data)
 import Data.Text (Text)
 import Data.Text.Encoding (decodeUtf8)
 import Data.Word
@@ -51,7 +53,7 @@ import Pact.Core.Pretty ( renderCompactString, Pretty(pretty) )
 -- Within Pact these are blake2b_256 but unvalidated as such,
 -- so other hash values are kosher (such as an ETH sha256, etc).
 newtype Hash = Hash { unHash :: ShortByteString }
-  deriving (Eq, Ord, NFData, Generic)
+  deriving (Eq, Ord, NFData, Generic, Data)
 
 instance Show Hash where
   show (Hash h) = show $ encodeBase64UrlUnpadded $ fromShort h
@@ -122,7 +124,7 @@ fromB64UrlUnpaddedText bs = case decodeBase64UrlUnpadded bs of
 
 
 newtype ModuleHash = ModuleHash { _mhHash :: Hash }
-  deriving (Eq, Ord, Show, Generic)
+  deriving (Eq, Ord, Show, Generic, Data)
   deriving newtype (NFData)
 
 placeholderHash :: ModuleHash

--- a/pact/Pact/Core/Info.hs
+++ b/pact/Pact/Core/Info.hs
@@ -1,8 +1,11 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+
 module Pact.Core.Info
  ( SpanInfo(..)
  , combineSpan
  ) where
 
+import Data.Data(Data)
 import Data.Default
 import GHC.Generics
 
@@ -12,7 +15,7 @@ data SpanInfo
   , _liStartColumn :: !Int
   , _liEndLine     :: !Int
   , _liEndColumn   :: !Int
-  } deriving (Eq, Show, Generic)
+  } deriving (Eq, Show, Generic, Data)
 
 instance Default SpanInfo where
   def = SpanInfo 0 0 0 0

--- a/pact/Pact/Core/Literal.hs
+++ b/pact/Pact/Core/Literal.hs
@@ -1,6 +1,9 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Pact.Core.Literal
  ( _LString
@@ -8,9 +11,11 @@ module Pact.Core.Literal
  , _LDecimal
  , _LUnit
  , _LBool
- , Literal(..)) where
+ , Literal(..)
+ ) where
 
 import Control.Lens(makePrisms)
+import Data.Data(Data)
 import Data.Text(Text)
 import Data.Decimal
 
@@ -19,13 +24,15 @@ import GHC.Generics
 
 import Pact.Core.Pretty
 
+deriving instance Data Decimal
+
 data Literal
   = LString !Text
   | LInteger !Integer
   | LDecimal !Decimal
   | LUnit
   | LBool !Bool
-  deriving (Show, Eq, Ord, Generic)
+  deriving (Show, Eq, Ord, Generic, Data)
 
 instance NFData Literal
 

--- a/pact/Pact/Core/Names.hs
+++ b/pact/Pact/Core/Names.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE InstanceSigs #-}
@@ -63,6 +64,7 @@ module Pact.Core.Names
  ) where
 
 import Control.Lens
+import Data.Data(Data)
 import Data.Text(Text)
 import qualified Data.Text as T
 import Data.Word(Word64)
@@ -78,7 +80,7 @@ import Pact.Core.Pretty(Pretty(..))
 
 -- | Newtype wrapper over bare namespaces
 newtype NamespaceName = NamespaceName { _namespaceName :: Text }
-  deriving (Eq, Ord, Show, Generic)
+  deriving (Eq, Ord, Show, Generic, Data)
 
 instance NFData NamespaceName
 
@@ -90,7 +92,7 @@ instance Pretty NamespaceName where
 data ModuleName = ModuleName
   { _mnName      :: Text
   , _mnNamespace :: Maybe NamespaceName
-  } deriving (Eq, Ord, Show, Generic)
+  } deriving (Eq, Ord, Show, Generic, Data)
 
 instance NFData ModuleName
 
@@ -111,7 +113,7 @@ data QualifiedName =
   QualifiedName
   { _qnName :: Text
   , _qnModName :: ModuleName
-  } deriving (Show, Eq, Generic)
+  } deriving (Show, Eq, Generic, Data)
 
 instance NFData QualifiedName
 
@@ -178,7 +180,7 @@ instance Pretty ParsedName where
 -- | Object and Schema row labels.
 -- So in Field "a" in {"a":v},
 newtype Field = Field { _field :: Text }
-  deriving (Eq, Ord, Show, Generic)
+  deriving (Eq, Ord, Show, Generic, Data)
   deriving newtype NFData
 
 instance Pretty Field where
@@ -219,7 +221,7 @@ data Name
   = Name
   { _nName :: !Text
   , _nKind :: NameKind }
-  deriving (Show, Eq, Ord, Generic)
+  deriving (Show, Eq, Ord, Generic, Data)
 
 instance NFData Name
 
@@ -228,7 +230,7 @@ data DynamicRef
   = DynamicRef
   { _drNameArg :: !Text
   , _drBindType :: DeBruijn
-  } deriving (Show, Eq, Ord, Generic)
+  } deriving (Show, Eq, Ord, Generic, Data)
 
 instance NFData DynamicRef
 
@@ -246,7 +248,7 @@ data NameKind
   -- ^ module reference, pointing to the module name +
   -- the implemented interfaces
   | NDynRef DynamicRef
-  deriving (Show, Eq, Ord, Generic)
+  deriving (Show, Eq, Ord, Generic, Data)
 
 instance NFData NameKind
 

--- a/pact/Pact/Core/Type.hs
+++ b/pact/Pact/Core/Type.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE TemplateHaskell #-}
 
@@ -33,6 +34,7 @@ module Pact.Core.Type
 
 import Control.Lens
 import Control.DeepSeq
+import Data.Data(Data)
 import Data.List
 import Data.Set(Set)
 import Data.Text(Text)
@@ -56,7 +58,7 @@ data PrimType =
   PrimGuard |
   PrimTime |
   PrimUnit
-  deriving (Eq,Ord,Show, Enum, Bounded, Generic)
+  deriving (Eq,Ord,Show, Enum, Bounded, Generic, Data)
 
 instance NFData PrimType
 
@@ -111,13 +113,13 @@ data Type
   | TyCapToken
   -- ^ type of cap tokens
   | TyAny
-  deriving (Eq, Show, Ord, Generic)
+  deriving (Eq, Show, Ord, Generic, Data)
 
 instance NFData Type
 
 data Schema
   = Schema QualifiedName (Map Field Type)
-  deriving (Eq, Show, Ord, Generic)
+  deriving (Eq, Show, Ord, Generic, Data)
 
 instance NFData Schema
 
@@ -199,7 +201,7 @@ data Arg ty
   = Arg
   { _argName :: !Text
   , _argType :: Maybe ty
-  } deriving (Show, Eq, Functor, Foldable, Traversable, Generic)
+  } deriving (Show, Eq, Functor, Foldable, Traversable, Generic, Data)
 
 instance NFData ty => NFData (Arg ty)
 


### PR DESCRIPTION
Just a proposal to avoid writing `Plated` for `Term` (and potentially other types) manually, which is a tad tedious. Feel free to frown upon!

---

PR checklist:

* [ ] Test coverage for the proposed changes
* [ ] PR description contains example output from repl interaction or a snippet from unit test output
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact-core/blob/master/CHANGELOG.md)

Additionally, please justify why you should or should not do the following:

* [ ] Confirm replay/back compat
* [ ] Benchmark regressions
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
