### PR TITLE
`enforce-pact-version` test case

### DIFF
--- a/pact-tests/pact-tests/pact-version.repl
+++ b/pact-tests/pact-tests/pact-version.repl
@@ -7,6 +7,12 @@
 (expect "min version in history" true (enforce-pact-version "1.0"))
 (expect "min version in history" true (enforce-pact-version "1.0.100"))
 
+(expect
+  "enforce-pact-version works for current pact version"
+  true
+  (enforce-pact-version (pact-version)))
+
+
 (expect-failure "min and max version in history"
                 (enforce-pact-version "1.0" "2.0"))
 


### PR DESCRIPTION
This PR adds a missing test case, which was added in prod: https://github.com/kadena-io/pact/pull/1334 

The check against `pact-version`.

PR checklist:

* [ ] Test coverage for the proposed changes
* [ ] PR description contains example output from repl interaction or a snippet from unit test output
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact-core/blob/master/CHANGELOG.md)

Additionally, please justify why you should or should not do the following:

* [ ] Confirm replay/back compat
* [ ] Benchmark regressions
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
