### PR TITLE
Improve callstack errors, check for recursion.

### DIFF
--- a/gasmodel/Pact/Core/GasModel/InterpreterGas.hs
+++ b/gasmodel/Pact/Core/GasModel/InterpreterGas.hs
@@ -355,7 +355,7 @@ gasMtWithHandlerValue pdb = do
                     , _ceInCap=False
                     , _ceDefPactStep=ps
                     , _ceBuiltins=benchmarkEnv }
-        handler = CEKHandler env unitConst Mt (ErrorState def []) CEKNoHandler
+        handler = CEKHandler env unitConst Mt (ErrorState def [] (pure def)) CEKNoHandler
     pure (ee, es, frame, handler, value)
 
 -- Gas for a lambda with N
@@ -375,7 +375,7 @@ gasMtWithHandlerError pdb =
                     , _ceInCap=False
                     , _ceDefPactStep=ps
                     , _ceBuiltins=benchmarkEnv }
-        handler = CEKHandler env unitConst Mt (ErrorState def []) CEKNoHandler
+        handler = CEKHandler env unitConst Mt (ErrorState def [] (pure def)) CEKNoHandler
     pure (ee, es, frame, handler, value)
 
 gasArgsWithRemainingArgs :: PactDb CoreBuiltin () -> C.Benchmark

--- a/gasmodel/Pact/Core/GasModel/Utils.hs
+++ b/gasmodel/Pact/Core/GasModel/Utils.hs
@@ -74,6 +74,7 @@ defaultGasEvalState =
   , _esDefPactExec=Nothing
   , _esCaps=capState
   , _esGasLog=Nothing
+  , _esCheckRecursion = pure (RecursionCheck mempty)
   }
   where
   capState = CapState [] mempty (S.singleton gmModuleName) mempty
@@ -342,8 +343,7 @@ runNativeBenchmarkPrepared envVars = runNativeBenchmark' pure stMod
 unitClosureNullary :: CEKEnv step CoreBuiltin () m -> Closure step CoreBuiltin () m
 unitClosureNullary env
   = Closure
