### PR TITLE
add identity builtin to support LSP

### DIFF
--- a/pact-tests/pact-tests/identity.repl
+++ b/pact-tests/pact-tests/identity.repl
@@ -1,0 +1,19 @@
+
+;; tests on literals
+(expect "identity on string literal" (identity "abc") "abc")
+(expect "identity on integer literal" (identity 123) 123)
+(expect "identity on decimal literal" (identity 12.3) 12.3)
+(expect "identity on bool literal: true" (identity true) true)
+(expect "identity on bool literal: false" (identity false) false)
+
+(expect-failure "identity on string literals can fail" (enforce (= (identity "a") "b")))
+
+;; tests on lists
+(expect "identity on list of literal" (identity ["a" "b" "c"]) ["a" "b" "c"])
+(expect "identity on nested list of literal" (identity [["a"]]) [["a"]])
+
+;; tests on object
+(expect "identity on object" (identity {"a": 1}) {"a": 1})
+
+;; tests on time
+(expect "identity on timel" (identity (time "2016-07-22T12:00:00Z")) (time "2016-07-22T12:00:00Z"))

--- a/pact/Pact/Core/Builtin.hs
+++ b/pact/Pact/Core/Builtin.hs
@@ -211,6 +211,7 @@ data CoreBuiltin
   | CoreTypeOf
   | CoreDec
   | CoreCond
+  | CoreIdentity
   deriving (Eq, Show, Ord, Bounded, Enum, Generic)
 
 instance NFData CoreBuiltin
@@ -377,6 +378,7 @@ coreBuiltinToText = \case
   CoreTypeOf -> "typeof"
   CoreDec -> "dec"
   CoreCond -> "cond"
+  CoreIdentity -> "identity"
 
 -- | Our `CoreBuiltin` user-facing representation.
 -- note: `coreBuiltinToUserText`
@@ -522,6 +524,7 @@ coreBuiltinToUserText = \case
   CoreTypeOf -> "typeof"
   CoreDec -> "dec"
   CoreCond -> "cond"
+  CoreIdentity -> "identity"
 
 instance IsBuiltin CoreBuiltin where
   builtinName = NativeName . coreBuiltinToText
@@ -670,6 +673,7 @@ instance IsBuiltin CoreBuiltin where
     CoreTypeOf -> 1
     CoreDec -> 1
     CoreCond -> 1
+    CoreIdentity -> 1
 
 
 coreBuiltinNames :: [Text]

--- a/pact/Pact/Core/Gas/TableGasModel.hs
+++ b/pact/Pact/Core/Gas/TableGasModel.hs
@@ -482,6 +482,7 @@ nativeGasTable = MilliGas . \case
   CoreDec ->
     basicWorkGas
   CoreCond -> basicWorkGas
+  CoreIdentity -> basicWorkGas
 
 replNativeGasTable :: ReplBuiltin CoreBuiltin -> MilliGas
 replNativeGasTable = \case

--- a/pact/Pact/Core/IR/Desugar.hs
+++ b/pact/Pact/Core/IR/Desugar.hs
@@ -288,9 +288,6 @@ desugarLispTerm = \case
           let c1 = Arg cvar1 Nothing
               c2 = Arg cvar2 Nothing
           pure $ Lam (c1 :| [c2]) (Var (BN (BareName cvar1)) i) i
-        | n == BareName "identity" -> do
-          let c1 = Arg ivar1 Nothing
-          pure $ Lam (c1 :| []) (Var (BN (BareName ivar1)) i) i
         | n == BareName "CHARSET_ASCII" -> pure (Constant (LInteger 0) i)
         | n == BareName "CHARSET_LATIN1" -> pure (Constant (LInteger 1) i)
         | otherwise ->
@@ -298,7 +295,6 @@ desugarLispTerm = \case
     where
     cvar1 = "#constantlyA1"
     cvar2 = "#constantlyA2"
-    ivar1 = "#identityA1"
   Lisp.Var n i -> pure (Var n i)
   Lisp.Block nel i -> do
     nel' <- traverse desugarLispTerm nel

--- a/pact/Pact/Core/IR/Eval/CoreBuiltin.hs
+++ b/pact/Pact/Core/IR/Eval/CoreBuiltin.hs
@@ -1590,6 +1590,12 @@ coreCond info b cont handler _env = \case
   args -> argsError info b args
 
 
+coreIdentity :: (CEKEval step b i m, MonadEval b i m) => NativeFunction step b i m
+coreIdentity info b cont handler _env = \case
+  [VPactValue pv] -> returnCEKValue cont handler $ VPactValue pv
+  args -> argsError info b args
+
+
 --------------------------------------------------
 -- Namespace functions
 --------------------------------------------------
@@ -1993,3 +1999,4 @@ coreBuiltinRuntime = \case
   CoreTypeOf -> coreTypeOf
   CoreDec -> coreDec
   CoreCond -> coreCond
+  CoreIdentity -> coreIdentity

--- a/pact/Pact/Core/Serialise/CBOR_V1.hs
+++ b/pact/Pact/Core/Serialise/CBOR_V1.hs
@@ -690,6 +690,7 @@ instance Serialise CoreBuiltin where
     CoreCeilingPrec -> encodeWord 126
     CoreFloorPrec -> encodeWord 127
     CoreCond -> encodeWord 128
+    CoreIdentity -> encodeWord 129
 
   decode = decodeWord >>= \case
     0 -> pure CoreAdd
@@ -823,6 +824,7 @@ instance Serialise CoreBuiltin where
     126 -> pure CoreCeilingPrec
     127 -> pure CoreFloorPrec
     128 -> pure CoreCond
+    129 -> pure CoreIdentity
     _ -> fail "unexpected decoding"
 
 


### PR DESCRIPTION
In this PR we add a dedicated builtin for the `identity` function. So-far, it was desugared directly into a lambda. This prevented us from displaying docs from the LSP.

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact-core/blob/master/CHANGELOG.md)

Additionally, please justify why you should or should not do the following:

* [ ] Confirm replay/back compat
* [ ] Benchmark regressions
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207151514407085