### PR TITLE
Profiling build support

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -13,3 +13,4 @@ source-repository-package
     --sha256: sha256-q5QQFYAJLoQcaW+qCUS8XRzuyca7zc4vnDNXLwlkQ0M=
 
 constraints: aeson <2.2
+tests: True

--- a/crypto/Pact/Core/Crypto/Pairing.hs
+++ b/crypto/Pact/Core/Crypto/Pairing.hs
@@ -42,6 +42,7 @@ module Pact.Core.Crypto.Pairing
   , pairingCheck
   , isOnCurve
   , Extension(..)
+  , extElements
   -- , toG1
   -- , fromG1
   -- , toG2
@@ -88,6 +89,9 @@ class GaloisField k => ExtensionField p k | p -> k, k -> p where
 newtype Extension p k
   = Extension (VPoly k)
   deriving (Show, Eq, Ord, NFData)
+
+extElements :: Extension p k -> Vector k
+extElements (Extension e) = unPoly e
 
 -- | Frobenius endomorphism precomputation.
 frobenius' :: GaloisField k => Vector k -> Vector k -> Maybe (Vector k)

--- a/pact-tng.cabal
+++ b/pact-tng.cabal
@@ -25,6 +25,11 @@ extra-source-files:
     cbits/musl/pow_data.h
     cbits/musl/sqrt_data.h
 
+flag with-crypto
+  description: Enable crypto primitives
+  manual: True
+  default: True
+
 common pact-common
   build-depends:
     , Decimal
@@ -71,7 +76,6 @@ common pact-common
     , cborg
     , unordered-containers
     , groups
-    , poly
     , mod
     , neat-interpolation
     -- ^ is used by the `BuiltinDocs` module.
@@ -97,18 +101,22 @@ common pact-common
 library pact-crypto
   import: pact-common
   hs-source-dirs: crypto
-
+  build-depends: poly
   exposed-modules:
     Pact.Core.Crypto.Hash.Poseidon
     Pact.Core.Crypto.Pairing
     Pact.Core.Crypto.Pairing.Fields
+  if !(flag(with-crypto))
+    buildable: False
 
 library
   import: pact-common
   hs-source-dirs: pact
 
-  build-depends:
-    pact-tng:pact-crypto
+  if (flag(with-crypto))
+    build-depends: pact-tng:pact-crypto
+  else
+    cpp-options: -DWITHOUT_CRYPTO
 
   build-tool-depends:
     , alex:alex
@@ -304,7 +312,6 @@ test-suite core-tests
     , groups
     , semirings
     , neat-interpolation
-    , pact-tng:pact-crypto
     , pact-tng:pact-lsp
     , lsp-test
     , lsp-types
@@ -321,3 +328,5 @@ test-suite core-tests
     , Pact.Core.Test.ZkTests
     , Pact.Core.Test.PoseidonTests
     , Pact.Core.Test.LanguageServer
+  if (flag(with-crypto))
+    build-depends: pact-tng:pact-crypto

--- a/pact/Pact/Core/IR/Eval/CoreBuiltin.hs
+++ b/pact/Pact/Core/IR/Eval/CoreBuiltin.hs
@@ -48,7 +48,6 @@ import qualified Data.Char as Char
 import qualified Data.ByteString as BS
 import qualified GHC.Exts as Exts
 import qualified Pact.Time as PactTime
-import qualified Data.Poly as Poly
 
 import Pact.Core.Builtin
 import Pact.Core.Literal
@@ -1660,9 +1659,7 @@ fromG2 CurveInf = ObjectData pts
     , (Field "y", PList (V.fromList [PLiteral (LInteger 0)]))]
 fromG2 (Point x y) = ObjectData pts
   where
-  toPactPt (Extension e) = let
-    elems' = fmap (PInteger . fromIntegral) (Poly.unPoly e)
-    in PList elems'
+  toPactPt ext = PList $ PInteger . fromIntegral <$> extElements ext
   x' = toPactPt x
   y' = toPactPt y
   pts =

