### PR TITLE
Publish binary as development-latest

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -44,7 +44,7 @@ jobs:
 
         echo Build the bundle
         nix build .#pact-binary-bundle --log-lines 500 --show-trace --out-link pact-binary-bundle
-        tar -zcvf pact-binary-bundle-.${{ matrix.os }}.tar.gz ./pact-binary-bundle
+        tar -zcvf pact-binary-bundle.${{ matrix.os }}.tar.gz ./pact-binary-bundle
 
         echo Build the recursive output
         nix build .#recursive.allDerivations --log-lines 500 --show-trace

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -56,6 +56,6 @@ jobs:
         retention-days: 5
 
     - name: Release latest build
-      uses: ncipollo/release-action
+      uses: ncipollo/release-action@v1.14.0
       with:
         artifacts: pact-binary-bundle

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -60,4 +60,6 @@ jobs:
       uses: ncipollo/release-action@v1.14.0
       with:
         artifacts: pact-binary-bundle.${{ matrix.os }}.tar.gz
-        tag: pact-binary-bundle.${{ matrix.os }}-latest
+        tag: development-latest
+        replacesArtifacts: true
+        allowUpdates: true

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -49,7 +49,13 @@ jobs:
         nix build .#recursive.allDerivations --log-lines 500 --show-trace
 
     - name: Publish the bundle
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: pact-bundle.${{ matrix.os }}
         path: pact-binary-bundle
+        retention-days: 5
+
+    - name: Release latest build
+      uses: ncipollo/release-action
+      with:
+        artifacts: pact-binary-bundle

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -42,5 +42,14 @@ jobs:
         echo Building the project and its devShell
         nix build .#check --log-lines 500 --show-trace
 
+        echo Build the bundle
+        nix build .#pact-binary-bundle --log-lines 500 --show-trace --out-link pact-binary-bundle
+
         echo Build the recursive output
         nix build .#recursive.allDerivations --log-lines 500 --show-trace
+
+    - name: Publish the bundle
+      uses: actions/upload-artifact@v3
+      with:
+        name: pact-bundle.${{ matrix.os }}
+        path: pact-binary-bundle

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -44,7 +44,7 @@ jobs:
 
         echo Build the bundle
         nix build .#pact-binary-bundle --log-lines 500 --show-trace --out-link pact-binary-bundle
-        tar -zcvf pact-binary-bundle.${{ matrix.os }}.tar.gz ./pact-binary-bundle
+        tar -zcvf pact-binary-bundle.${{ matrix.os }}.tar.gz $(readlink pact-binary-bundle)
 
         echo Build the recursive output
         nix build .#recursive.allDerivations --log-lines 500 --show-trace

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -44,6 +44,7 @@ jobs:
 
         echo Build the bundle
         nix build .#pact-binary-bundle --log-lines 500 --show-trace --out-link pact-binary-bundle
+        tar -zcvf pact-binary-bundle-.${{ matrix.os }}.tar.gz ./pact-binary-bundle
 
         echo Build the recursive output
         nix build .#recursive.allDerivations --log-lines 500 --show-trace
@@ -58,5 +59,5 @@ jobs:
     - name: Release latest build
       uses: ncipollo/release-action@v1.14.0
       with:
-        artifacts: pact-binary-bundle
-        tag: latest
+        artifacts: pact-binary-bundle.${{ matrix.os }}.tar.gz
+        tag: pact-binary-bundle.${{ matrix.os }}-latest

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -59,3 +59,4 @@ jobs:
       uses: ncipollo/release-action@v1.14.0
       with:
         artifacts: pact-binary-bundle
+        tag: latest

--- a/flake.lock
+++ b/flake.lock
@@ -256,6 +256,22 @@
         "type": "github"
       }
     },
+    "nix-bundle-exe": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1682949567,
+        "narHash": "sha256-K9PT8LVvTLOm3gX9ZFxag0X85DFgB2vvJB+S12disWw=",
+        "owner": "3noch",
+        "repo": "nix-bundle-exe",
+        "rev": "3522ae68aa4188f4366ed96b41a5881d6a88af97",
+        "type": "github"
+      },
+      "original": {
+        "owner": "3noch",
+        "repo": "nix-bundle-exe",
+        "type": "github"
+      }
+    },
     "nix-tools-static": {
       "flake": false,
       "locked": {
@@ -324,7 +340,8 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "hs-nix-infra": "hs-nix-infra"
+        "hs-nix-infra": "hs-nix-infra",
+        "nix-bundle-exe": "nix-bundle-exe"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,7 @@
   inputs = {
     hs-nix-infra.url = "github:kadena-io/hs-nix-infra";
     flake-utils.url = "github:numtide/flake-utils";
+    nix-bundle-exe = { url = "github:3noch/nix-bundle-exe"; flake = false; };
   };
 
   nixConfig = {
@@ -11,7 +12,7 @@
     trusted-public-keys = "nixcache.chainweb.com:FVN503ABX9F8x8K0ptnc99XEz5SaA4Sks6kNcZn2pBY= iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=";
   };
 
-  outputs = { self, flake-utils, hs-nix-infra }:
+  outputs = inputs@{ self, flake-utils, hs-nix-infra, ... }:
     flake-utils.lib.eachSystem
       [ "x86_64-linux" "x86_64-darwin"
         "aarch64-linux" "aarch64-darwin"
@@ -52,6 +53,8 @@
       '';
     in rec {
       packages.pact-binary = flake.packages."pact-tng:exe:pact";
+      packages.pact-binary-bundle = pkgs.callPackage inputs.nix-bundle-exe {}
+        packages.pact-binary;
       packages.pact-gasmodel = flake.packages."pact-tng:exe:gasmodel";
       packages.pact-tests = flake.checks."pact-tng:test:core-tests".overrideAttrs (old: {
         PACT_CORE_NIXBUILD=packages.pact-binary.exePath;


### PR DESCRIPTION
This PR adds releasing binary artefacts once they pass CI as `development-latest`. The general idea is to ship new versions of the LSP server via the VSCode plugin.

PR checklist:

* [ ] Test coverage for the proposed changes
* [ ] PR description contains example output from repl interaction or a snippet from unit test output
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact-core/blob/master/CHANGELOG.md)

Additionally, please justify why you should or should not do the following:

* [ ] Confirm replay/back compat
* [ ] Benchmark regressions
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