-  { _cloFnName = "foo"
-  , _cloModName = ModuleName "foomodule" Nothing
+  { _cloFqName = FullyQualifiedName (ModuleName "foomodule" Nothing) "foo" placeholderHash
   , _cloTypes = NullaryClosure
   , _cloArity = 0
   , _cloTerm = unitConst
@@ -355,8 +355,7 @@ unitClosureNullary env
 unitClosureUnary :: CEKEnv step CoreBuiltin () m -> Closure step CoreBuiltin () m
 unitClosureUnary env
   = Closure
-  { _cloFnName = "foo"
-  , _cloModName = ModuleName "foomodule" Nothing
+  { _cloFqName = FullyQualifiedName (ModuleName "foomodule" Nothing) "foo" placeholderHash
   , _cloTypes = ArgClosure (NE.fromList [Arg "fooCloArg" Nothing ()])
   , _cloArity = 1
   , _cloTerm = unitConst
@@ -367,8 +366,7 @@ unitClosureUnary env
 unitClosureBinary :: CEKEnv step CoreBuiltin () m -> Closure step CoreBuiltin () m
 unitClosureBinary env
   = Closure
-  { _cloFnName = "foo"
-  , _cloModName = ModuleName "foomodule" Nothing
+  { _cloFqName = FullyQualifiedName (ModuleName "foomodule" Nothing) "foo" placeholderHash
   , _cloTypes = ArgClosure (NE.fromList [Arg "fooCloArg1" Nothing (), Arg "fooCloArg2" Nothing ()])
   , _cloArity = 2
   , _cloTerm = unitConst
@@ -380,8 +378,7 @@ unitClosureBinary env
 boolClosureUnary :: Bool -> CEKEnv step b () m -> Closure step b () m
 boolClosureUnary b env
   = Closure
-  { _cloFnName = "foo"
-  , _cloModName = ModuleName "foomodule" Nothing
+  { _cloFqName = FullyQualifiedName (ModuleName "foomodule" Nothing) "foo" placeholderHash
   , _cloTypes = ArgClosure (NE.fromList [Arg "fooCloArg1" Nothing ()])
   , _cloArity = 1
   , _cloTerm = boolConst b
@@ -392,8 +389,7 @@ boolClosureUnary b env
 boolClosureBinary :: Bool -> CEKEnv step b () m -> Closure step b () m
 boolClosureBinary b env
   = Closure
-  { _cloFnName = "foo"
-  , _cloModName = ModuleName "fooModule" Nothing
+  { _cloFqName = FullyQualifiedName (ModuleName "foomodule" Nothing) "foo" placeholderHash
   , _cloTypes = ArgClosure (NE.fromList [Arg "fooCloArg1" Nothing (), Arg "fooCloArg2" Nothing ()])
   , _cloArity = 2
   , _cloTerm = boolConst b
@@ -404,8 +400,7 @@ boolClosureBinary b env
 intClosureBinary :: Integer -> CEKEnv step b () m -> Closure step b () m
 intClosureBinary b env
   = Closure
-  { _cloFnName = "foo"
-  , _cloModName = ModuleName "fooModule" Nothing
+  { _cloFqName = FullyQualifiedName (ModuleName "foomodule" Nothing) "foo" placeholderHash
   , _cloTypes = ArgClosure (NE.fromList [Arg "fooCloArg1" Nothing (), Arg "fooCloArg2" Nothing ()])
   , _cloArity = 2
   , _cloTerm = intConst b

--- a/pact-tests/Pact/Core/Test/ReplTests.hs
+++ b/pact-tests/Pact/Core/Test/ReplTests.hs
@@ -94,7 +94,7 @@ runReplTest pdb file src interp = do
   ensurePassing = \case
     RCompileValue (InterpretValue v i) -> case v of
       PLiteral (LString msg) -> do
-        let render = replError (SourceCode file src) (PEExecutionError (EvalError msg) i)
+        let render = replError (SourceCode file src) (PEExecutionError (EvalError msg) [] i)
         when (T.isPrefixOf "FAILURE:" msg) $ assertFailure (T.unpack render)
       _ -> pure ()
     _ -> pure ()

--- a/pact-tests/pact-tests/modref-recursion.repl
+++ b/pact-tests/pact-tests/modref-recursion.repl
@@ -1,7 +1,7 @@
 
 (interface call
 
-  (defun callF (m:module{call}))
+  (defun callF:integer (m:module{call}))
   )
 
 (module knot1 g
@@ -9,7 +9,7 @@
 
   (implements call)
 
-  (defun callF (m:module{call})
+  (defun callF:integer (m:module{call})
     (+ 1 2) ; call something so it costs gas
     (m::callF knot1)
   )
@@ -20,7 +20,7 @@
 
   (implements call)
 
-  (defun callF (m:module{call})
+  (defun callF:integer (m:module{call})
     (+ 1 2) ; call something so it costs gas
     (m::callF knot2)
   )
@@ -29,4 +29,4 @@
 (env-gasmodel "table")
 (env-gaslimit 10) ; ensures test does not run forever in case recursion breaks
 
-(expect-failure "Recursion should fail @ runtime" "asdf" (knot2.callF knot1))
+(expect-failure "Recursion should fail @ runtime" (knot2.callF knot1))

--- a/pact-tests/pact-tests/modref-recursion.repl
+++ b/pact-tests/pact-tests/modref-recursion.repl
@@ -1,0 +1,32 @@
+
+(interface call
+
+  (defun callF (m:module{call}))
+  )
+
+(module knot1 g
+  (defcap g () true)
+
+  (implements call)
+
+  (defun callF (m:module{call})
+    (+ 1 2) ; call something so it costs gas
+    (m::callF knot1)
+  )
+  )
+
+(module knot2 g
+  (defcap g () true)
+
+  (implements call)
+
+  (defun callF (m:module{call})
+    (+ 1 2) ; call something so it costs gas
+    (m::callF knot2)
+  )
+  )
+
+(env-gasmodel "table")
+(env-gaslimit 10) ; ensures test does not run forever in case recursion breaks
+
+(expect-failure "Recursion should fail @ runtime" "asdf" (knot2.callF knot1))

--- a/pact-tests/pact-tests/repl-toplevels.repl
+++ b/pact-tests/pact-tests/repl-toplevels.repl
@@ -3,4 +3,10 @@
 
 (defun repl-defun1:integer (a:integer b:integer) (+ a b))
 
-(expect "repl-consts work with repl defuns" 3 (repl-defun1 repl-const1 (repl-defun1 repl-const1 repl-const1)))
+(expect "repl-consts work with repl defuns" 3
+  (let
+    (
+    (v1 (repl-defun1 repl-const1 repl-const1))
+    )
+    (repl-defun1 repl-const1 v1))
+  )

--- a/pact-tng.cabal
+++ b/pact-tng.cabal
@@ -174,6 +174,7 @@ library
     Pact.Core.Scheme
     Pact.Core.Repl
     Pact.Core.SizeOf
+    Pact.Core.StackFrame
     Pact.Core.Legacy.LegacyPactValue
     Pact.Core.Legacy.LegacyCodec
 

--- a/pact/Pact/Core/Environment/Types.hs
+++ b/pact/Pact/Core/Environment/Types.hs
@@ -21,8 +21,6 @@ module Pact.Core.Environment.Types
  , eePublicData, eeMode, eeFlags
  , eeNatives, eeGasModel
  , eeNamespacePolicy, eeGasRef
- , PactState(..)
- , psLoaded
  , TxCreationTime(..)
  , PublicData(..)
  , pdPublicMeta, pdBlockHeight
@@ -47,6 +45,7 @@ module Pact.Core.Environment.Types
  , MonadEval
  , defaultEvalEnv
  , GasLogEntry(..)
+ , RecursionCheck(..)
  ) where
 
 
@@ -56,6 +55,7 @@ import Control.Monad.IO.Class
 import Data.Set(Set)
 import Data.Text(Text)
 import Data.Map.Strict(Map)
+import Data.List.NonEmpty (NonEmpty(..))
 import Data.IORef
 import Data.Default
 
@@ -77,6 +77,7 @@ import Pact.Core.Errors
 import Pact.Core.Gas
 import Pact.Core.Namespace
 import Pact.Core.SizeOf
+import Pact.Core.StackFrame
 import Pact.Core.Builtin (IsBuiltin)
 
 -- | Execution flags specify behavior of the runtime environment,
@@ -96,6 +97,8 @@ data ExecutionFlag
   | FlagEnforceKeyFormats
   -- | Require keysets to be defined in namespaces
   | FlagRequireKeysetNs
+  -- | Flag disabling return type checking
+  | FlagDisableRTC
   deriving (Eq,Ord,Show,Enum,Bounded, Generic)
 
 instance NFData ExecutionFlag
@@ -136,35 +139,13 @@ data EvalEnv b i
   , _eeGasRef :: IORef MilliGas
   -- ^ The gas ref
   , _eeGasModel :: GasModel b
+  -- ^ The current gas model
   } deriving (Generic)
 
 instance (NFData b, NFData i) => NFData (EvalEnv b i)
 
 makeLenses ''EvalEnv
 
-newtype PactState b i
-  = PactState
-  { _psLoaded :: Loaded b i
-  }
-
-makeLenses ''PactState
-
-data StackFunctionType
-  = SFDefun
-  | SFDefcap
-  | SFDefPact
-  deriving (Eq, Show, Enum, Bounded, Generic)
-
-instance NFData StackFunctionType
-
-data StackFrame
-  = StackFrame
-  { _sfFunction :: Text
-  , _sfModule :: ModuleName
-  , _sfFnType :: StackFunctionType }
-  deriving (Show, Generic)
-
-instance NFData StackFrame
 
 data GasLogEntry b = GasLogEntry
   { _gleCause :: Either GasArgs b
@@ -172,21 +153,37 @@ data GasLogEntry b = GasLogEntry
   , _gleTotalUsed :: MilliGas
   } deriving (Show, Generic, NFData)
 
+newtype RecursionCheck
+  = RecursionCheck (Set QualifiedName)
+  deriving (Show, Generic, NFData)
+
+instance Default RecursionCheck where
+  def = RecursionCheck mempty
+
+-- | Interpreter mutable state.
 data EvalState b i
   = EvalState
   { _esCaps :: !(CapState QualifiedName PactValue)
-  , _esStack :: ![StackFrame]
+  -- ^ The current set of granted and installed
+  -- capabilities
+  , _esStack :: ![StackFrame i]
+  -- ^ The runtime callstack, as a structure
   , _esEvents :: ![PactEvent PactValue]
+  -- ^ The list of emitted pact events, if any
   , _esLoaded :: !(Loaded b i)
+  -- ^ The runtime symbol table and module environment
   , _esDefPactExec :: !(Maybe DefPactExec)
+  -- ^ The current defpact execution state, if any
   , _esGasLog :: !(Maybe [GasLogEntry b])
+  -- ^ The current gas log
+  , _esCheckRecursion :: NonEmpty RecursionCheck
     -- ^ Sequence of gas expendature events.
   } deriving (Show, Generic)
 
 instance (NFData b, NFData i) => NFData (EvalState b i)
 
 instance Default (EvalState b i) where
-  def = EvalState def [] [] mempty Nothing Nothing
+  def = EvalState def [] [] mempty Nothing Nothing (RecursionCheck mempty :| [])
 
 makeClassy ''EvalState
 

--- a/pact/Pact/Core/Environment/Utils.hs
+++ b/pact/Pact/Core/Environment/Utils.hs
@@ -16,6 +16,7 @@ module Pact.Core.Environment.Utils
  , getModuleData
  , getModule
  , getModuleMember
+ , getModuleMemberWithHash
  , lookupModule
  , lookupModuleData
  , throwExecutionError
@@ -25,11 +26,14 @@ module Pact.Core.Environment.Utils
  , getAllStackCaps
  , checkSigCaps
  , allModuleExports
+ , liftDbFunction
  ) where
 
 import Control.Lens
 import Control.Applicative((<|>))
 import Control.Monad.Except
+import Control.Exception
+import Control.Monad.IO.Class(MonadIO(..))
 import Data.Default
 import Data.Maybe(mapMaybe)
 import qualified Data.Map.Strict as M
@@ -84,10 +88,22 @@ allModuleExports = \case
         allNewDeps = M.fromList $ toFqDep (_ifName iface) (_ifHash iface) <$> defs
     in allNewDeps <> deps
 
-throwExecutionError :: (MonadEval b i m) => i -> EvalError -> m a
-throwExecutionError i e = throwError (PEExecutionError e i)
+liftDbFunction
+  :: (MonadEvalState b i m, MonadError (PactError i) m, MonadIO m)
+  => i
+  -> IO a
+  -> m a
+liftDbFunction info action = do
+  liftIO (try action) >>= \case
+    Left dbopErr -> throwExecutionError info (DbOpFailure dbopErr)
+    Right e -> pure e
 
-throwExecutionError' :: (MonadEval b i m) => EvalError -> m a
+throwExecutionError :: (MonadEvalState b i m, MonadError (PactError i) m) => i -> EvalError -> m a
+throwExecutionError i e = do
+  st <- useEvalState esStack
+  throwError (PEExecutionError e st i)
+
+throwExecutionError' :: (MonadEvalState b i m, MonadError (PactError i) m, Default i) => EvalError -> m a
 throwExecutionError' = throwExecutionError def
 
 -- | lookupModuleData for only modules
@@ -147,6 +163,16 @@ getModuleMember info pdb (QualifiedName qn mn) = do
   md <- getModule info pdb mn
   case findDefInModule qn md of
     Just d -> pure d
+    Nothing -> do
+      let fqn = FullyQualifiedName mn qn (_mHash md)
+      throwExecutionError info (NameNotInScope fqn)
+
+
+getModuleMemberWithHash :: (MonadEval b i m) => i -> PactDb b i -> QualifiedName -> m (EvalDef b i, ModuleHash)
+getModuleMemberWithHash info pdb (QualifiedName qn mn) = do
+  md <- getModule info pdb mn
+  case findDefInModule qn md of
+    Just d -> pure (d, _mHash md)
     Nothing -> do
       let fqn = FullyQualifiedName mn qn (_mHash md)
       throwExecutionError info (NameNotInScope fqn)

--- a/pact/Pact/Core/Errors.hs
+++ b/pact/Pact/Core/Errors.hs
@@ -200,7 +200,18 @@ instance Pretty DesugarError where
       Pretty.hsep ["rollbacks aren't allowed on the last step in:", pretty mn]
     ExpectedFreeVariable t ->
       Pretty.hsep ["Expected free variable in expression, found locally bound: ", pretty t]
-    e -> pretty (show e)
+    -- Todo: pretty these
+    e@InvalidManagedArg{} -> pretty e
+    e@NotImplemented{} -> pretty e
+    e@InvalidImports{} -> pretty e
+    e@InvalidImportModuleHash{} -> pretty e
+    -- todo: maybe this is a syntaxError???
+    e@InvalidSyntax{} -> pretty e
+    e@InvalidDefInSchemaPosition{} -> pretty e
+    e@InvalidDynamicInvoke{} -> pretty e
+    e@DuplicateDefinition{} -> pretty e
+    e@InvalidBlessedHash{} -> pretty e
+    -- e -> pretty (show e)
 
 -- | Argument type mismatch meant for errors
 --   that does not force you to show the whole PactValue
@@ -324,11 +335,9 @@ data EvalError
   | NestedDefpactsNotAdvanced DefPactId
   | ExpectedPactValue
   | NotInDefPactExecution
-  | GuardEnforceError Text
   | NamespaceInstallError Text
   | DefineNamespaceError Text
   -- ^ Non-recoverable guard enforces.
-  | ConstIsNotAPactValue QualifiedName
   | PointNotOnCurve
   | YieldProvenanceDoesNotMatch Provenance [Provenance]
   | MismatchingKeysetNamespace NamespaceName
@@ -438,7 +447,41 @@ instance Pretty EvalError where
       [ "Enforce pact-version failed:"
       , "Could not parse " <> pretty str <> ", expect list of dot-separated integers"
       ]
-    e -> pretty (show e)
+    -- Todo: Fix each case
+    e@ModRefNotRefined{} -> pretty e
+    e@InvalidDefKind{} -> pretty e
+    e@NoSuchDef{} -> pretty e
+    e@InvalidManagedCap{} -> pretty e
+    e@CapNotInstalled{} -> pretty e
+    e@CapAlreadyInstalled{} -> pretty e
+    e@NameNotInScope{} -> pretty e
+    e@DefIsNotClosure{} -> pretty e
+    e@NoSuchKeySet{} -> pretty e
+    e@CannotUpgradeInterface{} -> pretty e
+    e@ModuleGovernanceFailure{} -> pretty e
+    e@DbOpFailure{} -> pretty e
+    e@DynNameIsNotModRef{} -> pretty e
+    e@ModuleDoesNotExist{} -> pretty e
+    e@ExpectedModule{} -> pretty e
+    e@HashNotBlessed{} -> pretty e
+    e@CannotApplyPartialClosure{} -> pretty e
+    e@ClosureAppliedToTooManyArgs{} -> pretty e
+    e@FormIllegalWithinDefcap{} -> pretty e
+    e@RunTimeTypecheckFailure{} -> pretty e
+    e@NativeIsTopLevelOnly{} -> pretty e
+    e@EventDoesNotMatchModule{} -> pretty e
+    e@InvalidEventCap{} -> pretty e
+    e@NestedDefpactsNotAdvanced{} -> pretty e
+    e@ExpectedPactValue{} -> pretty e
+    e@NotInDefPactExecution{} -> pretty e
+    e@NamespaceInstallError{} -> pretty e
+    e@DefineNamespaceError{} -> pretty e
+    e@PointNotOnCurve{} -> pretty e
+    e@YieldProvenanceDoesNotMatch{} -> pretty e
+    e@MismatchingKeysetNamespace{} -> pretty e
+    e@RuntimeRecursionDetected{} -> pretty e
+
+
 
 instance Exception EvalError
 

--- a/pact/Pact/Core/Errors.hs
+++ b/pact/Pact/Core/Errors.hs
@@ -16,12 +16,10 @@ module Pact.Core.Errors
  , PactError(..)
  , ArgTypeError(..)
  , peInfo
- , liftDbFunction
+ , viewErrorStack
  ) where
 
 import Control.Lens hiding (ix)
-import Control.Monad.Except(MonadError(..))
-import Control.Monad.IO.Class(MonadIO(..))
 import Control.Exception
 import Data.Text(Text)
 import Data.Dynamic (Typeable)
@@ -39,6 +37,7 @@ import Pact.Core.Gas
 import Pact.Core.Pretty as Pretty
 import Pact.Core.Hash
 import Pact.Core.Persistence
+import Pact.Core.StackFrame
 import Pact.Core.DefPacts.Types
 
 
@@ -219,11 +218,11 @@ instance NFData ArgTypeError
 instance Pretty ArgTypeError where
   pretty = \case
     ATEPrim p -> Pretty.brackets $ pretty p
-    ATEList -> "[list]"
-    ATEObject -> "[object]"
-    ATETable -> "[table]"
-    ATEClosure -> "[closure]"
-    ATEModRef -> "[modref]"
+    ATEList -> "list"
+    ATEObject -> "object"
+    ATETable -> "table"
+    ATEClosure -> "closure"
+    ATEModRef -> "modref"
 
 
 -- | All fatal execution errors which should pause
@@ -335,6 +334,7 @@ data EvalError
   | MismatchingKeysetNamespace NamespaceName
   | EnforcePactVersionFailure V.Version (Maybe V.Version)
   | EnforcePactVersionParseFailure Text
+  | RuntimeRecursionDetected QualifiedName
   deriving (Show, Generic)
 
 instance NFData EvalError
@@ -448,7 +448,7 @@ data PactError info
   | PEDesugarError DesugarError info
   -- | PETypecheckError TypecheckError info
   -- | PEOverloadError OverloadError info
-  | PEExecutionError EvalError info
+  | PEExecutionError EvalError [StackFrame info] info
   deriving (Show, Functor, Generic)
 
 instance NFData info => NFData (PactError info)
@@ -458,9 +458,10 @@ instance Pretty (PactError info) where
     PELexerError e _ -> pretty e
     PEParseError e _ -> pretty e
     PEDesugarError e _ -> pretty e
-    PEExecutionError e _ -> pretty e
+    PEExecutionError e _ _ ->
+      pretty e
 
-peInfo :: Lens (PactError info) (PactError info') info info'
+peInfo :: Lens (PactError info) (PactError info) info info
 peInfo f = \case
   PELexerError le info ->
     PELexerError le <$> f info
@@ -468,16 +469,13 @@ peInfo f = \case
     PEParseError pe <$> f info
   PEDesugarError de info ->
     PEDesugarError de <$> f info
-  PEExecutionError ee info ->
-    PEExecutionError ee <$> f info
+  PEExecutionError ee stack info ->
+    PEExecutionError ee stack <$> f info
+
+viewErrorStack :: PactError info -> [StackFrame info]
+viewErrorStack = \case
+  PEExecutionError _ stack _ -> stack
+  _ -> []
 
 instance (Show info, Typeable info) => Exception (PactError info)
 
-liftDbFunction
-  :: (MonadError (PactError i) m, MonadIO m)
-  => i
-  -> IO a
-  -> m a
-liftDbFunction info action = do
-  e <- liftIO $ catch (Right <$> action) (pure . Left . DbOpFailure)
-  either (throwError . (`PEExecutionError` info)) pure e

--- a/pact/Pact/Core/Errors.hs
+++ b/pact/Pact/Core/Errors.hs
@@ -201,16 +201,16 @@ instance Pretty DesugarError where
     ExpectedFreeVariable t ->
       Pretty.hsep ["Expected free variable in expression, found locally bound: ", pretty t]
     -- Todo: pretty these
-    e@InvalidManagedArg{} -> pretty e
-    e@NotImplemented{} -> pretty e
-    e@InvalidImports{} -> pretty e
-    e@InvalidImportModuleHash{} -> pretty e
+    e@InvalidManagedArg{} -> pretty (show e)
+    e@NotImplemented{} -> pretty (show e)
+    e@InvalidImports{} -> pretty (show e)
+    e@InvalidImportModuleHash{} -> pretty (show e)
     -- todo: maybe this is a syntaxError???
-    e@InvalidSyntax{} -> pretty e
-    e@InvalidDefInSchemaPosition{} -> pretty e
-    e@InvalidDynamicInvoke{} -> pretty e
-    e@DuplicateDefinition{} -> pretty e
-    e@InvalidBlessedHash{} -> pretty e
+    e@InvalidSyntax{} -> pretty (show e)
+    e@InvalidDefInSchemaPosition{} -> pretty (show e)
+    e@InvalidDynamicInvoke{} -> pretty (show e)
+    e@DuplicateDefinition{} -> pretty (show e)
+    e@InvalidBlessedHash{} -> pretty (show e)
     -- e -> pretty (show e)
 
 -- | Argument type mismatch meant for errors
@@ -448,38 +448,38 @@ instance Pretty EvalError where
       , "Could not parse " <> pretty str <> ", expect list of dot-separated integers"
       ]
     -- Todo: Fix each case
-    e@ModRefNotRefined{} -> pretty e
-    e@InvalidDefKind{} -> pretty e
-    e@NoSuchDef{} -> pretty e
-    e@InvalidManagedCap{} -> pretty e
-    e@CapNotInstalled{} -> pretty e
-    e@CapAlreadyInstalled{} -> pretty e
-    e@NameNotInScope{} -> pretty e
-    e@DefIsNotClosure{} -> pretty e
-    e@NoSuchKeySet{} -> pretty e
-    e@CannotUpgradeInterface{} -> pretty e
-    e@ModuleGovernanceFailure{} -> pretty e
-    e@DbOpFailure{} -> pretty e
-    e@DynNameIsNotModRef{} -> pretty e
-    e@ModuleDoesNotExist{} -> pretty e
-    e@ExpectedModule{} -> pretty e
-    e@HashNotBlessed{} -> pretty e
-    e@CannotApplyPartialClosure{} -> pretty e
-    e@ClosureAppliedToTooManyArgs{} -> pretty e
-    e@FormIllegalWithinDefcap{} -> pretty e
-    e@RunTimeTypecheckFailure{} -> pretty e
-    e@NativeIsTopLevelOnly{} -> pretty e
-    e@EventDoesNotMatchModule{} -> pretty e
-    e@InvalidEventCap{} -> pretty e
-    e@NestedDefpactsNotAdvanced{} -> pretty e
-    e@ExpectedPactValue{} -> pretty e
-    e@NotInDefPactExecution{} -> pretty e
-    e@NamespaceInstallError{} -> pretty e
-    e@DefineNamespaceError{} -> pretty e
-    e@PointNotOnCurve{} -> pretty e
-    e@YieldProvenanceDoesNotMatch{} -> pretty e
-    e@MismatchingKeysetNamespace{} -> pretty e
-    e@RuntimeRecursionDetected{} -> pretty e
+    e@ModRefNotRefined{} -> pretty (show e)
+    e@InvalidDefKind{} -> pretty (show e)
+    e@NoSuchDef{} -> pretty (show e)
+    e@InvalidManagedCap{} -> pretty (show e)
+    e@CapNotInstalled{} -> pretty (show e)
+    e@CapAlreadyInstalled{} -> pretty (show e)
+    e@NameNotInScope{} -> pretty (show e)
+    e@DefIsNotClosure{} -> pretty (show e)
+    e@NoSuchKeySet{} -> pretty (show e)
+    e@CannotUpgradeInterface{} -> pretty (show e)
+    e@ModuleGovernanceFailure{} -> pretty (show e)
+    e@DbOpFailure{} -> pretty (show e)
+    e@DynNameIsNotModRef{} -> pretty (show e)
+    e@ModuleDoesNotExist{} -> pretty (show e)
+    e@ExpectedModule{} -> pretty (show e)
+    e@HashNotBlessed{} -> pretty (show e)
+    e@CannotApplyPartialClosure{} -> pretty (show e)
+    e@ClosureAppliedToTooManyArgs{} -> pretty (show e)
+    e@FormIllegalWithinDefcap{} -> pretty (show e)
+    e@RunTimeTypecheckFailure{} -> pretty (show e)
+    e@NativeIsTopLevelOnly{} -> pretty (show e)
+    e@EventDoesNotMatchModule{} -> pretty (show e)
+    e@InvalidEventCap{} -> pretty (show e)
+    e@NestedDefpactsNotAdvanced{} -> pretty (show e)
+    e@ExpectedPactValue{} -> pretty (show e)
+    e@NotInDefPactExecution{} -> pretty (show e)
+    e@NamespaceInstallError{} -> pretty (show e)
+    e@DefineNamespaceError{} -> pretty (show e)
+    e@PointNotOnCurve{} -> pretty (show e)
+    e@YieldProvenanceDoesNotMatch{} -> pretty (show e)
+    e@MismatchingKeysetNamespace{} -> pretty (show e)
+    e@RuntimeRecursionDetected{} -> pretty (show e)
 
 
 

--- a/pact/Pact/Core/IR/Eval/CEK.hs
+++ b/pact/Pact/Core/IR/Eval/CEK.hs
@@ -326,7 +326,7 @@ mkDefunClosure d fqn e = case _dfunTerm d of
   Nullary body i ->
     pure (Closure fqn NullaryClosure 0 body (_dfunRType d) e i)
   _ ->
-    failInvariant di ("definition is not a closure: " <> T.pack (show d))
+    failInvariant (_dfunInfo d) ("definition is not a closure: " <> T.pack (show d))
 
 mkDefPactClosure
   :: i

--- a/pact/Pact/Core/IR/Eval/CEK.hs
+++ b/pact/Pact/Core/IR/Eval/CEK.hs
@@ -136,7 +136,7 @@ evaluateTerm cont handler env (Var n info)  = do
       let fqn = FullyQualifiedName mname (_nName n) mh
       lookupFqName fqn >>= \case
         Just (Dfun d) -> do
-          dfunClo <- VDefClosure <$> mkDefunClosure d mname env
+          dfunClo <- VDefClosure <$> mkDefunClosure d fqn env
           returnCEKValue cont handler dfunClo
         -- Todo: this should be GADT'd out
         -- and defconsts should already be evaluated
@@ -317,14 +317,14 @@ evaluateTerm cont handler env (ObjectLit o info) = do
 mkDefunClosure
   :: (MonadEval b i m)
   => Defun Name Type b i
-  -> ModuleName
+  -> FullyQualifiedName
   -> CEKEnv step b i m
   -> m (Closure step b i m)
-mkDefunClosure d@(Defun (Arg n mty _) _ _ di) mn e = case _dfunTerm d of
+mkDefunClosure d fqn e = case _dfunTerm d of
   Lam args body i ->
-    pure (Closure n mn (ArgClosure args) (NE.length args) body mty e i)
+    pure (Closure fqn (ArgClosure args) (NE.length args) body (_dfunRType d) e i)
   Nullary body i ->
-    pure (Closure n mn NullaryClosure 0 body mty e i)
+    pure (Closure fqn NullaryClosure 0 body (_dfunRType d) e i)
   _ ->
     failInvariant di ("definition is not a closure: " <> T.pack (show d))
 
@@ -387,8 +387,8 @@ applyPact
   -> m (CEKEvalResult step b i m)
 applyPact i pc ps cont handler cenv nested = useEvalState esDefPactExec >>= \case
   Just pe -> throwExecutionError i (MultipleOrNestedDefPactExecFound pe)
-  Nothing -> getModuleMember i (_cePactDb cenv) (pc ^. pcName) >>= \case
-    DPact defPact -> do
+  Nothing -> getModuleMemberWithHash i (_cePactDb cenv) (pc ^. pcName) >>= \case
+    (DPact defPact, mh) -> do
       let nSteps = NE.length (_dpSteps defPact)
 
       -- `applyPact` is only called from `initPact` or `resumePact`.
@@ -412,16 +412,15 @@ applyPact i pc ps cont handler cenv nested = useEvalState esDefPactExec >>= \cas
 
       setEvalState esDefPactExec (Just pe)
       let cont' = DefPactStepC cenv cont
-
+          contFqn = qualNameToFqn (pc ^. pcName) mh
+          sf = StackFrame contFqn (pc ^. pcArgs) SFDefPact i
       case (ps ^. psRollback, step) of
         (False, _) ->
-          evalWithStackFrame i cont' handler cenv sf Nothing (ordinaryDefPactStepExec step)
+          evalWithStackFrame i cont' handler cenv Nothing sf (ordinaryDefPactStepExec step)
         (True, StepWithRollback _ rollbackExpr) ->
-          evalWithStackFrame i cont' handler cenv sf Nothing rollbackExpr
+          evalWithStackFrame i cont' handler cenv Nothing sf rollbackExpr
         (True, Step{}) -> throwExecutionError i (DefPactStepHasNoRollback ps)
     _otherwise -> failInvariant i "defpact continuation does not point to defun"
-  where
-  sf = StackFrame (view (pcName . qnName) pc) (view (pcName . qnModName) pc) SFDefPact
 {-# SPECIALIZE applyPact
    :: ()
    -> DefPactContinuation QualifiedName PactValue
@@ -469,8 +468,8 @@ applyNestedPact i pc ps cont handler cenv = useEvalState esDefPactExec >>= \case
   Nothing -> failInvariant i $
     "applyNestedPact: Nested DefPact attempted but no pactExec found" <> T.pack (show pc)
 
-  Just pe -> getModuleMember i (_cePactDb cenv) (pc ^. pcName) >>= \case
-    DPact defPact -> do
+  Just pe -> getModuleMemberWithHash i (_cePactDb cenv) (pc ^. pcName) >>= \case
+    (DPact defPact, mh) -> do
       step <- maybe (failInvariant i "Step not found") pure
         $ _dpSteps defPact ^? ix (ps ^. psStep)
 
@@ -509,16 +508,16 @@ applyNestedPact i pc ps cont handler cenv = useEvalState esDefPactExec >>= \case
       let
         cenv' = set ceDefPactStep (Just ps) cenv
         cont' = NestedDefPactStepC cenv' cont pe
+        contFqn = FullyQualifiedName (pc ^. pcName . qnModName) (pc ^. pcName . qnName) mh
+        sf = StackFrame contFqn (pc ^. pcArgs) SFDefPact i
 
       case (ps ^. psRollback, step) of
         (False, _) ->
-          evalWithStackFrame i cont' handler cenv' sf Nothing  (ordinaryDefPactStepExec step)
+          evalWithStackFrame i cont' handler cenv' Nothing sf (ordinaryDefPactStepExec step)
         (True, StepWithRollback _ rollbackExpr) ->
-          evalWithStackFrame i cont' handler cenv' sf Nothing rollbackExpr
+          evalWithStackFrame i cont' handler cenv' Nothing sf rollbackExpr
         (True, Step{}) -> throwExecutionError i (DefPactStepHasNoRollback ps)
     _otherwise -> failInvariant i "applyNestedPact: Expected a DefPact bot got something else"
-  where
-  sf = StackFrame (view (pcName . qnName) pc) (view (pcName . qnModName) pc) SFDefPact
 {-# SPECIALIZE applyNestedPact
    :: ()
    -> DefPactContinuation QualifiedName PactValue
@@ -731,30 +730,41 @@ acquireModuleAdmin i cont handler env mdl = do
    -> Eval (EvalResult CEKBigStep CoreBuiltin () Eval)
     #-}
 
+-- | Evaluate a term with all the stack manipulation logic
 evalWithStackFrame
   :: (CEKEval step b i m, MonadEval b i m)
   => i
   -> Cont step b i m
   -> CEKErrorHandler step b i m
   -> CEKEnv step b i m
-  -> StackFrame
   -> Maybe Type
+  -> StackFrame i
   -> EvalTerm b i
   -> m (CEKEvalResult step b i m)
-evalWithStackFrame info cont handler env sf mty body = do
+evalWithStackFrame info cont handler env mty sf body = do
   cont' <- pushStackFrame info cont mty sf
   evalCEK cont' handler env body
 
+-- | Push a stack frame into the stack, and check it for recursion
 pushStackFrame
   :: (MonadEval b i m)
   => i
   -> Cont step b i m
   -> Maybe Type
-  -> StackFrame
+  -> StackFrame i
   -> m (Cont step b i m)
 pushStackFrame info cont mty sf = do
+  checkRecursion
   esStack %== (sf :)
   pure (StackPopC info mty cont)
+  where
+  checkRecursion = do
+    RecursionCheck currentCalled <- usesEvalState esCheckRecursion NE.head
+    let qn = fqnToQualName (_sfName sf)
+    when (S.member qn currentCalled) $ throwExecutionError info (RuntimeRecursionDetected qn)
+    esCheckRecursion %== NE.cons (RecursionCheck (S.insert qn currentCalled))
+
+
 
 -- | Our main workhorse for "Evaluate a capability, then do something else"
 -- `evalCap` handles
@@ -848,16 +858,16 @@ evalCap info currCont handler env origToken@(CapToken fqn args) popType ecType c
                     else currCont
             inCapEnv = set ceInCap True $ set ceLocal newLocals env
         (esCaps . csSlots) %== (CapSlot qualCapToken []:)
-        evalWithStackFrame info cont' handler inCapEnv capStackFrame Nothing capBody
+        evalWithStackFrame info cont' handler inCapEnv Nothing capStackFrame capBody
   qualCapName = fqnToQualName fqn
   qualCapToken = CapToken qualCapName args
-  capStackFrame = StackFrame (_fqName fqn) (_fqModule fqn) SFDefcap
+  capStackFrame = StackFrame fqn args SFDefcap info
   -- This function is handles both evaluating the manager function for the installed parameter
   -- and continuing evaluation for the actual capability body.
   evalUserManagedCap cont' env' capBody managedCap = case _mcManaged managedCap of
     ManagedParam mpfqn oldV managedIx -> do
       dfun <- getDefun info mpfqn
-      dfunClo <- mkDefunClosure dfun (_fqModule mpfqn) env
+      dfunClo <- mkDefunClosure dfun mpfqn env
       newV <- maybe (failInvariant info "Managed param does not exist at index") pure (args ^? ix managedIx)
       -- Set the mgr fun to evaluate after we apply the capability body
       -- NOTE: test-capability doesn't actually run the manager function, it just runs the cap pop then
@@ -1518,16 +1528,22 @@ applyContToValue (ObjC env info currfield fs vs cont) handler v = do
 
 applyContToValue (EnforceErrorC info _) handler v = case v of
   VString err -> returnCEK Mt handler (VError err info)
-  _ -> failInvariant info "enforce function did not return a string"
+  -- TODO: remove
+  _ -> failInvariant info $ "enforce function did not return a string" <> T.pack (show v)
 -- Discard the value of running a user guard, no error occured, so
 applyContToValue (IgnoreValueC v cont) handler _v =
   returnCEKValue cont handler (VPactValue v)
 
 applyContToValue (StackPopC i mty cont) handler v = do
   v' <- (\pv -> maybeTCType i pv mty) =<< enforcePactValue i v
-  -- Todo: this seems like an invariant failure, so maybe safeTail is not what we want?
-  -- Testing will determine whether this is observable.
-  (esStack %== safeTail) *> returnCEKValue cont handler (VPactValue v')
+  esStack %== safeTail
+  esCheckRecursion %== getPrevRecCheck
+  returnCEKValue cont handler (VPactValue v')
+  where
+  getPrevRecCheck (_ :| l) = case l of
+    top : rest -> top :| rest
+    [] -> def :| []
+
 applyContToValue (DefPactStepC env cont) handler v =
   useEvalState esDefPactExec >>= \case
     Nothing -> failInvariant def "No PactExec found"
@@ -1587,6 +1603,8 @@ nestedPactsNotAdvanced resultState ps =
   any (\npe -> _peStep npe /= _psStep ps) (_peNestedDefPactExec resultState)
 {-# INLINE nestedPactsNotAdvanced #-}
 
+-- | Apply a closure to its arguments,
+--   dispatching based on closure type.
 applyLam
   :: (CEKEval step b i m, MonadEval b i m)
   => CanApply step b i m
@@ -1594,22 +1612,18 @@ applyLam
   -> Cont step b i m
   -> CEKErrorHandler step b i m
   -> m (CEKEvalResult step b i m)
-applyLam vc@(C (Closure fn mn ca arity term mty env cloi)) args cont handler
+applyLam vc@(C (Closure fqn ca arity term mty env cloi)) args cont handler
+  -- Fully apply closure and evaluate
   | arity == argLen = case ca of
     ArgClosure cloargs -> do
-      let qn = QualifiedName fn mn
-      chargeGasArgs cloi (GAApplyLam (renderQualName qn) argLen)
+      chargeGasArgs cloi (GAApplyLam (renderFullyQualName fqn) argLen)
       args' <- traverse (enforcePactValue cloi) args
       tcArgs <- zipWithM (\arg (Arg _ ty _) -> VPactValue <$> maybeTCType cloi arg ty) args' (NE.toList cloargs)
-      esStack %== (StackFrame fn mn SFDefun :)
-      let cont' = StackPopC cloi mty cont
-          varEnv = RAList.fromList (reverse tcArgs)
-      evalCEK cont' handler (set ceLocal varEnv env) term
+      let varEnv = RAList.fromList (reverse tcArgs)
+      evalWithStackFrame cloi cont handler (set ceLocal varEnv env) mty (StackFrame fqn args' SFDefun cloi) term
     NullaryClosure -> do
-      esStack %== (StackFrame fn mn SFDefun :)
-      let cont' = StackPopC cloi mty cont
-          varEnv = mempty
-      evalCEK cont' handler (set ceLocal varEnv env) term
+      let varEnv = mempty
+      evalWithStackFrame cloi cont handler (set ceLocal varEnv env) mty (StackFrame fqn [] SFDefun cloi) term
   | argLen > arity = throwExecutionError cloi ClosureAppliedToTooManyArgs
   | otherwise = case ca of
     NullaryClosure -> throwExecutionError cloi ClosureAppliedToTooManyArgs
@@ -1617,17 +1631,18 @@ applyLam vc@(C (Closure fn mn ca arity term mty env cloi)) args cont handler
       | null args ->
         returnCEKValue cont handler (VClosure vc)
       | otherwise -> do
-        chargeGasArgs cloi (GAApplyLam fn argLen)
+        chargeGasArgs cloi (GAApplyLam (renderFullyQualName fqn) argLen)
         apply' mempty (NE.toList cloargs) args
   where
   argLen = length args
-  -- Here we enforce an argument to a user fn is a
+  -- Here we enforce an argument to a user fn is a pact value
   apply' e (Arg _ ty _:tys) (x:xs) = do
     x' <- (\pv -> maybeTCType cloi pv ty) =<< enforcePactValue cloi x
     apply' (RAList.cons (VPactValue x') e) tys xs
   apply' e (ty:tys) [] = do
     let env' = set ceLocal e env
-        pclo = PartialClosure (Just (StackFrame fn mn SFDefun)) (ty :| tys) (length tys + 1) term mty env' cloi
+        -- Todo: fix partial SF args
+        pclo = PartialClosure (Just (StackFrame fqn [] SFDefun cloi)) (ty :| tys) (length tys + 1) term mty env' cloi
     returnCEKValue cont handler (VPartialClosure pclo)
   apply' _ [] _ = throwExecutionError cloi ClosureAppliedToTooManyArgs
 
@@ -1672,9 +1687,7 @@ applyLam (PC (PartialClosure li argtys _ term mty env cloi)) args cont handler =
   apply' e [] [] = do
     case li of
       Just sf -> do
-        let cont' = StackPopC cloi mty cont
-        esStack %== (sf :)
-        evalCEK cont' handler (set ceLocal e env) term
+        evalWithStackFrame cloi cont handler (set ceLocal e env) mty sf term
       Nothing -> do
         let cont' = EnforcePactValueC cloi cont
         evalCEK cont' handler (set ceLocal e env) term
@@ -1745,9 +1758,9 @@ applyLam (CT (CapTokenClosure fqn argtys arity i)) args cont handler
    -> Eval (EvalResult CEKBigStep CoreBuiltin () Eval)
     #-}
 
-getSfName :: Maybe StackFrame -> T.Text
+getSfName :: Maybe (StackFrame i) -> T.Text
 getSfName = \case
-  Just sf -> renderQualName (QualifiedName (_sfFunction sf) (_sfModule sf))
+  Just sf -> renderFullyQualName (_sfName sf)
   Nothing -> "#lambda"
 
 checkSchema :: M.Map Field PactValue -> Schema -> Bool
@@ -1875,14 +1888,14 @@ runUserGuard
   -> UserGuard QualifiedName PactValue
   -> m (CEKEvalResult step b i m)
 runUserGuard info cont handler env (UserGuard qn args) =
-  getModuleMember info (_cePactDb env) qn >>= \case
-    Dfun d -> do
+  getModuleMemberWithHash info (_cePactDb env) qn >>= \case
+    (Dfun d, mh) -> do
       when (length (_dfunArgs d) /= length args) $ throwExecutionError info CannotApplyPartialClosure
       let env' = sysOnlyEnv env
-      clo <- mkDefunClosure d (_qnModName qn) env'
+      clo <- mkDefunClosure d (qualNameToFqn qn mh) env'
       -- Todo: sys only here
       applyLam (C clo) (VPactValue <$> args) (IgnoreValueC (PBool True) cont) handler
-    d -> throwExecutionError info (InvalidDefKind (defKind (_qnModName qn) d) "run-user-guard")
+    (d, _) -> throwExecutionError info (InvalidDefKind (defKind (_qnModName qn) d) "run-user-guard")
 {-# SPECIALIZE runUserGuard
    :: ()
    -> CoreCEKCont
@@ -2022,9 +2035,9 @@ isKeysetInSigs info cont handler env (KeySet kskeys ksPred) = do
   runCustomPred matched = \case
     TQN qn -> do
       pdb <- viewEvalEnv eePactDb
-      getModuleMember info pdb qn >>= \case
-        Dfun d -> do
-          clo <- mkDefunClosure d (_qnModName qn) env
+      getModuleMemberWithHash info pdb qn >>= \case
+        (Dfun d, mh) -> do
+          clo <- mkDefunClosure d (qualNameToFqn qn mh) env
           let cont' = BuiltinC env info RunKeysetPredC cont
           applyLam (C clo) [VInteger (fromIntegral count), VInteger (fromIntegral matched)] cont' handler
         _ -> failInvariant info "invalid def type for custom keyset predicate"
@@ -2065,4 +2078,3 @@ unconsWorkNodeGas = (MilliGas 100)
 
 tryNodeGas :: MilliGas
 tryNodeGas = (MilliGas 100)
-

--- a/pact/Pact/Core/IR/Eval/Runtime/Types.hs
+++ b/pact/Pact/Core/IR/Eval/Runtime/Types.hs
@@ -594,7 +594,7 @@ data EvalCapType
 
 -- | State to preserve in the error handler
 data ErrorState i
-  = ErrorState (CapState QualifiedName PactValue) [StackFrame i]
+  = ErrorState (CapState QualifiedName PactValue) [StackFrame i] (NonEmpty RecursionCheck)
   deriving (Show, Generic)
 
 instance NFData i => NFData (ErrorState i)

--- a/pact/Pact/Core/IR/Eval/Runtime/Utils.hs
+++ b/pact/Pact/Core/IR/Eval/Runtime/Utils.hs
@@ -50,7 +50,6 @@ module Pact.Core.IR.Eval.Runtime.Utils
 import Control.Lens
 import Control.Monad(when)
 import Control.Monad.IO.Class
-import Control.Monad.Except(MonadError(..))
 import Data.IORef
 import Data.Foldable(find, toList)
 import Data.Maybe(listToMaybe)
@@ -124,7 +123,7 @@ maybeTCType i pv = maybe (pure pv) (typecheckArgument i pv)
 findCallingModule :: (MonadEval b i m) => m (Maybe ModuleName)
 findCallingModule = do
   stack <- useEvalState esStack
-  pure $ listToMaybe $ fmap _sfModule stack
+  pure $ listToMaybe $ fmap (_fqModule . _sfName) stack
 
 calledByModule
   :: (MonadEval b i m)
@@ -132,14 +131,17 @@ calledByModule
   -> m Bool
 calledByModule mn = do
   stack <- useEvalState esStack
-  case find (\sf -> _sfModule sf == mn) stack of
+  case find (\sf -> (_fqModule . _sfName) sf == mn) stack of
     Just _ -> pure True
     Nothing -> pure False
 
+-- | Throw an invariant failure, that is
+-- an error which we do not expect to see during regular pact
+-- execution. If this case is ever hit, we have a problem with
+-- some invalid state in interpretation
 failInvariant :: MonadEval b i m => i -> Text -> m a
-failInvariant i b =
-  let e = PEExecutionError (InvariantFailure b) i
-  in throwError e
+failInvariant i reason =
+  throwExecutionError i (InvariantFailure reason)
 
 -- Todo: MaybeT cleans this up
 getCallingModule :: (MonadEval b i m) => i -> m (EvalModule b i)
@@ -159,11 +161,11 @@ safeTail [] = []
 isExecutionFlagSet :: (MonadEval b i m) => ExecutionFlag -> m Bool
 isExecutionFlagSet flag = viewsEvalEnv eeFlags (S.member flag)
 
-evalStateToErrorState :: EvalState b i -> ErrorState
+evalStateToErrorState :: EvalState b i -> ErrorState i
 evalStateToErrorState es =
   ErrorState (_esCaps es) (_esStack es)
 
-restoreFromErrorState :: ErrorState -> EvalState b i -> EvalState b i
+restoreFromErrorState :: ErrorState i -> EvalState b i -> EvalState b i
 restoreFromErrorState (ErrorState caps stack) =
   set esCaps caps . set esStack stack
 

--- a/pact/Pact/Core/IR/Eval/Runtime/Utils.hs
+++ b/pact/Pact/Core/IR/Eval/Runtime/Utils.hs
@@ -163,11 +163,11 @@ isExecutionFlagSet flag = viewsEvalEnv eeFlags (S.member flag)
 
 evalStateToErrorState :: EvalState b i -> ErrorState i
 evalStateToErrorState es =
-  ErrorState (_esCaps es) (_esStack es)
+  ErrorState (_esCaps es) (_esStack es) (_esCheckRecursion es)
 
 restoreFromErrorState :: ErrorState i -> EvalState b i -> EvalState b i
-restoreFromErrorState (ErrorState caps stack) =
-  set esCaps caps . set esStack stack
+restoreFromErrorState (ErrorState caps stack recur) =
+  set esCaps caps . set esStack stack . set esCheckRecursion recur
 
 checkNonLocalAllowed :: (MonadEval b i m) => i -> m ()
 checkNonLocalAllowed info = do

--- a/pact/Pact/Core/IR/Term.hs
+++ b/pact/Pact/Core/IR/Term.hs
@@ -99,6 +99,10 @@ data Defun name ty builtin info
   , _dfunInfo :: info
   } deriving (Show, Functor, Eq, Generic)
 
+-- | accessor for compat
+_dfunRType :: Defun name ty builtin info -> Maybe ty
+_dfunRType (Defun (Arg _ mty _) _ _ _) = mty
+
 data Step name ty builtin info
   = Step (Term name ty builtin info)
   | StepWithRollback

--- a/pact/Pact/Core/Names.hs
+++ b/pact/Pact/Core/Names.hs
@@ -48,6 +48,7 @@ module Pact.Core.Names
  , replModuleHash
  , fqnToName
  , fqnToQualName
+ , qualNameToFqn
  , NativeName(..)
  , RowKey(..)
  , rowKey
@@ -268,6 +269,10 @@ fqnToName (FullyQualifiedName mn name mh) =
 fqnToQualName :: FullyQualifiedName -> QualifiedName
 fqnToQualName (FullyQualifiedName mn name _) =
   QualifiedName name mn
+
+qualNameToFqn :: QualifiedName -> ModuleHash -> FullyQualifiedName
+qualNameToFqn (QualifiedName name mn) mh =
+  FullyQualifiedName mn name mh
 
 instance Pretty FullyQualifiedName where
   pretty fq = pretty $ fqnToQualName fq

--- a/pact/Pact/Core/PactValue.hs
+++ b/pact/Pact/Core/PactValue.hs
@@ -90,9 +90,9 @@ instance Pretty PactValue where
     PList p -> Pretty.list (V.toList (pretty <$> p))
     PGuard g -> pretty g
     PObject o ->
-      braces $ hsep $ punctuate comma (objPair <$> M.toList o)
+      braces $ mconcat $ punctuate comma (objPair <$> M.toList o)
       where
-      objPair (f, t) = dquotes (pretty f) <> ":" <> pretty t
+      objPair (f, t) = dquotes (pretty f) <> ":" <+> pretty t
     PModRef md -> pretty md
     PCapToken (CapToken fqn args) ->
       parens (pretty (fqnToQualName fqn)) <> if null args then mempty else hsep (pretty <$> args)

--- a/pact/Pact/Core/Pretty.hs
+++ b/pact/Pact/Core/Pretty.hs
@@ -23,7 +23,6 @@ import Prettyprinter
 import qualified Prettyprinter as Pretty
 import Prettyprinter.Render.String
 import Prettyprinter.Render.Text
-import Data.List(intersperse)
 import Data.List.NonEmpty(NonEmpty)
 
 import qualified Data.List.NonEmpty as NE
@@ -50,7 +49,7 @@ commaSepNE :: Pretty a => NonEmpty a -> Doc ann
 commaSepNE = commaSep . NE.toList
 
 commaSep :: Pretty a => [a] -> Doc ann
-commaSep = Pretty.hsep . intersperse "," . fmap pretty
+commaSep = Pretty.hsep . Pretty.punctuate "," . fmap pretty
 
 commaBraces, commaBrackets, bracketsSep, parensSep, bracesSep :: [Doc ann] -> Doc ann
 commaBraces   = encloseSep "{" "}" ","
@@ -58,7 +57,3 @@ commaBrackets = encloseSep "[" "]" ","
 bracketsSep   = brackets . sep
 parensSep     = parens   . sep
 bracesSep     = braces   . sep
-
--- prettyList :: Pretty a => [a] -> Doc ann
--- prettyList = list . map pretty
-

--- a/pact/Pact/Core/Repl/Runtime/ReplBuiltin.hs
+++ b/pact/Pact/Core/Repl/Runtime/ReplBuiltin.hs
@@ -78,14 +78,15 @@ coreExpect info b cont handler _env = \case
                 returnCEKValue cont handler $ VLiteral $ LString $ "FAILURE: " <> msg <> " expected: " <> v1s <> ", received: " <> v2s
             else returnCEKValue cont handler (VLiteral (LString ("Expect: success " <> msg)))
           _ -> returnCEK cont handler (VError "evaluation within expect did not return a pact value" info)
-      Right (VError errMsg _) ->
-        returnCEKValue cont handler $ VString $ "FAILURE: " <> msg <> "evaluation of actual failed with error message: " <> errMsg
+      Right (VError errMsg _) -> do
+        putEvalState es
+        returnCEKValue cont handler $ VString $ "FAILURE: " <> msg <> " evaluation of actual failed with error message: " <> errMsg
       Right _v ->
         returnCEK cont handler $ VError "FAILURE: expect expression did not return a pact value for comparison" info
       Left err -> do
         putEvalState es
         currSource <- use replCurrSource
-        returnCEKValue cont handler $ VString $ "FAILURE: " <> msg <> "evaluation of actual failed with error message:\n" <>
+        returnCEKValue cont handler $ VString $ "FAILURE: " <> msg <> " evaluation of actual failed with error message:\n" <>
           replError currSource err
   args -> argsError info b args
 

--- a/pact/Pact/Core/Repl/Utils.hs
+++ b/pact/Pact/Core/Repl/Utils.hs
@@ -154,7 +154,7 @@ instance MonadEvalState b SpanInfo (ReplM b) where
 instance HasEvalState (ReplState b) b SpanInfo where
   evalState = replEvalState
 
-instance (Pretty b, Show b) => PhaseDebug b SpanInfo (ReplM b) where
+instance (Pretty b) => PhaseDebug b SpanInfo (ReplM b) where
   debugPrint dp term = do
     case dp of
       DPLexer -> whenReplFlagSet ReplDebugLexer $ liftIO $ do
@@ -171,8 +171,6 @@ instance (Pretty b, Show b) => PhaseDebug b SpanInfo (ReplM b) where
           liftIO $ do
             putStrLn "----------- Desugar output ---------------"
             print (pretty t)
-            print (show t)
-            print $ "At span information: " <> show (view Term.termInfo t)
         _ -> pure ()
 
 

--- a/pact/Pact/Core/Repl/Utils.hs
+++ b/pact/Pact/Core/Repl/Utils.hs
@@ -307,8 +307,11 @@ replError (SourceCode srcFile src) pe =
       colMarker = T.replicate (maxPad+1) " " <> "| " <> T.replicate (_liStartColumn pei) " " <> T.replicate (max 1 (_liEndColumn pei - _liStartColumn pei)) "^"
       errRender = renderText pe
       fileErr = file <> ":" <> T.pack (show (_liStartLine pei + 1)) <> ":" <> T.pack (show (_liStartColumn pei)) <> ": "
-  in T.unlines ([fileErr <> errRender] ++ slice ++ [colMarker])
+  in T.unlines ([fileErr <> errRender] ++ slice ++ [colMarker, sfRender])
   where
+  sfRender = case viewErrorStack pe of
+    [] -> mempty
+    sfs -> renderText' $ vsep (("  at" <+>) . pretty <$> sfs)
   padLeft t pad = T.replicate (pad - (T.length t)) " " <> t <> " "
   -- Zip the line number with the source text, and apply the number padding correctly
   withLine st pad lns = zipWith (\i e -> padLeft (T.pack (show i)) pad <> "| " <> e) [st+1..] lns

--- a/pact/Pact/Core/StackFrame.hs
+++ b/pact/Pact/Core/StackFrame.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE DeriveTraversable #-}
+
+
+module Pact.Core.StackFrame
+ ( StackFrame(..)
+ , StackFunctionType(..))
+ where
+
+import Control.DeepSeq(NFData)
+import GHC.Generics
+
+import Pact.Core.Names
+import Pact.Core.PactValue
+import Pact.Core.Pretty
+
+
+data StackFunctionType
+  = SFDefun
+  | SFDefcap
+  | SFDefPact
+  deriving (Eq, Show, Enum, Bounded, Generic)
+
+instance NFData StackFunctionType
+
+data StackFrame i
+  = StackFrame
+  { _sfName :: !FullyQualifiedName
+  , _sfArgs :: ![PactValue]
+  , _sfFnType :: !StackFunctionType
+  , _sfInfo :: !i }
+  deriving (Show, Generic, Functor, Foldable, Traversable)
+
+instance NFData i => NFData (StackFrame i)
+
+instance Pretty (StackFrame i) where
+  pretty (StackFrame sfn args _ _) =
+    parens (pretty sfn <> if null args then mempty else space <> hsep (pretty <$> args))


### PR DESCRIPTION
This PR improves the state of error messages in core, as well as adds a runtime recursion check for module references.

Given this repl file:
```
(module caller g

  (defcap g () true)

  (defun caller ()
    (caller1)
  )

  (defun caller1 ()
    (caller2 31)
  )

  (defun caller2 (a:integer)
    (caller3 31 "bob`")
  )

  (defun caller3 (a:integer arg:string)
    (enforce false "whoopsie!")
  )
  )

(caller)
```

Pre-this PR, the following is a repl snippet of the error emitted by loading the file:
```
pact>(load "example.repl" true)
"Loading example.repl..."
Loaded module caller, hash Z9GxDb9xe8joF3x1SfeqbMuN9RrSSekRm5N2TBTJ5zI
example.repl:18:4: Program encountered an unhandled raised error: whoopsie!
 18 |     (enforce false "whoopsie!")
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^

```

Post-this, the error improves to

```
pact>(load "example.repl" true)
"Loading example.repl..."
Loaded module caller, hash Z9GxDb9xe8joF3x1SfeqbMuN9RrSSekRm5N2TBTJ5zI
example.repl:18:4: Program encountered an unhandled raised error: whoopsie!
 18 |     (enforce false "whoopsie!")
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  at (caller.caller3 31 "bob`")
  at (caller.caller2 31)
  at (caller.caller1)
  at (caller.caller)
  ```

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact-core/blob/master/CHANGELOG.md)