--- a/pact/Pact/Core/IR/Eval/CoreBuiltin.hs
+++ b/pact/Pact/Core/IR/Eval/CoreBuiltin.hs
@@ -9,7 +9,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE MultiWayIf #-}
-{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE CPP #-}
 
 module Pact.Core.IR.Eval.CoreBuiltin
  ( coreBuiltinRuntime
@@ -32,12 +32,11 @@ import Data.Attoparsec.Text(parseOnly)
 import Data.Containers.ListUtils(nubOrd)
 import Data.Bits
 import Data.Either(isLeft, isRight)
-import Data.Foldable(foldl', traverse_, toList)
+import Data.Foldable(foldl', toList)
 import Data.Decimal(roundTo', Decimal, DecimalRaw(..))
 import Data.Vector(Vector)
 import Data.Maybe(maybeToList)
 import Numeric(showIntAtBase)
-import qualified Control.Lens as Lens
 import qualified Data.Vector as V
 import qualified Data.Vector.Algorithms.Intro as V
 import qualified Data.Text as T
@@ -46,8 +45,13 @@ import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import qualified Data.Char as Char
 import qualified Data.ByteString as BS
-import qualified GHC.Exts as Exts
 import qualified Pact.Time as PactTime
+
+#ifndef WITHOUT_CRYPTO
+import Data.Foldable(traverse_)
+import qualified Control.Lens as Lens
+import qualified GHC.Exts as Exts
+#endif
 
 import Pact.Core.Builtin
 import Pact.Core.Literal
@@ -62,9 +66,11 @@ import Pact.Core.Environment
 import Pact.Core.Capabilities
 import Pact.Core.Namespace
 import Pact.Core.Gas
-import Pact.Core.Crypto.Pairing
 import Pact.Core.Type
+#ifndef WITHOUT_CRYPTO
+import Pact.Core.Crypto.Pairing
 import Pact.Core.Crypto.Hash.Poseidon
+#endif
 
 import Pact.Core.IR.Term
 import Pact.Core.IR.Eval.Runtime
@@ -1616,6 +1622,7 @@ coreChainData info b cont handler _env = \case
 -- ZK defns
 -- -------------------------
 
+#ifndef WITHOUT_CRYPTO
 ensureOnCurve :: (Num p, Eq p, MonadEval b i m) => i -> CurvePoint p -> p -> m ()
 ensureOnCurve info p bp = unless (isOnCurve p bp) $ throwExecutionError info PointNotOnCurve
 
@@ -1730,6 +1737,7 @@ zkPointAddition info b cont handler _env = \case
       _ -> argsError info b args
   args -> argsError info b args
 
+
 -----------------------------------
 -- Poseidon
 -----------------------------------
@@ -1742,6 +1750,22 @@ poseidonHash info b cont handler _env = \case
       chargeGasArgs info (GPoseidonHashHackAChain (length intArgs))
       returnCEKValue cont handler $ VInteger (poseidon (V.toList intArgs))
   args -> argsError info b args
+
+#else
+
+zkPairingCheck :: (MonadEval b i m) => NativeFunction step b i m
+zkPairingCheck info _b _cont _handler _env _args = failInvariant info "crypto disabled"
+
+zkScalaMult :: (MonadEval b i m) => NativeFunction step b i m
+zkScalaMult info _b _cont _handler _env _args = failInvariant info "crypto disabled"
+
+zkPointAddition :: (MonadEval b i m) => NativeFunction step b i m
+zkPointAddition info _b _cont _handler _env _args = failInvariant info "crypto disabled"
+
+poseidonHash :: (MonadEval b i m) => NativeFunction step b i m
+poseidonHash info _b _cont _handler _env _args = failInvariant info "crypto disabled"
+
+#endif
 
 
 -----------------------------------


### PR DESCRIPTION
To build/run with profiling, pass `--flags="-with-crypto"` to `cabal`. This disables all `poly`-related stuff (namely, ZK and poseidon hash), but that should still be good enough to build the core with profiling and get meaningful performance data.

PR checklist:

* [ ] Test coverage for the proposed changes
* [ ] PR description contains example output from repl interaction or a snippet from unit test output
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact-core/blob/master/CHANGELOG.md)

Additionally, please justify why you should or should not do the following:

* [ ] Confirm replay/back compat
* [ ] Benchmark regressions
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
