### PR TITLE
tests: remove marmalade submodule

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Build and cache artifacts
       run: |
         echo Building the project and its devShell
-        nix build .?submodules=1#check --log-lines 500 --show-trace
+        nix build .#check --log-lines 500 --show-trace
 
         echo Build the bundle
         nix build .#pact-binary-bundle --log-lines 500 --show-trace --out-link pact-binary-bundle

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "pact-tests/pact-tests/marmalade"]
-	path = pact-tests/pact-tests/marmalade
-	url = https://github.com/kadena-io/marmalade.git

--- a/pact-tests/pact-tests/marmalade/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/pact-tests/pact-tests/marmalade/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -1,0 +1,51 @@
+name: Bug
+description: File a bug report
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before opening a bug report, please search for the behaviour in the existing issues. 
+        
+        ---
+        
+        Thank you for taking the time to file a bug report. To address this bug as fast as possible, we need some information.
+  - type: textarea
+    id: behavior
+    attributes:
+      label: Expected Behavior
+      description: "Tell us what should happen"
+      placeholder: "..."
+    validations:
+      required: true  
+  - type: textarea
+    id: current
+    attributes:
+      label: Current Behavior
+      description: "Tell us what happens instead of the expected behavior"
+      placeholder: "..."
+    validations:
+      required: true
+  - type: textarea
+    id: possible
+    attributes:
+      label: Possible Solution
+      description: "Not obligatory, but suggest a fix/reason for the bug"
+      placeholder: "..."
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: "Provide a link to a live example, or an unambiguous set of steps to reproduce this bug. Include code to reproduce, if relevant"
+      placeholder: "1. 2. 3. 4."
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: If applicable, provide relevant log output. No need for backticks here.
+      render: shell

--- a/pact-tests/pact-tests/marmalade/.github/ISSUE_TEMPLATE/ENHANCEMENT-REQUEST.yml
+++ b/pact-tests/pact-tests/marmalade/.github/ISSUE_TEMPLATE/ENHANCEMENT-REQUEST.yml
@@ -1,0 +1,36 @@
+name: Enhancement
+description: Enhancement Request
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before opening a enhancement request, please search for similar requests in the existing issues. 
+        
+        ---
+        
+        Thank you for taking the time to make a suggestion. To review this as fast as possible, we need some information.
+  - type: textarea
+    id: context
+    attributes:
+      label: Context (Environment)
+      description: "What are you trying to accomplish - Providing context helps us come up with a solution that is most useful"
+      placeholder: "..."
+    validations:
+      required: true  
+  - type: textarea
+    id: details
+    attributes:
+      label: Detailed Description
+      description: "Provide a detailed description of the change or addition you are proposing"
+      placeholder: "..."
+    validations:
+      required: true
+  - type: textarea
+    id: possible
+    attributes:
+      label: Possible Implementation
+      description: "Not obligatory, but suggest an idea for implementing addition or change"
+      placeholder: "..."
+    validations:
+      required: false
+  

--- a/pact-tests/pact-tests/marmalade/.github/ISSUE_TEMPLATE/config.yml
+++ b/pact-tests/pact-tests/marmalade/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Marmalade
+    url: https://marmalade.art/
+    about: Marmalade official website

--- a/pact-tests/pact-tests/marmalade/.github/actions/repl/action.yml
+++ b/pact-tests/pact-tests/marmalade/.github/actions/repl/action.yml
@@ -1,0 +1,18 @@
+name: REPL
+description: Run a REPL test
+
+inputs:
+  target:
+    description: "The target file to run"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: "Test ${{ inputs.target }}"
+      shell: bash
+      run: |
+        bin/pact -t ${{ inputs.target }} > out.log 2>&1
+        cat out.log
+        r=`tail -1 out.log | grep "Load successful"`
+        if [ -n "$r" ]; then exit 0; else cat out.log; echo "\nPact run failed."; exit 1; fi

--- a/pact-tests/pact-tests/marmalade/.github/actions/setup-pact/action.yml
+++ b/pact-tests/pact-tests/marmalade/.github/actions/setup-pact/action.yml
@@ -1,0 +1,28 @@
+name: Setup Pact
+description: Setup pact environment for running tests
+
+inputs:
+  version:
+    description: "Target Pact version to install"
+    required: false
+    default: "4.10.0"
+
+runs:
+  using: composite
+  steps:
+    - name: Get pact binary
+      shell: bash
+      run: |
+        mkdir bin
+        cd bin
+        wget https://github.com/kadena-io/pact/releases/download/v${{ inputs.version }}/pact-${{ inputs.version }}-linux-20.04.zip
+        unzip "pact*.zip"
+        chmod +x pact
+        cd ..
+
+    - name: Install z3 (ubuntu-18.04)
+      uses: pavpanchekha/setup-z3@0.2.0
+      with:
+        version: "4.8.10"
+        architecture: "x64"
+        distribution: "ubuntu-18.04"

--- a/pact-tests/pact-tests/marmalade/.github/workflows/test-example-policies.yml
+++ b/pact-tests/pact-tests/marmalade/.github/workflows/test-example-policies.yml
@@ -1,0 +1,49 @@
+name: Test example policies
+
+on:
+  push:
+    paths:
+      - "examples/**"
+  pull_request:
+    paths:
+      - "examples/**"
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  test-pact:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Pact
+        uses: ./.github/actions/setup-pact
+        with:
+          version: "4.10.0"
+
+      - name: Test fixed-issuance-policy-v1
+        uses: ./.github/actions/repl
+        with:
+          target: examples/policies/fixed-issuance-policy/fixed-issuance-policy-v1.pact
+
+      - name: Test onchain-manifest-policy-v1
+        uses: ./.github/actions/repl
+        with:
+          target: examples/policies/onchain-manifest-policy/onchain-manifest-policy-v1.repl
+
+      - name: Test timed-mint-policy-v1
+        uses: ./.github/actions/repl
+        with:
+          target: examples/policies/timed-mint-policy/timed-mint-policy-v1.repl
+
+      - name: Test private-token-policy-v1
+        uses: ./.github/actions/repl
+        with:
+          target: examples/policies/private-token-policy/private-token-policy-v1.repl
+
+      - name: Test multi-asset-policy-v1
+        uses: ./.github/actions/repl
+        with:
+          target: examples/policies/multi-asset-policy/multi-asset-policy.repl

--- a/pact-tests/pact-tests/marmalade/.github/workflows/test-marmalade.yml
+++ b/pact-tests/pact-tests/marmalade/.github/workflows/test-marmalade.yml
@@ -1,0 +1,62 @@
+name: Test Marmalade protocol
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  test-pact:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Pact
+        uses: ./.github/actions/setup-pact
+        with:
+          version: "4.10.0"
+
+      - name: Test pact/marmalade.repl
+        uses: ./.github/actions/repl
+        with:
+          target: pact/marmalade.repl
+
+      - name: Test pact/policy-manager/policy-manager.repl
+        uses: ./.github/actions/repl
+        with:
+          target: pact/policy-manager/policy-manager.repl
+
+      - name: Test concrete collection-policy
+        uses: ./.github/actions/repl
+        with:
+          target: pact/concrete-policies/collection-policy/collection-policy-v1.repl
+
+      - name: Test concrete non-fungible-policy
+        uses: ./.github/actions/repl
+        with:
+          target: pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.repl
+
+      - name: Test concrete royalty-policy
+        uses: ./.github/actions/repl
+        with:
+          target: pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
+
+      - name: Test concrete guard-policy
+        uses: ./.github/actions/repl
+        with:
+          target: pact/concrete-policies/guard-policy/guard-policy-v1.repl
+
+      - name: Test conventional auction sale contract
+        uses: ./.github/actions/repl
+        with:
+          target: pact/sale-contracts/conventional-auction/conventional-auction.repl
+
+      - name: Test dutch auction sale contract
+        uses: ./.github/actions/repl
+        with:
+          target: pact/sale-contracts/dutch-auction/dutch-auction.repl

--- a/pact-tests/pact-tests/marmalade/.gitignore
+++ b/pact-tests/pact-tests/marmalade/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+src/scratch-pad.js
+.vscode/
+.DS_Store
+*.code-workspace
+yarn-error.log
+.pact-history

--- a/pact-tests/pact-tests/marmalade/README.md
+++ b/pact-tests/pact-tests/marmalade/README.md
@@ -1,0 +1,7 @@
+# Kadena Marmalade V2: Mint a Marketplace
+
+## Decentralized Infrastructure for Poly-Fungibles and NFTs
+
+This repo houses smart contracts and frontend code for Marmalade, Kadena's platform for poly-fungibles and NFTs.
+
+[[MARMALADE DOCS]](https://docs.kadena.io/marmalade)

--- a/pact-tests/pact-tests/marmalade/examples/policies/fixed-issuance-policy/fixed-issuance-policy-v1.pact
+++ b/pact-tests/pact-tests/marmalade/examples/policies/fixed-issuance-policy/fixed-issuance-policy-v1.pact
@@ -1,0 +1,127 @@
+(namespace (read-msg 'ns))
+
+(module fixed-issuance-policy-v1 GOVERNANCE
+
+  @doc "Policy for minting with a fixed issuance"
+
+  (defconst ADMIN-KS:string "marmalade-examples.fixed-issuance-policy")
+
+  (defcap GOVERNANCE ()
+    (enforce-guard ADMIN-KS))
+
+  (defconst POLICY:string (format "{}" [fixed-issuance-policy-v1]))
+
+  (implements kip.token-policy-v2)
+  (use kip.token-policy-v2 [token-info])
+  (use marmalade-v2.policy-manager)
+
+  (defconst FIXED-ISSUANCE-SPEC:string "fixed_issuance_spec")
+
+  (defschema supply-schema
+    max-supply:decimal
+    min-amount:decimal
+    precision:integer
+  )
+
+  (deftable supplies:{supply-schema})
+
+  (defun get-supply:object{supply-schema} (token:object{token-info})
+    (read supplies (at 'id token))
+  )
+
+  (defun enforce-init:bool
+    ( token:object{token-info}
+    )
+    @doc "The function is run at `create-token` step of marmalade-v2.ledger.      \
+    \ Required msg-data keys:                                                  \
+    \ * fixed_issuance_spec:object{supply-schema} - registers minimum mint     \
+    \ amount, max-supply, and precision information of the created token"
+    (require-capability (INIT-CALL (at "id" token) (at "precision" token) (at "uri" token) POLICY))
+    (let* (
+            (fixed-issuance-spec:object{supply-schema} (read-msg FIXED-ISSUANCE-SPEC))
+            (min-amount:decimal (at 'min-amount fixed-issuance-spec))
+            (max-supply:decimal (at 'max-supply fixed-issuance-spec))
+            (precision:integer (at 'precision fixed-issuance-spec))
+            )
+      (enforce (= (at 'precision token) precision) "Invalid Precision")
+      (enforce (and (= (floor min-amount precision) min-amount) (> min-amount 0.0)) "Invalid min-amount")
+      (enforce (and (= (floor max-supply precision) max-supply) (>= max-supply 0.0)) "Invalid max-supply")
+      (insert supplies (at 'id token) {
+        "min-amount": min-amount
+       ,"max-supply": max-supply
+       ,"precision": precision
+        }))
+    true
+  )
+
+  (defun enforce-mint:bool
+    ( token:object{token-info}
+      account:string
+      guard:guard
+      amount:decimal
+    )
+    (require-capability (MINT-CALL (at "id" token) account amount POLICY))
+    (bind (get-supply token)
+      { 'min-amount:=min-amount:decimal
+      , 'max-supply:=max-supply:decimal
+      }
+      (enforce (>= amount min-amount) "mint amount < min-amount")
+      (if (> max-supply 0.0)
+        (enforce (<= (+ amount (at 'supply token)) max-supply) "Exceeds max supply")
+        true
+      )
+  ))
+
+  (defun enforce-burn:bool
+    ( token:object{token-info}
+      account:string
+      amount:decimal
+    )
+    true
+  )
+
+  (defun enforce-offer:bool
+    ( token:object{token-info}
+      seller:string
+      amount:decimal
+      timeout:integer
+      sale-id:string
+    )
+    true
+  )
+
+  (defun enforce-buy:bool
+    ( token:object{token-info}
+      seller:string
+      buyer:string
+      buyer-guard:guard
+      amount:decimal
+      sale-id:string )
+    true
+  )
+
+  (defun enforce-withdraw:bool
+    ( token:object{token-info}
+      seller:string
+      amount:decimal
+      timeout:integer
+      sale-id:string )
+    true
+  )
+
+  (defun enforce-transfer:bool
+    ( token:object{token-info}
+      sender:string
+      guard:guard
+      receiver:string
+      amount:decimal )
+    true
+  )
+)
+
+
+(if (read-msg 'upgrade)
+  ["upgrade complete"]
+  [(create-table supplies) ])
+
+(enforce-guard ADMIN-KS)

--- a/pact-tests/pact-tests/marmalade/examples/policies/fixed-issuance-policy/fixed-issuance-policy-v1.repl
+++ b/pact-tests/pact-tests/marmalade/examples/policies/fixed-issuance-policy/fixed-issuance-policy-v1.repl
@@ -1,0 +1,158 @@
+
+;;load policy manager, ledger
+(load "../../../pact/marmalade.repl")
+
+
+(begin-tx "load fixed issuance policy")
+  (env-data {
+    "ns": "marmalade-examples"
+  , "fixed-issuance-policy": ["fixed-issuance-policy"]
+  , "upgrade": false}
+  )
+  (env-sigs [
+    { 'key: 'fixed-issuance-policy
+     ,'caps: []
+  }])
+
+  (ns.write-registry (read-msg 'ns) (read-keyset 'fixed-issuance-policy) true)
+  (define-namespace
+    (read-msg 'ns)
+    (read-keyset 'fixed-issuance-policy) (read-keyset 'fixed-issuance-policy)
+  )
+
+  (namespace (read-msg 'ns))
+
+  (define-keyset (+ (read-msg 'ns) ".fixed-issuance-policy") (read-keyset 'fixed-issuance-policy))
+  
+  (load "fixed-issuance-policy-v1.pact")
+  (typecheck "marmalade-examples.fixed-issuance-policy-v1")
+
+(commit-tx)
+
+(begin-tx "Create token with fixed issuance policy")
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-examples.fixed-issuance-policy-v1)
+  (use mini-guard-utils)
+  (env-data {
+          "token-id": (create-token-id { 'uri: "test-fixed-issuance-policy-v1-0", 'precision: 0, 'policies: [marmalade-examples.fixed-issuance-policy-v1] } ALWAYS-TRUE),
+          "token-id-wrong-precision": (create-token-id { 'uri: "test-fixed-issuance-policy-v1-0", 'precision: 1, 'policies: [marmalade-examples.fixed-issuance-policy-v1] } ALWAYS-TRUE ),
+          "fixed_issuance_spec": {
+              'max-supply:2.0,
+              'min-amount:1.0,
+              'precision:0}
+      }
+  )
+
+  (env-sigs [])
+
+  (expect "create a token with fixed-issuance-policy"
+      true
+      (create-token (read-msg 'token-id) 0 "test-fixed-issuance-policy-v1-0" [marmalade-examples.fixed-issuance-policy-v1] ALWAYS-TRUE))
+
+  (expect "create-token events"
+      [ {"name": "marmalade-v2.ledger.TOKEN","params": [(read-msg 'token-id) 0 [marmalade-examples.fixed-issuance-policy-v1] "test-fixed-issuance-policy-v1-0" ALWAYS-TRUE]} ]
+      (map (remove "module-hash")  (env-events true)))
+
+  (expect-failure "Precision is incorrect"
+      "Invalid Precision"
+      (create-token (read-msg 'token-id-wrong-precision) 1 "test-fixed-issuance-policy-v1-0" [marmalade-examples.fixed-issuance-policy-v1] ALWAYS-TRUE))
+
+  (env-data {
+          "token-id": (create-token-id { 'uri: "test-fixed-issuance-policy-v1-1", 'precision: 0, 'policies: [marmalade-examples.fixed-issuance-policy-v1] } ALWAYS-TRUE),
+          "fixed_issuance_spec": {
+              'max-supply:2.0,
+              'min-amount:0.0,
+              'precision:0
+          }
+      }
+  )
+
+  (expect-failure "min amount is not valid"
+      "Invalid min-amount"
+      (create-token (read-msg 'token-id) 0 "test-fixed-issuance-policy-v1-1" [marmalade-examples.fixed-issuance-policy-v1] ALWAYS-TRUE))
+
+  (env-data {
+          "token-id": (create-token-id { 'uri: "test-fixed-issuance-policy-v1-1", 'precision: 1, 'policies: [marmalade-examples.fixed-issuance-policy-v1] } ALWAYS-TRUE),
+          "fixed_issuance_spec": {
+              'max-supply:0.0,
+              'min-amount:1.0,
+              'precision:1
+          }
+      }
+  )
+
+  (expect "Create token succeeds with max-supply 0"
+      true
+      (create-token (read-msg 'token-id) 1 "test-fixed-issuance-policy-v1-1" [marmalade-examples.fixed-issuance-policy-v1] ALWAYS-TRUE))
+
+  (expect "create-token events"
+    [ {"name": "marmalade-v2.ledger.TOKEN","params": [(read-msg 'token-id) 1 [marmalade-examples.fixed-issuance-policy-v1] "test-fixed-issuance-policy-v1-1" ALWAYS-TRUE]} ]
+    (map (remove "module-hash")  (env-events true)))
+
+(commit-tx)
+
+(begin-tx "Mint token")
+
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-examples.fixed-issuance-policy-v1)
+  (use mini-guard-utils)
+
+  (env-data {
+    "token-id": (create-token-id { 'uri: "test-fixed-issuance-policy-v1-2", 'precision: 1, 'policies: [marmalade-examples.fixed-issuance-policy-v1] } ALWAYS-TRUE),
+    "token-id-wrong-precision": (create-token-id { 'uri: "test-fixed-issuance-policy-v1-2", 'precision: 1, 'policies: [marmalade-examples.fixed-issuance-policy-v1] } ALWAYS-TRUE ),
+    "fixed_issuance_spec": {
+        'max-supply:1.0,
+        'min-amount:0.5,
+        'precision:1}
+    }
+  )
+
+  (env-sigs [])
+
+  (expect "create a token with fixed-issuance-policy"
+    true
+    (create-token (read-msg 'token-id) 1 "test-fixed-issuance-policy-v1-2" [marmalade-examples.fixed-issuance-policy-v1] ALWAYS-TRUE))
+
+  (expect "create-token events"
+    [ {"name": "marmalade-v2.ledger.TOKEN","params": [(read-msg 'token-id) 1 [marmalade-examples.fixed-issuance-policy-v1] "test-fixed-issuance-policy-v1-2" ALWAYS-TRUE]} ]
+    (map (remove "module-hash")  (env-events true)))
+
+  (env-data {
+          "token-id": (create-token-id { 'uri: "test-fixed-issuance-policy-v1-2", 'precision: 1, 'policies: [marmalade-examples.fixed-issuance-policy-v1] } ALWAYS-TRUE)
+          ,"account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+          ,"account-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+      }
+  )
+
+  (env-sigs [
+    { 'key: 'account
+     ,'caps: [(marmalade-v2.ledger.MINT (read-msg 'token-id) (read-msg 'account) 2.0)]
+    }])
+  
+  (expect-failure "Fail if minting more than max-supply"
+    "Exceeds max supply"
+    (mint (read-msg 'token-id) (read-msg 'account) (read-keyset 'account-guard ) 2.0))
+
+  (env-sigs [
+    { 'key: 'account
+      ,'caps: [(marmalade-v2.ledger.MINT (read-msg 'token-id) (read-msg 'account) 1.0)]
+    }])
+
+  (expect-failure "Fail if minting less than min-amount"
+    "mint amount < min-amount"
+    (mint (read-msg 'token-id) (read-msg 'account) (read-keyset 'account-guard ) 0.2))
+
+
+  (expect "Minted successfully"
+    true
+    (mint (read-msg 'token-id) (read-msg 'account) (read-keyset 'account-guard ) 1.0))
+
+  (expect "mint events"
+    [ {"name": "marmalade-v2.ledger.MINT","params": [(read-msg 'token-id) (read-msg 'account) 1.0]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-msg 'token-id) (read-msg 'account) (read-keyset 'account-guard)]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-msg 'token-id) 1.0 {"account": "","current": 0.0,"previous": 0.0} {"account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3","current": 1.0,"previous": 0.0}]} {"name": "marmalade-v2.ledger.SUPPLY","params": [(read-msg 'token-id) 1.0]}]
+    (map (remove "module-hash")  (env-events true)))
+
+(rollback-tx)

--- a/pact-tests/pact-tests/marmalade/examples/policies/fixed-issuance-policy/fixed-issuance-policy.md
+++ b/pact-tests/pact-tests/marmalade/examples/policies/fixed-issuance-policy/fixed-issuance-policy.md
@@ -1,0 +1,37 @@
+
+# Fixed Issuance Policy
+
+Fixed Issuance Policy is an example module of Marmalade which provides a simple method to program a fractional token. Because there are various ways to program fractional tokens, the contract only provides the simplest feature that is required for fractional tokens, and encourages users to extend upon the
+contract. 
+
+## Specification, tables, capabilities:
+
+**Schemas**: `supply-schema` is a schema that store information related to the issuance of the token.
+   - `max-supply`: refers to the maximum number of supply that tokens can be minted to. If max-supply equals `0.0`, then the token is considered to have unlimited supply .
+   - `min-amount`: min-amount is the minimum amount that the token can be minted with.
+   - `precision`: precision is the same precision used in `marmalade-v2.ledger`. It is enforced that the two precisions equal each other.
+
+**Tables**: `supplies` table stores token supply information.
+
+**Capabilities**:
+ - `GOVERNANCE`: enforces access control of contract upgrade.
+
+## Policy Functions
+
+**`enforce-init`:** Run during `marmalade-v2.ledger.create-token`, and registers the token's supply information.
+
+**`enforce-mint`:** Enforced during `marmalade-v2.ledger.mint`, and enforces the mint logic following the provided supply information
+
+**`enforce-burn`:** Enabled without limitation. In order to program burn, the token must incorporate a different policy that programs burn.
+
+**`enforce-offer`:** Enabled without limitation. In order to program offer, the token must incorporate a different policy that programs offer.
+
+**`enforce-buy`:** Enabled without limitation. In order to program buy, the token must incorporate a different policy that programs buy.
+
+**`enforce-withdraw`:** Enabled without limitation. In order to program withdraw, the token must incorporate a different policy that programs withdraw.
+
+**`enforce-transfer`:** Enabled without limitation. In order to program transfer, the token must incorporate a different policy that programs transfer.
+
+## Custom functions
+
+**`get-supply:`** This function is used to retrieve supply information from the `token_spec`

--- a/pact-tests/pact-tests/marmalade/examples/policies/multi-asset-policy/multi-asset-policy.md
+++ b/pact-tests/pact-tests/marmalade/examples/policies/multi-asset-policy/multi-asset-policy.md
@@ -1,0 +1,93 @@
+# Multi-asset Policy
+
+The `multi-asset-policy` module is a part of the Marmalade example policies designed to manage multi-asset tokens in a context-dependent manner. It adheres to the `kip.token-policy-v2` standard and provides functionality for asset management, including proposing, accepting, and rejecting assets related to a token.
+
+There are two possible implementations, for fungible and non-fungible tokens.
+
+- Fungible: Asset URIs need to be provided at the token creation
+- Non-fungible: Asset URIs can be proposed by the token operator and accepted/rejected by the token owner
+
+## Specification, tables, capabilities:
+
+**Schemas**:
+- `token-asset-schema`
+  - `uri:string`: Represents the asset URI.
+
+- `token-proposed-asset-schema`
+  - `assets:[string]`: Represents the list of proposed asset URIs.
+
+- `token-operators-schema`
+  - `guard:guard`: Represents the guard of the token creator/operator.
+
+**Tables**:
+- `token-assets:{token-asset-schema}`: Stores the token asset URIs.
+- `proposed-assets:{token-proposed-asset-schema}`: Stores the list of proposed asset URIs.
+- `token-operators:{token-operators-schema}`: Stores the token operator guard for proposing new assets.
+
+**Capabilities**:
+ - `GOVERNANCE`: enforces access control of contract upgrade.
+ - `PROPOSE_ASSET (token-id:string uri:string)`: enforces access control of token operator.
+ - `ACCEPT_ASSET (token-id:string asset-id:integer owner:string)`: enforces access control of token owner.
+ - `REJECT_ASSET (token-id:string asset-id:integer owner:string)`: enforces access control of token owner.
+ - `REJECT_ALL_ASSETS (token-id:string owner:string)`: enforces access control of token owner.
+ - `SET_ASSET_PRIORITY (token-id:string asset-id:integer priority:integer owner:string)`: enforces access control of token owner.
+
+
+**Events**:
+ - `ASSET_PROPOSED (token-id:string asset-id:integer uri:string)`: emitted when new asset is proposed.
+ - `ASSET_ACCEPTED (token-id:string asset-id:integer uri:string owner:string)`: emitted when the asset has been accepted.
+ - `ASSET_REJECTED (token-id:string asset-id:integer uri:string owner:string)`: emitted when the asset has been rejected.
+ - `ASSET_SET (token-id:string asset-id:integer uri:string)`: emitted at init for fungible tokens.
+ - `ASSET_PRIORITY_SET (token-id:string asset-id:integer priority:integer owner:string)`: emitted when new asset priority is set.
+
+## Policy Functions
+
+**`enforce-init`:** Enforced during `marmalade-v2.ledger.create-token`, and requires `assets` data message for fungible and `operator_guard` for non-fungible tokens.
+
+**`enforce-mint`:** Enabled without limitation.
+
+**`enforce-burn`:** Enabled without limitation.
+
+**`enforce-offer`:** Enabled without limitation.
+
+**`enforce-buy`:** Enabled without limitation.
+
+**`enforce-withdraw`:** Enabled without limitation.
+
+**`enforce-transfer`:** Enabled without limitation.
+
+## Custom functions
+
+**`get-asset:`** Retrieves an asset URI for the given token by index.
+
+**`get-assets:`** Retrieves all asset URIs for the given token.
+
+**`propose-asset:`** Used by token operator to propose new asset URI.
+
+**`replace-proposed-asset:`** Used by token operator to replace existing proposed asset URI.
+
+**`get-proposed-assets:`** Get a list of proposed asset URIs.
+
+**`get-proposed-asset:`** Get proposed asset URI by index.
+
+**`reject-proposed-asset:`** Reject proposed asset URI for token by index.
+
+**`reject-all-proposed-assets:`** Reject all proposed assets for token.
+
+**`accept-asset:`** Used by token owner to accept proposed asset by index.
+
+**`set-asset-priority:`** Used by token owner to set asset priority.
+
+## Utility functions
+
+**`has-non-fungible-policy:`** Returns `true` if `marmalade-v2.non-fungible-policy-v1` is present in the `policies` array.
+
+**`enforce-non-fungible-policy:`** Enforces that `marmalade-v2.non-fungible-policy-v1` is present in token details.
+
+**`enforce-assets-at-init:`** Enforces that `assets` data message is present at `enforce-init` for fungible tokens.
+
+**`enforce-operator-at-init:`** Enforces that `operator_guard` data message is present at `enforce-init` for non-fungible tokens.
+
+**`update-array:`** Updates string array item by index.
+
+**`remove-item:`** Remove item from array by index.

--- a/pact-tests/pact-tests/marmalade/examples/policies/multi-asset-policy/multi-asset-policy.pact
+++ b/pact-tests/pact-tests/marmalade/examples/policies/multi-asset-policy/multi-asset-policy.pact
@@ -1,0 +1,350 @@
+(namespace (read-msg 'ns))
+
+(module multi-asset-policy GOVERNANCE
+
+  @doc "Policy for context-dependant multi-asset tokens."
+
+  (implements kip.token-policy-v2)
+
+  (use kip.token-manifest)
+  (use kip.token-policy-v2 [token-info])
+  (use marmalade-v2.policy-manager)
+  (use marmalade-v2.non-fungible-policy-v1)
+
+  (defconst ADMIN-KS:string "marmalade-examples.multi-asset-policy")
+
+  (defcap GOVERNANCE ()
+    (enforce-guard ADMIN-KS))
+
+  (defconst OPERATOR-GUARD-MSG-KEY:string "operator_guard")
+  (defconst ASSETS-MSG-KEY:string "assets")
+
+  ; PROTOCOL CAPABILITIES
+
+  (defcap PROPOSE_ASSET (token-id:string uri:string)
+    (enforce-guard (at 'guard (read token-operators token-id)))
+  )
+  
+  (defcap REJECT_ASSET (token-id:string asset-id:integer owner:string)
+    (enforce-guard (marmalade-v2.ledger.account-guard token-id owner))
+  )  
+
+  (defcap REJECT_ALL_ASSETS (token-id:string owner:string)
+    (enforce-guard (marmalade-v2.ledger.account-guard token-id owner))
+  )
+  
+  (defcap ACCEPT_ASSET (token-id:string asset-id:integer owner:string)
+    (enforce-guard (marmalade-v2.ledger.account-guard token-id owner))
+  )
+
+  (defcap SET_ASSET_PRIORITY (token-id:string asset-id:integer priority:integer owner:string)
+    (enforce-guard (marmalade-v2.ledger.account-guard token-id owner))
+  )
+
+  ; PROTOCOL EVENTS
+
+  (defcap ASSET_PROPOSED (token-id:string asset-id:integer uri:string)
+    @doc "Emitted when new asset is proposed"
+    @event
+    true
+  )
+
+  (defcap ASSET_REJECTED (token-id:string asset-id:integer uri:string owner:string)
+    @doc "Emitted when the asset has been rejected"
+    @event
+    true
+  )
+    
+  (defcap ASSET_ACCEPTED (token-id:string asset-id:integer uri:string owner:string)
+    @doc "Emitted when the asset has been accepted"
+    @event
+    true
+  )
+
+  (defcap ASSET_SET (token-id:string asset-id:integer uri:string)
+    @doc "Emitted at init for fungible tokens"
+    @event
+
+    true
+  )
+
+  (defcap ASSET_PRIORITY_SET (token-id:string asset-id:integer priority:integer owner:string)
+    @doc "Emitted when new asset priority is set"
+    @event
+    true
+  )
+
+  (defschema token-asset-schema 
+    assets:[string]
+  )
+
+  (defschema token-operators-schema
+    guard:guard
+  )
+
+  (deftable token-assets:{token-asset-schema})
+  (deftable proposed-assets:{token-asset-schema})
+  (deftable token-operators:{token-operators-schema})
+
+  ; PROTOCOL FUNCTIONS
+
+  (defun get-asset:string (token-id:string asset-id:integer)
+    (at asset-id (at 'assets (read token-assets token-id)))
+  )  
+  
+  (defun get-assets:[string] (token-id:string)
+    (with-default-read token-assets token-id 
+      { 'assets: [] } 
+      { 'assets := assets } 
+      assets
+    )
+  )
+
+  (defun propose-asset:bool (token-id:string uri:string)
+    (enforce-non-fungible-policy token-id)
+    (enforce (not (= uri "")) "URI cannot be empty")
+    (let* (
+      (assets:[string] (+ (get-proposed-assets token-id) [uri]))
+      (asset-id:integer (- (length assets) 1))
+    )
+      (with-capability (PROPOSE_ASSET token-id uri)
+        (write proposed-assets token-id { 'assets: assets })
+        (emit-event (ASSET_PROPOSED token-id asset-id uri))
+        true
+      )
+    )
+  )
+
+  (defun replace-proposed-asset:bool (token-id:string asset-id:integer uri:string)
+    (enforce (not (= uri "")) "URI cannot be empty")
+
+    (let (
+      (assets:[string] (get-proposed-assets token-id))
+      (operator-guard:guard (at 'guard (read token-operators token-id)))
+    )
+      (enforce (> (length assets) asset-id) "Invalid asset ID")
+      (enforce (not (= uri (at asset-id assets))) "Must be different URI")
+
+      (with-capability (ASSET_PROPOSED token-id asset-id uri)
+        (write proposed-assets token-id { 'assets: (update-array assets asset-id uri) })
+        true
+      )
+    )
+  )
+
+  (defun get-proposed-assets:[string] (token-id:string)
+    (with-default-read proposed-assets token-id 
+      { 'assets: [] } 
+      { 'assets := assets } 
+      assets
+    )
+  )
+
+  (defun get-proposed-asset:string (token-id:string asset-id:integer)
+    (at asset-id (get-proposed-assets token-id))
+  )
+
+  (defun reject-proposed-asset:bool (token-id:string asset-id:integer owner:string)
+    (let ((balance:decimal (marmalade-v2.ledger.get-balance token-id owner)))
+      (enforce (= balance 1.0) "Token not owned")
+    )
+
+    (let ((assets:[string] (get-proposed-assets token-id)))
+      (enforce (>= (- (length assets) 1) asset-id) "Invalid asset ID")
+      (with-capability (REJECT_ASSET token-id asset-id owner)
+        (let ((updated-assets:[string] (filter (lambda (index:integer) (not (= index asset-id))) (enumerate 0 (- (length assets) 1)))))
+          (write proposed-assets token-id { 'assets: updated-assets })
+          true
+        )
+      )
+      (emit-event (ASSET_REJECTED token-id asset-id (at asset-id assets) owner))
+    )
+  )
+
+  (defun reject-all-proposed-assets:bool (token-id:string owner:string)
+    (let (
+      (balance:decimal (marmalade-v2.ledger.get-balance token-id owner))
+      (assets:[string] (get-proposed-assets token-id))
+    )
+      (enforce (= balance 1.0) "Token not owned")
+
+      (with-capability (REJECT_ALL_ASSETS token-id owner)
+        (write proposed-assets token-id { 'assets: [] })
+      )
+
+      (map 
+        (lambda (asset-id:integer)
+          (emit-event (ASSET_REJECTED token-id asset-id (at asset-id assets) owner))
+        ) 
+      (enumerate 0 (- (length assets) 1)))
+
+      true
+    )
+  )
+
+  (defun accept-asset:bool (token-id:string asset-id:integer owner:string)
+    (let (
+      (balance:decimal (marmalade-v2.ledger.get-balance token-id owner))
+      (uri:string (get-proposed-asset token-id asset-id))
+      (assets:[string] (get-assets token-id))
+    )
+      (enforce (= balance 1.0) "Token not owned")
+
+      (with-capability (ACCEPT_ASSET token-id asset-id owner)
+        (write token-assets token-id { 'assets: (+ assets [uri]) })
+        (emit-event (ASSET_ACCEPTED token-id asset-id uri owner))
+        true  
+      )
+    )
+  )
+
+  (defun set-asset-priority (token-id:string asset-id:integer priority:integer owner:string)
+    (let* (
+      (balance:decimal (marmalade-v2.ledger.get-balance token-id owner))
+      (assets:[string] (get-assets token-id))
+      (target-asset:string (at asset-id assets))
+      (asset-to-be-replaced:string (at priority assets))
+      (updated-assets:[string] (update-array assets priority target-asset))
+      (truncated-assets:[string] (remove-item updated-assets asset-id))
+    )
+      (enforce (= balance 1.0) "Token not owned")
+
+      (with-capability (SET_ASSET_PRIORITY token-id asset-id priority owner)
+        (write token-assets token-id { 'assets: (+ truncated-assets [asset-to-be-replaced]) })
+        (emit-event (ASSET_PRIORITY_SET token-id asset-id priority owner))
+        true
+      )
+    )
+  
+  )
+
+  ; POLICY FUNCTIONS
+
+  (defun enforce-init:bool
+    ( token:object{token-info}
+    )
+    (if (has-non-fungible-policy (at 'policies token))
+      (enforce-operator-at-init token)
+      (enforce-assets-at-init token)
+    )
+  )
+
+  (defun enforce-mint:bool
+    ( token:object{token-info}
+      account:string
+      guard:guard
+      amount:decimal
+    )
+    true
+  )
+
+  (defun enforce-burn:bool
+    ( token:object{token-info}
+      account:string
+      amount:decimal
+    )
+    true
+  )
+
+  (defun enforce-offer:bool
+    ( token:object{token-info}
+      seller:string
+      amount:decimal
+      timeout:integer
+      sale-id:string )
+    true
+  )
+
+  (defun enforce-buy:bool
+    ( token:object{token-info}
+      seller:string
+      buyer:string
+      buyer-guard:guard
+      amount:decimal
+      sale-id:string )
+    true
+  )
+
+  (defun enforce-withdraw:bool
+    ( token:object{token-info}
+      seller:string
+      amount:decimal
+      timeout:integer
+      sale-id:string )
+    true
+  )
+
+  (defun enforce-transfer:bool
+    ( token:object{token-info}
+      sender:string
+      guard:guard
+      receiver:string
+      amount:decimal )
+    true
+  )
+
+  ; UTILITY FUNCTIONS
+
+  (defun has-non-fungible-policy:bool (policies)
+    (> (length (filter (lambda (policy) (= policy marmalade-v2.non-fungible-policy-v1)) policies)) 0))
+
+  (defun enforce-non-fungible-policy (token-id:string)
+    (let ((policies (at 'policies (marmalade-v2.ledger.get-token-info token-id))))
+      (enforce (has-non-fungible-policy policies) "Token does not have non-fungible policy")
+    )
+  )
+  
+  (defun enforce-assets-at-init:bool
+    ( token:object{token-info}
+    )
+    (let ((assets:[string] (read-msg ASSETS-MSG-KEY)))
+
+      (enforce (> (length assets) 0) "At least one asset must be provided")
+
+      (insert token-assets (at 'id token) { 'assets: assets } )
+
+      (map
+        (lambda (asset-id:integer)
+          (emit-event (ASSET_SET (at 'id token) asset-id (at asset-id assets)))
+        ) 
+      (enumerate 0 (- (length assets) 1)))
+      true
+    )
+  )
+
+  (defun enforce-operator-at-init:bool
+    ( token:object{token-info}
+    )
+    (let ((operator-guard:guard (read-msg OPERATOR-GUARD-MSG-KEY)))
+      (enforce-guard operator-guard)
+      (insert token-operators (at 'id token) { 'guard: operator-guard })
+      true
+    )
+  )
+
+  (defun update-array:[string] (array:[string] index:integer value:string)
+    (map (lambda (i) 
+      (if (= i index)
+        value
+        (at i array)))
+    (enumerate 0 (- (length array) 1)))
+  )
+
+  (defun remove-item:[string] (array:[string] index:integer)
+    (+ 
+      (take index array)
+      (take (- 1 (- (length array) index)) array)
+    )
+  )
+)
+
+(if (read-msg 'upgrade)
+  true
+  [
+    (create-table token-assets)
+    (create-table proposed-assets)
+    (create-table token-operators)
+  ]
+)
+
+(enforce-guard ADMIN-KS)

--- a/pact-tests/pact-tests/marmalade/examples/policies/multi-asset-policy/multi-asset-policy.repl
+++ b/pact-tests/pact-tests/marmalade/examples/policies/multi-asset-policy/multi-asset-policy.repl
@@ -1,0 +1,441 @@
+
+;;load policy manager, ledger
+(load "../../../pact/marmalade.repl")
+
+(begin-tx "load multi asset policy")
+  (env-data {
+    "ns": "marmalade-examples"
+  , "multi-asset-policy": ["multi-asset-policy"]
+  , "upgrade": false}
+  )
+  (env-sigs [
+    { 'key: 'multi-asset-policy
+     ,'caps: []
+  }])
+
+  (ns.write-registry (read-msg 'ns) (read-keyset 'multi-asset-policy) true)
+  (define-namespace
+    (read-msg 'ns)
+    (read-keyset 'multi-asset-policy) (read-keyset 'multi-asset-policy)
+  )
+
+  (namespace (read-msg 'ns))
+
+  (define-keyset (+ (read-msg 'ns) ".multi-asset-policy") (read-keyset 'multi-asset-policy))
+  
+  (load "multi-asset-policy.pact")
+  (typecheck "marmalade-examples.multi-asset-policy")
+(commit-tx)
+
+(begin-tx "create multi-asset token without non-fungible policy")
+
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-examples.multi-asset-policy)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+
+  (env-data {
+    "token-id": (create-token-id { 'uri: "multi-asset-policy-fungible", 'precision: 0, 'policies: [marmalade-examples.multi-asset-policy] } ALWAYS-TRUE)
+  } )
+
+  (expect-failure "fail to create the token without assets"
+    "No such key in message: assets"
+    (create-token (read-msg 'token-id) 0 "multi-asset-policy-fungible" [marmalade-examples.multi-asset-policy] ALWAYS-TRUE))
+
+  (env-data {
+    "token-id": (create-token-id { 'uri: "multi-asset-policy-fungible", 'precision: 0, 'policies: [marmalade-examples.multi-asset-policy] } ALWAYS-TRUE)
+    ,"assets": []
+  } )
+
+  (expect-failure "fail to create the token with asset length of zero"
+    "At least one asset must be provided"
+    (create-token (read-msg 'token-id) 0 "multi-asset-policy-fungible" [marmalade-examples.multi-asset-policy] ALWAYS-TRUE))
+
+
+  (env-data {
+    "token-id": (create-token-id { 'uri: "multi-asset-policy-fungible", 'precision: 0, 'policies: [marmalade-examples.multi-asset-policy] } ALWAYS-TRUE)
+    ,"assets": ["ipfs://1" "ipfs://2"]
+  } )
+
+  (expect "create the token without non-fungible policy"
+    true
+    (create-token (read-msg 'token-id) 0 "multi-asset-policy-fungible" [marmalade-examples.multi-asset-policy] ALWAYS-TRUE))
+
+  (expect "events"
+    [ 
+      {"name": "marmalade-examples.multi-asset-policy.ASSET_SET","params": [(read-msg 'token-id) 0 "ipfs://1"]} 
+      ,{"name": "marmalade-examples.multi-asset-policy.ASSET_SET","params": [(read-msg 'token-id) 1 "ipfs://2"]} 
+      ,{"name": "marmalade-v2.ledger.TOKEN","params": [(read-msg 'token-id) 0 [marmalade-examples.multi-asset-policy] "multi-asset-policy-fungible" ALWAYS-TRUE]} 
+    ]
+    (map (remove "module-hash")  (env-events true)))
+
+  (expect "get token assets URI"
+    "ipfs://1"
+    (get-asset (read-msg 'token-id) 0)
+  )
+
+  (expect "get token assets URI"
+    "ipfs://2"
+    (get-asset (read-msg 'token-id) 1)
+  )
+
+  (expect "get all token asset URIs"
+    ["ipfs://1" "ipfs://2"]
+    (get-assets (read-msg 'token-id))
+  )
+
+  (expect-failure "should not allow proposing new assets"
+    "Token does not have non-fungible policy"
+    (propose-asset (read-msg 'token-id) "ipfs://1"))
+
+(commit-tx)
+
+(begin-tx "create multi-asset token with non-fungible policy")
+
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-examples.multi-asset-policy)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+
+  (env-data {
+    "token-id": (create-token-id { 'uri: "multi-asset-policy-non-fungible", 'precision: 0, 'policies: [marmalade-examples.multi-asset-policy marmalade-v2.non-fungible-policy-v1] } ALWAYS-TRUE)
+  } )
+
+  (expect-failure "fail to create the token without operator_guard"
+    "No such key in message: operator_guard"
+    (create-token (read-msg 'token-id) 0 "multi-asset-policy-non-fungible" [marmalade-examples.multi-asset-policy marmalade-v2.non-fungible-policy-v1] ALWAYS-TRUE))
+
+  (env-data {
+    "token-id": (create-token-id { 'uri: "multi-asset-policy-non-fungible", 'precision: 0, 'policies: [marmalade-examples.multi-asset-policy marmalade-v2.non-fungible-policy-v1] } ALWAYS-TRUE)
+    ,"operator_guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+  } )
+
+  (env-sigs [
+    { 'key: "e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+     ,'caps: []}
+  ])
+
+  (expect "create the token with non-fungible policy"
+    true
+    (create-token (read-msg 'token-id) 0 "multi-asset-policy-non-fungible" [marmalade-examples.multi-asset-policy marmalade-v2.non-fungible-policy-v1] ALWAYS-TRUE))
+
+  (expect "events"
+    [ {"name": "marmalade-v2.ledger.TOKEN","params": [(read-msg 'token-id) 0 [marmalade-examples.multi-asset-policy marmalade-v2.non-fungible-policy-v1] "multi-asset-policy-non-fungible" ALWAYS-TRUE]} ]
+    (map (remove "module-hash")  (env-events true)))
+
+(commit-tx)
+
+(begin-tx "propose new assets")
+
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-examples.multi-asset-policy)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+
+  (env-data {
+    "token-id": (create-token-id { 'uri: "multi-asset-policy-non-fungible", 'precision: 0, 'policies: [marmalade-examples.multi-asset-policy marmalade-v2.non-fungible-policy-v1] } ALWAYS-TRUE)
+    ,"new-asset": "ipfs://1"
+    ,"replaced-asset": "ipfs://1-replaced"
+    ,"owner": "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+    ,"owner-guard": {"keys": ["6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"], "pred": "keys-all"}
+    ,"operator_guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+  } )
+
+  (env-sigs [
+    { 'key: "6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+     ,'caps: [(marmalade-v2.ledger.MINT (read-msg 'token-id) (read-msg 'owner) 1.0)]}
+  ])
+
+  (expect "mint token sucessfully"
+    true
+    (mint (read-msg 'token-id) (read-msg 'owner) (read-keyset 'owner-guard) 1.0)
+  )
+
+  (expect "mint events"
+  [ {"name": "marmalade-v2.ledger.MINT","params": [(read-msg 'token-id) (read-msg 'owner) 1.0]}
+    {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-msg 'token-id) (read-msg 'owner) (read-keyset 'owner-guard)]}
+    {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-msg 'token-id) 1.0 {"account": "","current": 0.0,"previous": 0.0} {"account": "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3","current": 1.0,"previous": 0.0}]} {"name": "marmalade-v2.ledger.SUPPLY","params": [(read-msg 'token-id) 1.0]}]
+  (map (remove "module-hash")  (env-events true)))
+
+  (env-sigs [
+    { 'key: "e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+     ,'caps: [(marmalade-examples.multi-asset-policy.PROPOSE_ASSET (read-msg 'token-id) (read-msg 'new-asset))]}
+  ])
+
+  (expect "no proposed assets at the begining"
+    []
+    (get-proposed-assets (read-msg 'token-id))
+  )
+
+  (expect "new asset successfully proposed"
+    true
+    (propose-asset (read-msg 'token-id) (read-msg 'new-asset)))
+
+  (expect "events"
+    [{"name": "marmalade-examples.multi-asset-policy.ASSET_PROPOSED","params": [(read-msg 'token-id) 0 (read-msg 'new-asset)]}]
+    (map (remove "module-hash")  (env-events true)))
+  
+  (expect "get previously added asset"
+    [(read-msg 'new-asset)]
+    (get-proposed-assets (read-msg 'token-id))
+  )
+
+  (expect-failure "fail if asset index does not exist"
+    "Invalid asset ID"
+    (replace-proposed-asset (read-msg 'token-id) 7 (read-msg 'new-asset)))
+
+  (expect-failure "fail if new asset is the same as the current one"
+    "Must be different URI"
+    (replace-proposed-asset (read-msg 'token-id) 0 (read-msg 'new-asset)))
+
+  (env-sigs [
+    { 'key: "e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+      ,'caps: [(marmalade-examples.multi-asset-policy.PROPOSE_ASSET (read-msg 'token-id) (read-msg 'replaced-asset))]}
+  ])
+
+  (expect "asset URI sucessfully replaced"
+    true
+    (replace-proposed-asset (read-msg 'token-id) 0 (read-msg 'replaced-asset)))
+
+  (expect "events"
+    [{"name": "marmalade-examples.multi-asset-policy.ASSET_PROPOSED","params": [(read-msg 'token-id) 0 (read-msg 'replaced-asset)]}]
+    (map (remove "module-hash")  (env-events true)))
+
+(commit-tx)
+
+
+(begin-tx "reject proposed assets")
+
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-examples.multi-asset-policy)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+
+  (env-data {
+    "token-id": (create-token-id { 'uri: "multi-asset-policy-non-fungible", 'precision: 0, 'policies: [marmalade-examples.multi-asset-policy marmalade-v2.non-fungible-policy-v1] } ALWAYS-TRUE)
+    ,"replaced-asset": "ipfs://1-replaced"
+    ,"owner": "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+    ,"operator_guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+  } )
+
+  (env-sigs [
+    { 'key: "6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+     ,'caps: [(marmalade-examples.multi-asset-policy.REJECT_ASSET (read-msg 'token-id) 0 (read-msg 'owner))]}
+  ])
+
+  (expect "reject proposed asset"
+    true
+    (reject-proposed-asset (read-msg 'token-id) 0 (read-msg 'owner))
+  )
+
+  (expect "events"
+    [{"name": "marmalade-examples.multi-asset-policy.ASSET_REJECTED","params": [(read-msg 'token-id) 0 (read-msg 'replaced-asset) (read-msg 'owner)]}]
+    (map (remove "module-hash")  (env-events true)))
+
+  (expect "no proposed assets after rejecting"
+    []
+    (get-proposed-assets (read-msg 'token-id))
+  )
+
+  (env-sigs [
+    { 'key: "e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+     ,'caps: [
+      (marmalade-examples.multi-asset-policy.PROPOSE_ASSET (read-msg 'token-id) "ipfs://1")
+      ,(marmalade-examples.multi-asset-policy.PROPOSE_ASSET (read-msg 'token-id) "ipfs://2")
+    ]}
+  ])
+
+  (expect "new asset successfully proposed"
+    true
+    (propose-asset (read-msg 'token-id) "ipfs://1"))
+
+  (expect "new asset successfully proposed"
+    true
+    (propose-asset (read-msg 'token-id) "ipfs://2"))
+
+  (expect "events"
+    [
+      {"name": "marmalade-examples.multi-asset-policy.ASSET_PROPOSED","params": [(read-msg 'token-id) 0 "ipfs://1"]}
+      ,{"name": "marmalade-examples.multi-asset-policy.ASSET_PROPOSED","params": [(read-msg 'token-id) 1 "ipfs://2"]}
+    ]
+    (map (remove "module-hash")  (env-events true)))
+
+  (env-sigs [
+    { 'key: "6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+      ,'caps: [(marmalade-examples.multi-asset-policy.REJECT_ALL_ASSETS (read-msg 'token-id) (read-msg 'owner))]}
+  ])
+
+  (expect "reject all proposed assets"
+    true
+    (reject-all-proposed-assets (read-msg 'token-id) (read-msg 'owner))
+  )
+
+  (expect "events"
+    [
+      {"name": "marmalade-examples.multi-asset-policy.ASSET_REJECTED","params": [(read-msg 'token-id) 0 "ipfs://1" (read-msg 'owner)]}
+      ,{"name": "marmalade-examples.multi-asset-policy.ASSET_REJECTED","params": [(read-msg 'token-id) 1 "ipfs://2" (read-msg 'owner)]}
+    ]
+    (map (remove "module-hash")  (env-events true)))
+  
+(commit-tx)
+
+
+(begin-tx "accept proposed assets")
+
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-examples.multi-asset-policy)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+
+  (env-data {
+    "token-id": (create-token-id { 'uri: "multi-asset-policy-non-fungible", 'precision: 0, 'policies: [marmalade-examples.multi-asset-policy marmalade-v2.non-fungible-policy-v1] } ALWAYS-TRUE)
+    ,"owner": "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+    ,"operator_guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+  } )
+
+  (env-sigs [
+    { 'key: "e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+     ,'caps: [
+      (marmalade-examples.multi-asset-policy.PROPOSE_ASSET (read-msg 'token-id) "ipfs://1")
+      ,(marmalade-examples.multi-asset-policy.PROPOSE_ASSET (read-msg 'token-id) "ipfs://2")
+      ,(marmalade-examples.multi-asset-policy.PROPOSE_ASSET (read-msg 'token-id) "ipfs://3")
+    ]}
+  ])
+
+  (expect "new asset successfully proposed"
+    true
+    (propose-asset (read-msg 'token-id) "ipfs://1"))
+
+  (expect "new asset successfully proposed"
+    true
+    (propose-asset (read-msg 'token-id) "ipfs://2"))
+
+  (expect "new asset successfully proposed"
+    true
+    (propose-asset (read-msg 'token-id) "ipfs://3"))
+
+  (expect "events"
+    [
+      {"name": "marmalade-examples.multi-asset-policy.ASSET_PROPOSED","params": [(read-msg 'token-id) 0 "ipfs://1"]},
+      {"name": "marmalade-examples.multi-asset-policy.ASSET_PROPOSED","params": [(read-msg 'token-id) 1 "ipfs://2"]},
+      {"name": "marmalade-examples.multi-asset-policy.ASSET_PROPOSED","params": [(read-msg 'token-id) 2 "ipfs://3"]}
+    ]
+    (map (remove "module-hash")  (env-events true)))
+
+  (expect-failure "active asset does not exist"
+    "row not found: t:KaIJSvJEBJI8fV2LxDG6Jk_ASLRdQ-0SIr5CiAR2noM"
+    (get-asset (read-msg 'token-id) 0)
+  )
+
+  (env-sigs [
+    { 'key: "6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+      ,'caps: [
+        (marmalade-examples.multi-asset-policy.ACCEPT_ASSET (read-msg 'token-id) 0 (read-msg 'owner))
+        ,(marmalade-examples.multi-asset-policy.ACCEPT_ASSET (read-msg 'token-id) 1 (read-msg 'owner))
+        ,(marmalade-examples.multi-asset-policy.ACCEPT_ASSET (read-msg 'token-id) 2 (read-msg 'owner))
+      ]}
+  ])
+
+  (expect "accept proposed asset"
+    true
+    (accept-asset (read-msg 'token-id) 0 (read-msg 'owner))
+  )
+
+  (expect "accept proposed asset"
+    true
+    (accept-asset (read-msg 'token-id) 1 (read-msg 'owner))
+  )
+
+  (expect "accept proposed asset"
+    true
+    (accept-asset (read-msg 'token-id) 2 (read-msg 'owner))
+  )
+
+  (expect "events"
+    [
+      {"name": "marmalade-examples.multi-asset-policy.ASSET_ACCEPTED", "params": [(read-msg 'token-id) 0 "ipfs://1" (read-msg 'owner)]},
+      {"name": "marmalade-examples.multi-asset-policy.ASSET_ACCEPTED", "params": [(read-msg 'token-id) 1 "ipfs://2" (read-msg 'owner)]},
+      {"name": "marmalade-examples.multi-asset-policy.ASSET_ACCEPTED", "params": [(read-msg 'token-id) 2 "ipfs://3" (read-msg 'owner)]}
+    ]
+    (map (remove "module-hash")  (env-events true)))
+  
+  (expect "successfully get asset URI"
+    "ipfs://1"
+    (get-asset (read-msg 'token-id) 0)
+  )
+
+  (expect "successfully get asset URI"
+    "ipfs://2"
+    (get-asset (read-msg 'token-id) 1)
+  )
+
+  (expect "successfully get asset URI"
+    "ipfs://3"
+    (get-asset (read-msg 'token-id) 2)
+  )
+  
+(commit-tx)
+
+(begin-tx "change asset priority")
+
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-examples.multi-asset-policy)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+
+  (env-data {
+    "token-id": (create-token-id { 'uri: "multi-asset-policy-non-fungible", 'precision: 0, 'policies: [marmalade-examples.multi-asset-policy marmalade-v2.non-fungible-policy-v1] } ALWAYS-TRUE)
+    ,"owner": "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+    ,"target-asset-id": 1
+    ,"new-priority": 0
+  } )
+ 
+  (expect "successfully get all asset URIs"
+    ["ipfs://1" "ipfs://2" "ipfs://3"]
+    (get-assets (read-msg 'token-id)))
+
+  (env-sigs [
+    { 'key: "6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+      ,'caps: [
+        (marmalade-examples.multi-asset-policy.SET_ASSET_PRIORITY (read-msg 'token-id) (read-integer 'target-asset-id) (read-integer 'new-priority) (read-msg 'owner))
+      ]}
+  ])
+
+  (expect "successfully set new priority"
+    true
+    (set-asset-priority (read-msg 'token-id) (read-integer 'target-asset-id) (read-integer 'new-priority) (read-msg 'owner) ))
+ 
+  (expect "events"
+    [{"name": "marmalade-examples.multi-asset-policy.ASSET_PRIORITY_SET", "params": [(read-msg 'token-id) (read-integer 'target-asset-id) (read-integer 'new-priority) (read-msg 'owner)]}]
+    (map (remove "module-hash")  (env-events true)))
+
+  (expect "successfully get all asset URIs"
+    ["ipfs://2" "ipfs://3" "ipfs://1"]
+    (get-assets (read-msg 'token-id)))
+
+  (env-sigs [
+    { 'key: "6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+      ,'caps: [
+        (marmalade-examples.multi-asset-policy.SET_ASSET_PRIORITY (read-msg 'token-id) 0 2 (read-msg 'owner))
+      ]}
+  ])
+
+  (expect "successfully set new priority"
+    true
+    (set-asset-priority (read-msg 'token-id) 0 2 (read-msg 'owner) ))
+ 
+  (expect "events"
+    [{"name": "marmalade-examples.multi-asset-policy.ASSET_PRIORITY_SET", "params": [(read-msg 'token-id) 0 2 (read-msg 'owner)]}]
+    (map (remove "module-hash")  (env-events true)))
+
+  (expect "successfully get all asset URIs"
+    ["ipfs://3" "ipfs://2" "ipfs://1"]
+    (get-assets (read-msg 'token-id)))
+
+(commit-tx)

--- a/pact-tests/pact-tests/marmalade/examples/policies/onchain-manifest-policy/onchain-manifest-policy-v1.pact
+++ b/pact-tests/pact-tests/marmalade/examples/policies/onchain-manifest-policy/onchain-manifest-policy-v1.pact
@@ -1,0 +1,134 @@
+(namespace (read-msg 'ns))
+
+(module onchain-manifest-policy-v1 GOVERNANCE
+
+  @doc "onchain manifest storage for marmalade-v2"
+  (implements kip.token-policy-v2)
+
+  (use kip.token-manifest)
+  (use kip.token-policy-v2 [token-info])
+  (use marmalade-v2.policy-manager)
+
+  (defconst ADMIN-KS:string "marmalade-examples.onchain-manifest-policy")
+
+  (defcap GOVERNANCE ()
+    (enforce-guard ADMIN-KS))
+
+  (defconst POLICY:string (format "{}" [onchain-manifest-policy-v1]))
+    
+  (defconst MANIFEST-SPEC-MSG-KEY:string "manifest_spec")
+
+  (defschema manifest-spec
+    manifest:object{manifest}
+    guard:guard
+  )
+
+  (deftable manifests:{manifest-spec})
+
+  (defcap UPGRADE (token-id:string)
+    @managed
+    (with-read manifests token-id {
+      "guard":=manifest-guard
+      }
+      (enforce-guard manifest-guard)
+    )
+  )
+
+  (defun get-manifest:object{manifest} (token-id:string)
+    (with-read manifests token-id {
+      "manifest":= manifest
+    }
+    manifest
+  ))
+
+  (defun upgrade-manifest
+    ( token-id:string
+      manifest:object{manifest}
+    )
+    (with-capability (UPGRADE token-id)
+      (enforce-verify-manifest manifest)
+      (update manifests token-id {
+        "manifest": manifest
+      })
+    )
+  )
+
+  (defun enforce-init:bool
+    ( token:object{token-info}
+    )
+    @doc "Executed at `create-token` step of marmalade.ledger.                  \
+    \ Required msg-data keys:                                                  \
+    \ * manifest_spec:object{manifest-spec} - registers the manifest object of \
+    \ the token and the guard that manages the upgrade of the manifest on chain"
+    (require-capability (INIT-CALL (at "id" token) (at "precision" token) (at "uri" token) POLICY))
+    (let ( (manifest:object{manifest-spec} (read-msg MANIFEST-SPEC-MSG-KEY )) )
+      (enforce-verify-manifest (at 'manifest manifest))
+      (insert manifests (at 'id token) manifest)
+    )
+    true
+  )
+
+  (defun enforce-mint:bool
+    ( token:object{token-info}
+      account:string
+      guard:guard
+      amount:decimal
+    )
+    true
+  )
+
+  (defun enforce-burn:bool
+    ( token:object{token-info}
+      account:string
+      amount:decimal
+    )
+    true
+  )
+
+  (defun enforce-offer:bool
+    ( token:object{token-info}
+      seller:string
+      amount:decimal
+      timeout:integer
+      sale-id:string
+    )
+    true
+  )
+
+  (defun enforce-buy:bool
+    ( token:object{token-info}
+      seller:string
+      buyer:string
+      buyer-guard:guard
+      amount:decimal
+      sale-id:string )
+    true
+  )
+
+
+  (defun enforce-transfer:bool
+    ( token:object{token-info}
+      sender:string
+      guard:guard
+      receiver:string
+      amount:decimal )
+    true
+  )
+
+
+  (defun enforce-withdraw:bool
+    ( token:object{token-info}
+      seller:string
+      amount:decimal
+      timeout:integer
+      sale-id:string )
+    true
+  )
+)
+
+(if (read-msg 'upgrade)
+  ["upgrade complete"]
+  [ (create-table manifests)
+])
+
+(enforce-guard ADMIN-KS)

--- a/pact-tests/pact-tests/marmalade/examples/policies/onchain-manifest-policy/onchain-manifest-policy-v1.repl
+++ b/pact-tests/pact-tests/marmalade/examples/policies/onchain-manifest-policy/onchain-manifest-policy-v1.repl
@@ -1,0 +1,144 @@
+
+;;load policy manager, ledger
+(load "../../../pact/marmalade.repl")
+
+(begin-tx "load onchain manifest policy")
+  (env-data {
+    "ns": "marmalade-examples"
+  , "onchain-manifest-policy": ["onchain-manifest-policy"]
+  , "upgrade": false}
+  )
+  (env-sigs [
+    { 'key: 'onchain-manifest-policy
+     ,'caps: []
+  }])
+
+  (ns.write-registry (read-msg 'ns) (read-keyset 'onchain-manifest-policy) true)
+  (define-namespace
+    (read-msg 'ns)
+    (read-keyset 'onchain-manifest-policy) (read-keyset 'onchain-manifest-policy)
+  )
+
+  (namespace (read-msg 'ns))
+
+  (define-keyset (+ (read-msg 'ns) ".onchain-manifest-policy") (read-keyset 'onchain-manifest-policy))
+  
+  (load "onchain-manifest-policy-v1.pact")
+  (typecheck "marmalade-examples.onchain-manifest-policy-v1")
+(commit-tx)
+
+(begin-tx "create token with onchain manifest policy")
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-examples.onchain-manifest-policy-v1)
+  (use mini-guard-utils)
+
+  (env-data {
+    "token-id": (create-token-id { 'uri: "test-onchain-manifest-uri", 'precision: 0, 'policies: [marmalade-examples.onchain-manifest-policy-v1] } ALWAYS-TRUE)
+   ,"manifest_spec": {
+      "guard": {"keys": ["manifest"], "pred": "keys-all"}
+   }
+  })
+
+  (expect-failure "fail to create token with invalid manifest"
+    "Failure: Missing fields for {manifest-spec}"
+    (create-token (read-msg 'token-id) 0 "test-onchain-manifest-uri" [marmalade-examples.onchain-manifest-policy-v1] ALWAYS-TRUE))
+
+  (env-data {
+    "token-id": (create-token-id { 'uri: "test-onchain-manifest-uri", 'precision: 0, 'policies: [marmalade-examples.onchain-manifest-policy-v1] } ALWAYS-TRUE)
+   ,"manifest_spec": {
+      "manifest": (kip.token-manifest.create-manifest (kip.token-manifest.uri "text" "data") [])
+     ,"guard": {"keys": ["manifest"], "pred": "keys-all"}
+   }
+  })
+
+  (env-sigs [])
+
+  (expect "create a token with onchain manifest policy"
+    true
+    (create-token (read-msg 'token-id) 0 "test-onchain-manifest-uri" [marmalade-examples.onchain-manifest-policy-v1] ALWAYS-TRUE))
+
+  (expect "Manifest is added at create-token"
+    {"uri": {"scheme": "text","data": "data"},"hash": "QoE_VBnnOaZqxcBBbTXSQ7CVNWPXZ9iP6BbxTmPY-ag","data": []}
+    (get-manifest (read-msg 'token-id )))
+(commit-tx)
+
+(begin-tx "upgrade token manifest")
+  (use marmalade-v2.ledger)
+  (use marmalade-examples.onchain-manifest-policy-v1)
+  (use mini-guard-utils)
+
+   (env-data {
+     "token-id": (create-token-id { 'uri: "test-onchain-manifest-uri", 'precision: 0, 'policies: [marmalade-examples.onchain-manifest-policy-v1] } ALWAYS-TRUE)
+    ,"manifest1": (kip.token-manifest.create-manifest (kip.token-manifest.uri "text1" "data") [])
+   })
+
+  (env-sigs [
+    {"key": "malicious-user", "caps": [(marmalade-examples.onchain-manifest-policy-v1.UPGRADE (read-msg 'token-id))]}
+    ])
+ 
+  (expect-failure "fail to upgrade a onchain manifest with malicious user"
+    "Keyset failure (keys-all): [manifest...]"
+    (upgrade-manifest (read-msg 'token-id ) (read-msg 'manifest1 )))
+
+  (env-sigs [
+    {"key": "manifest", "caps": [(marmalade-examples.onchain-manifest-policy-v1.UPGRADE (read-msg 'token-id))]}
+    ])
+  
+  (expect "upgrade a onchain manifest"
+    "Write succeeded"
+    (upgrade-manifest (read-msg 'token-id ) (read-msg 'manifest1 )))
+
+  (expect "upgrade-manifest events"
+    [ { "name": "marmalade-examples.onchain-manifest-policy-v1.UPGRADE","params": [(read-msg 'token-id)]} ]
+    (map (remove "module-hash")  (env-events true)))
+
+  (expect "Manifest was upgraded"
+   {"uri": {"scheme": "text1","data": "data"},"hash": "dD_VD1vl5Qx25WYNhW6RWIuxo25LQfa49Fs55ckMwUE","data": []}
+   (get-manifest (read-msg 'token-id )))
+   
+(commit-tx)
+   
+(begin-tx "create token with onchain manifest and royalty policy")
+
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-v2.util-v1)
+  (use marmalade-examples.onchain-manifest-policy-v1)
+  (use mini-guard-utils)
+
+  (env-data {
+    "creator-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+  })
+  (coin.create-account "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3" (read-keyset 'creator-guard))
+
+  (env-data {
+    "policies": (+ (create-policies (create-concrete-policy [marmalade-v2.royalty-policy-v1])) [marmalade-examples.onchain-manifest-policy-v1])
+   ,"token-id": (create-token-id { 'uri: "onchain-manifest-with-royalty", 'precision: 0, 'policies: (+ (create-policies (create-concrete-policy [marmalade-v2.royalty-policy-v1])) [marmalade-examples.onchain-manifest-policy-v1]) } ALWAYS-TRUE)
+   ,"manifest_spec": {
+      "manifest": (kip.token-manifest.create-manifest (kip.token-manifest.uri "text" "data") [])
+     ,"guard": {"keys": ["manifest"], "pred": "keys-all"}
+   }
+   ,"royalty_spec": {
+      "fungible": coin
+     ,"creator": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+     ,"creator-guard":  {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+     ,"royalty-rate": 0.05
+    }
+   ,"collection_id": "collection:aHZrcOD_nHHHiEQgIhdfjcWfUKcD1dvsdG00tE4fAC8"
+  })
+
+  (env-sigs [])
+
+  (expect "create a token with onchain manifest policy"
+    true
+    (create-token (read-msg 'token-id) 0 "onchain-manifest-with-royalty" (read-msg 'policies) ALWAYS-TRUE))
+
+  (expect "create-token events"
+    [ 
+      {"name": "marmalade-v2.royalty-policy-v1.ROYALTY","params": [(read-msg 'token-id) (read-msg 'royalty_spec) ]},
+      {"name": "marmalade-v2.ledger.TOKEN","params": [(read-msg 'token-id) 0 (read-msg 'policies) "onchain-manifest-with-royalty" ALWAYS-TRUE]} ]
+    (map (remove "module-hash")  (env-events true)))
+
+(rollback-tx)
+

--- a/pact-tests/pact-tests/marmalade/examples/policies/onchain-manifest-policy/onchain-manifest-policy.md
+++ b/pact-tests/pact-tests/marmalade/examples/policies/onchain-manifest-policy/onchain-manifest-policy.md
@@ -1,0 +1,39 @@
+# Onchain Manifest Policy
+
+The `onchain-manifest-policy-v1` module is a part of Marmalade that provides onchain manifest storage for `marmalade-v2`. It implements the `kip.token-policy-v2` interface and enables the management of token manifests on the blockchain.
+
+## Specification, tables, capabilities:
+
+**Schemas**:
+- `manifest-spec`: Defines the structure of the manifest specification.
+  - `manifest:object{manifest}`: Represents the manifest object.
+  - `guard:guard`: Manages the upgrade of the manifest on chain.
+
+**Tables**:
+- `manifests:{manifest-spec}`: Stores the token manifest information.
+
+**Capabilities**:
+ - `GOVERNANCE`: enforces access control of contract upgrade.
+
+## Policy Functions
+
+**`enforce-init`:** Enforced during `marmalade-v2.ledger.create-token`, and enforces the following msg-data keys:
+  - `manifest_spec:object{manifest-spec}`: Registers the manifest object of the token and the guard that manages the upgrade of the manifest on chain.
+
+**`enforce-mint`:** Enforced during `marmalade-v2.ledger.mint`, and enforces the mint logic following the provided supply information
+
+**`enforce-burn`:** Enabled without limitation.
+
+**`enforce-offer`:** Enabled without limitation.
+
+**`enforce-buy`:** Enabled without limitation.
+
+**`enforce-withdraw`:** Enabled without limitation.
+
+**`enforce-transfer`:** Enabled without limitation.
+
+## Custom functions
+
+**`get-manifest:`** Retrieves the manifest object for a given token ID.
+
+**`upgrade-manifest:`** Upgrades the manifest for a given token ID.

--- a/pact-tests/pact-tests/marmalade/examples/policies/private-token-policy/private-token-policy-v1.pact
+++ b/pact-tests/pact-tests/marmalade/examples/policies/private-token-policy/private-token-policy-v1.pact
@@ -1,0 +1,140 @@
+(namespace (read-msg 'ns))
+
+(module private-token-policy-v1 GOVERNANCE
+
+  (defconst ADMIN-KS:string "marmalade-examples.private-token-policy")
+
+  (defcap GOVERNANCE ()
+    (enforce-guard ADMIN-KS))
+
+  (implements kip.token-policy-v2)
+  (implements kip.updatable-uri-policy-v1)
+  (use kip.token-policy-v2 [token-info])
+  (use marmalade-v2.guard-policy-v1 [URI-GUARD-MSG-KEY])
+
+  (defschema revealed-tokens-schema
+    revealed:bool  
+  )
+
+  (deftable revealed-tokens:{revealed-tokens-schema})
+
+  (defcap TOKEN_REVEALED (token-id:string uri:string)
+    @doc "Emitted when the token URI has been revealed"
+    @event
+    true
+  )
+
+  (defun has-guard-policy:bool (policies)
+    (> (length (filter (lambda (policy) (= (format "{}" [policy]) "marmalade-v2.guard-policy-v1")) policies)) 0))
+
+  (defun enforce-init:bool
+    ( token:object{token-info}
+    )
+
+    (enforce (has-guard-policy (at 'policies token)) "Guard policy is required for private tokens")
+
+    (read-msg URI-GUARD-MSG-KEY)
+
+    true
+  )
+
+  (defun enforce-mint:bool
+    ( token:object{token-info}
+      account:string
+      guard:guard
+      amount:decimal
+    )
+    true
+  )
+
+  (defun enforce-burn:bool
+    ( token:object{token-info}
+      account:string
+      amount:decimal
+    )
+    true
+  )
+
+  (defun enforce-offer:bool
+    ( token:object{token-info}
+      seller:string
+      amount:decimal
+      timeout:integer
+      sale-id:string )
+    true
+  )
+
+  (defun enforce-buy:bool
+    ( token:object{token-info}
+      seller:string
+      buyer:string
+      buyer-guard:guard
+      amount:decimal
+      sale-id:string )
+    true
+  )
+
+  (defun enforce-withdraw:bool
+    ( token:object{token-info}
+      seller:string
+      amount:decimal
+      timeout:integer
+      sale-id:string )
+    true
+  )
+
+  (defun enforce-transfer:bool
+    ( token:object{token-info}
+      sender:string
+      guard:guard
+      receiver:string
+      amount:decimal )
+    true
+  )
+
+  (defun enforce-update-uri:bool
+    ( token:object{kip.token-policy-v2.token-info}
+      new-uri:string
+    )
+    (let ((revealed:bool (is-revealed (at 'id token))))
+      (enforce revealed "Update disabled prior to revealing")
+    )
+  )
+
+  (defun reveal-uri:bool (token-id:string new-uri:string)
+    (let* (
+      (token-info:object{kip.token-policy-v2.token-info} (marmalade-v2.ledger.get-token-info token-id))
+      (token-uri-hash:string (at 'uri token-info))
+      (already-revealed:bool (is-revealed token-id))
+    )
+      (enforce (not already-revealed) "Token URI already revealed")
+
+      (enforce (not (= new-uri "")) "URI cannot be empty")
+
+      (enforce (= token-uri-hash (hash new-uri)) "URI does not match the hash")
+      
+      (insert revealed-tokens token-id { 'revealed: true })
+
+      (marmalade-v2.ledger.update-uri token-id new-uri)
+
+      (emit-event (TOKEN_REVEALED token-id new-uri))
+     
+      true
+    )
+  )
+
+  (defun is-revealed:bool (token-id:string)
+    (with-default-read revealed-tokens token-id 
+      { 'revealed : false } 
+      { 'revealed := revealed }
+      revealed
+    )
+  )
+)
+
+(if (read-msg 'upgrade)
+  true
+  (create-table revealed-tokens)
+)
+
+(enforce-guard ADMIN-KS)

--- a/pact-tests/pact-tests/marmalade/examples/policies/private-token-policy/private-token-policy-v1.repl
+++ b/pact-tests/pact-tests/marmalade/examples/policies/private-token-policy/private-token-policy-v1.repl
@@ -1,0 +1,138 @@
+;;load policy manager, ledger
+(load "../../../pact/marmalade.repl")
+
+(begin-tx "load policy")
+  (env-data {
+    "ns": "marmalade-examples"
+  , "private-token-policy": ["private-token-policy"]
+  , "upgrade": false}
+  )
+  (env-sigs [
+    { 'key: 'private-token-policy
+     ,'caps: []
+  }])
+
+  (ns.write-registry (read-msg 'ns) (read-keyset 'private-token-policy) true)
+  (define-namespace
+    (read-msg 'ns)
+    (read-keyset 'private-token-policy) (read-keyset 'private-token-policy)
+  )
+
+  (namespace (read-msg 'ns))
+
+  (define-keyset (+ (read-msg 'ns) ".private-token-policy") (read-keyset 'private-token-policy))
+  
+  (load "private-token-policy-v1.pact")
+  (typecheck "marmalade-examples.private-token-policy-v1")
+
+(commit-tx)
+
+(begin-tx "Require guard-policy")
+    (use marmalade-v2.ledger)
+    (use marmalade-examples.private-token-policy-v1)
+    (use mini-guard-utils)
+  
+  (env-data {
+    "token-id": (create-token-id { 'uri: (hash "ipfs://secret-uri"), 'precision: 0, 'policies: [marmalade-examples.private-token-policy-v1 marmalade-v2.guard-policy-v1] } ALWAYS-TRUE)
+    ,"token-id-without-guard-policy": (create-token-id { 'uri: (hash "ipfs://secret-uri"), 'precision: 0, 'policies: [marmalade-examples.private-token-policy-v1] } ALWAYS-TRUE)
+  })
+
+  (expect-failure "Failed to create a token without guard-policy"
+    "Guard policy is required for private tokens"
+    (create-token (read-msg 'token-id-without-guard-policy) 0 (hash "ipfs://secret-uri") [marmalade-examples.private-token-policy-v1] ALWAYS-TRUE))
+
+  (expect-failure "Failed to create a token without uri-guard"
+    "Failure: Tx Failed: No such key in message: uri_guard"
+    (create-token (read-msg 'token-id) 0 (hash "ipfs://secret-uri") [marmalade-examples.private-token-policy-v1 marmalade-v2.guard-policy-v1] ALWAYS-TRUE))
+
+(commit-tx)
+
+(begin-tx "Create private token")
+    (use marmalade-v2.ledger)
+    (use marmalade-examples.private-token-policy-v1)
+    (use marmalade-v2.guard-policy-v1 [GUARD_SUCCESS])
+    (use mini-guard-utils)
+    
+  (env-data {
+     "token-id": (create-token-id { 'uri: (hash "ipfs://secret-uri"), 'precision: 0, 'policies: [marmalade-examples.private-token-policy-v1 marmalade-v2.guard-policy-v1] } ALWAYS-TRUE)
+     ,"uri_guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+  })
+
+  (expect "Token created successfully"
+    true
+    (create-token (read-msg 'token-id) 0 (hash "ipfs://secret-uri") [marmalade-examples.private-token-policy-v1 marmalade-v2.guard-policy-v1] ALWAYS-TRUE))
+
+  (expect "create-token events"
+    [ {"name": "marmalade-v2.guard-policy-v1.GUARDS","params": [(read-msg 'token-id) {"burn-guard": GUARD_SUCCESS,"mint-guard": GUARD_SUCCESS,"sale-guard": GUARD_SUCCESS,"transfer-guard": GUARD_SUCCESS,"uri-guard":(read-keyset 'uri_guard)}] },
+      {"name": "marmalade-v2.ledger.TOKEN","params": [(read-msg 'token-id) 0 [marmalade-examples.private-token-policy-v1 marmalade-v2.guard-policy-v1] (hash "ipfs://secret-uri") ALWAYS-TRUE]}]
+    (map (remove "module-hash")  (env-events true)))
+
+(commit-tx)
+
+(begin-tx "Reveal private token URI")
+    (use marmalade-v2.ledger)
+    (use marmalade-examples.private-token-policy-v1)
+    (use mini-guard-utils)
+
+  (env-data {
+    "secret-uri": "ipfs://secret-uri"
+    ,"token-id": (create-token-id { 'uri: (hash "ipfs://secret-uri"), 'precision: 0, 'policies: [marmalade-examples.private-token-policy-v1 marmalade-v2.guard-policy-v1] } ALWAYS-TRUE)
+    ,"uri-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+  })
+
+  (expect "token has not been revealed"
+    false
+    (is-revealed (read-msg 'token-id))
+  )
+
+  (expect-failure "shoud not be able to update uri before revealing"
+    "Update disabled prior to revealing"
+    (marmalade-v2.ledger.update-uri (read-msg 'token-id) "")
+  )
+  
+  (expect-failure "fail if new URI is empty string"
+    "URI cannot be empty"
+    (reveal-uri (read-msg 'token-id) ""))
+  
+  (expect-failure "fail if new URI is wrong"
+    "URI does not match the hash"
+    (reveal-uri (read-msg 'token-id) "ipfs://wrong-uri"))
+
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+      ,'caps: [
+        (marmalade-v2.ledger.UPDATE-URI (read-msg 'token-id) (read-msg 'secret-uri))
+        ,(marmalade-v2.guard-policy-v1.UPDATE-URI (read-msg 'token-id) (read-msg 'secret-uri))]
+    }])
+  
+  (expect "successfully reveal the URI"
+    true
+    (reveal-uri (read-msg 'token-id) (read-msg 'secret-uri)))
+
+  (expect "reveal uri events"
+    [{"name": "marmalade-v2.ledger.UPDATE-URI","params": [(read-msg 'token-id) (read-msg 'secret-uri)]}
+    ,{"name": "marmalade-examples.private-token-policy-v1.TOKEN_REVEALED","params": [(read-msg 'token-id) (read-msg 'secret-uri)]} ]
+    (map (remove "module-hash")  (env-events true)))
+  
+  (expect "token has been revealed"
+    true
+    (is-revealed (read-msg 'token-id))
+  )
+    
+  (expect-failure "cannot reveal the URI again"
+    "Token URI already revealed"
+    (reveal-uri (read-msg 'token-id) "ipfs://something-new"))
+
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+      ,'caps: [
+        (marmalade-v2.ledger.UPDATE-URI (read-msg 'token-id) "ipfs://updated")
+        ,(marmalade-v2.guard-policy-v1.UPDATE-URI (read-msg 'token-id) "ipfs://updated")]
+    }])
+
+  (expect "shoud be able to update uri after revealing"
+    true
+    (marmalade-v2.ledger.update-uri (read-msg 'token-id) "ipfs://updated")
+  )
+      
+(commit-tx)

--- a/pact-tests/pact-tests/marmalade/examples/policies/private-token-policy/private-token-policy.md
+++ b/pact-tests/pact-tests/marmalade/examples/policies/private-token-policy/private-token-policy.md
@@ -1,0 +1,47 @@
+# Private token policy
+
+Private token policy allows creators to make an airdrop without revealing the metadata of the token beforehand. The token URI can be revealed at any time, making the metadata known to all.
+
+## Requirements:
+
+Concrete policy `guard-policy` must be used in conjunction with `private-token-policy` to make sure only an authorized account can update the token URI.
+
+While creating a token, the URI should be the hash of the actual URI. This can be calculated using a local call to the node so there is no trace recorded on the chain.
+
+Note: token URI can still be updated by the `uri-guard` but only after revealing the initial URI.
+
+## Specification, tables, capabilities, events:
+
+**Schemas**: `revealed-tokens-schema` is a schema that stores which tokens have been revealed
+  - `revealed`: shows if the URI has been revealed.
+
+**Tables**: `revealed-tokens` table stores which tokens have been revealed.
+  - `id`: the id of the token
+
+**Capabilities**:
+ - `GOVERNANCE`: enforces access control of contract upgrades.
+
+**Events**:
+ - `TOKEN_REVEALED (token-id uri)`: Emitted when the token URI has been revealed.
+
+## Policy Functions
+
+**`enforce-init`:** Enforced during `marmalade-v2.ledger.create-token`, and will ensure the concrete `guard-policy` is present along with the URI guard.
+
+**`enforce-mint`:** Enabled without limitation.
+
+**`enforce-burn`:** Enabled without limitation.
+
+**`enforce-offer`:** Enabled without limitation.
+
+**`enforce-buy`:** Enabled without limitation.
+
+**`enforce-withdraw`:** Enabled without limitation.
+
+**`enforce-transfer`:** Enabled without limitation.
+
+**`enforce-update-uri`:** Enforced during `marmalade-v2.ledger.update-uri`, and will allow updating only if the token has been revealed before.
+
+**`reveal-uri`:** Will make sure that the saved hash of the URI matches the hashed new URI and will invoke `marmalade-v2.ledger.update-uri`.
+
+**`is-revealed`:** Check if the URI has been revealed.

--- a/pact-tests/pact-tests/marmalade/examples/policies/soul-bound-policy/soul-bound-policy-v1.pact
+++ b/pact-tests/pact-tests/marmalade/examples/policies/soul-bound-policy/soul-bound-policy-v1.pact
@@ -1,0 +1,118 @@
+(namespace (read-msg 'ns))
+
+(module soul-bound-policy-v1 GOVERNANCE
+
+  (defconst ADMIN-KS:string "marmalade-examples.soul-bound-policy")
+
+  (defcap GOVERNANCE ()
+    (enforce-guard ADMIN-KS))
+
+  (defconst POLICY:string (format "{}" [soul-bound-policy-v1]))
+
+  (implements kip.token-policy-v2)
+  (use kip.token-policy-v2 [token-info])
+  (use marmalade-v2.policy-manager)
+  (use marmalade-v2.guard-policy-v1 [MINT-GUARD-MSG-KEY BURN-GUARD-MSG-KEY GUARD_SUCCESS])
+
+  (defschema mint-record 
+    account:string
+  )
+
+  (deftable records:{mint-record})
+
+  (defun has-guard-policy:bool (policies)
+    (> (length (filter (lambda (policy) (= policy marmalade-v2.guard-policy-v1)) policies)) 0))
+
+  (defun enforce-init:bool
+    ( token:object{token-info}
+    )
+    @doc "The function is run at `create-token` step of marmalade-v2.ledger."
+
+    (require-capability (INIT-CALL (at "id" token) (at "precision" token) (at "uri" token) POLICY))
+
+    (enforce (= (at 'precision token) 0) "Precision must be 0 for soul-bound tokens")
+
+    (read-msg MINT-GUARD-MSG-KEY)
+    (read-msg BURN-GUARD-MSG-KEY)
+
+    (enforce (has-guard-policy (at 'policies token)) "Guard policy is required for soul-bound tokens")
+
+    true
+  )
+
+  (defun enforce-mint:bool
+    ( token:object{token-info}
+      account:string
+      guard:guard
+      amount:decimal
+    )
+    (require-capability (MINT-CALL (at "id" token) account amount POLICY))
+
+    (enforce (= amount 1.0) "Amount must be 1.0 for soul-bound tokens")
+
+    (let* ((mint-record:object{mint-record} (try { 'account: "" } (read records (at 'id token))))
+          (has-mint-record:bool (!= (at 'account mint-record) "")))
+      (enforce (not has-mint-record) "Token was already minted")
+    )
+
+    (insert records (at 'id token) { 'account: account })
+
+    true
+  )
+
+  (defun enforce-burn:bool
+    ( token:object{token-info}
+      account:string
+      amount:decimal
+    )
+    (require-capability (BURN-CALL (at "id" token) account amount POLICY))
+
+    (enforce (= amount 1.0) "Amount must be 1.0 for soul-bound tokens")
+
+    true
+  )
+
+  (defun enforce-offer:bool
+    ( token:object{token-info}
+      seller:string
+      amount:decimal
+      timeout:integer
+      sale-id:string )
+    (enforce false "Sale is not allowed!")
+  )
+
+  (defun enforce-buy:bool
+    ( token:object{token-info}
+      seller:string
+      buyer:string
+      buyer-guard:guard
+      amount:decimal
+      sale-id:string )
+    (enforce false "Sale is not allowed!")
+  )
+
+  (defun enforce-withdraw:bool
+    ( token:object{token-info}
+      seller:string
+      amount:decimal
+      timeout:integer
+      sale-id:string )
+    (enforce false "Sale is not allowed!")
+  )
+
+  (defun enforce-transfer:bool
+    ( token:object{token-info}
+      sender:string
+      guard:guard
+      receiver:string
+      amount:decimal )
+    (enforce false "Transfer is not allowed!")
+  )
+)
+
+(if (read-msg 'upgrade)
+  true
+  (create-table records)
+)
+
+(enforce-guard ADMIN-KS)

--- a/pact-tests/pact-tests/marmalade/examples/policies/soul-bound-policy/soul-bound-policy-v1.repl
+++ b/pact-tests/pact-tests/marmalade/examples/policies/soul-bound-policy/soul-bound-policy-v1.repl
@@ -1,0 +1,304 @@
+;;load policy manager, ledger
+(load "../../../pact/marmalade.repl")
+
+(begin-tx "load timed mint policy")
+  (env-data {
+    "ns": "marmalade-examples"
+  , "soul-bound-policy": ["soul-bound-policy"]
+  , "upgrade": false}
+  )
+  (env-sigs [
+    { 'key: 'soul-bound-policy
+     ,'caps: []
+  }])
+
+  (ns.write-registry (read-msg 'ns) (read-keyset 'soul-bound-policy) true)
+  (define-namespace
+    (read-msg 'ns)
+    (read-keyset 'soul-bound-policy) (read-keyset 'soul-bound-policy)
+  )
+
+  (namespace (read-msg 'ns))
+
+  (define-keyset (+ (read-msg 'ns) ".soul-bound-policy") (read-keyset 'soul-bound-policy))
+  
+  (load "soul-bound-policy-v1.pact")
+  (typecheck "marmalade-examples.soul-bound-policy-v1")
+
+(commit-tx)
+
+(begin-tx "Require guard-policy for soul-bound tokens")
+    (use marmalade-v2.ledger)
+    (use marmalade-examples.soul-bound-policy-v1)
+    (use mini-guard-utils)
+  
+  (env-data {
+    "token-id": (create-token-id { 'uri: "test-default-guard", 'precision: 0, 'policies: [marmalade-examples.soul-bound-policy-v1 marmalade-v2.guard-policy-v1] } ALWAYS-TRUE)
+  })
+
+  (expect-failure "Failed to create a token without mint-guard"
+    "Failure: Tx Failed: No such key in message: mint_guard"
+    (create-token (read-msg 'token-id) 0 "test-default-guard" [marmalade-examples.soul-bound-policy-v1 marmalade-v2.guard-policy-v1] ALWAYS-TRUE))
+
+  (env-data {
+    "token-id": (create-token-id { 'uri: "test-default-guard", 'precision: 0, 'policies: [marmalade-examples.soul-bound-policy-v1 marmalade-v2.guard-policy-v1] } ALWAYS-TRUE)
+    ,"mint_guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+  })
+
+  (expect-failure "Failed to create a token without burn-guard"
+    "Failure: Tx Failed: No such key in message: burn_guard"
+    (create-token (read-msg 'token-id) 0 "test-default-guard" [marmalade-examples.soul-bound-policy-v1 marmalade-v2.guard-policy-v1] ALWAYS-TRUE))
+
+  (env-data {
+    "mint_guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+    ,"burn_guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+    ,"token-id-without-guard-policy": (create-token-id { 'uri: "test-default-guard", 'precision: 0, 'policies: [marmalade-examples.soul-bound-policy-v1] } ALWAYS-TRUE)
+  })
+
+  (expect-failure "Failed to create a token without guard-policy"
+    "Guard policy is required for soul-bound tokens"
+    (create-token (read-msg 'token-id-without-guard-policy) 0 "test-default-guard" [marmalade-examples.soul-bound-policy-v1] ALWAYS-TRUE))
+  
+(commit-tx)
+
+(begin-tx "Create soul bounded token")
+    (use marmalade-v2.ledger)
+    (use marmalade-examples.soul-bound-policy-v1)
+    (use marmalade-v2.guard-policy-v1 [GUARD_SUCCESS])
+    (use mini-guard-utils)
+  (env-data {
+     "token-id": (create-token-id { 'uri: "test-default-guard", 'precision: 0, 'policies: [marmalade-examples.soul-bound-policy-v1 marmalade-v2.guard-policy-v1] } ALWAYS-TRUE)
+     ,"token-id-with-bad-precision": (create-token-id { 'uri: "test-default-guard", 'precision: 1, 'policies: [marmalade-examples.soul-bound-policy-v1 marmalade-v2.guard-policy-v1] } ALWAYS-TRUE)
+     ,"mint_guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+     ,"burn_guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+  })
+
+  (expect-failure "failed to create token with precision bigger than 0"
+    "Precision must be 0 for soul-bound tokens"
+    (create-token (read-msg 'token-id-with-bad-precision) 1 "test-default-guard" [marmalade-examples.soul-bound-policy-v1 marmalade-v2.guard-policy-v1] ALWAYS-TRUE))
+
+  (expect "Token created successfully"
+    true
+    (create-token (read-msg 'token-id) 0 "test-default-guard" [marmalade-examples.soul-bound-policy-v1 marmalade-v2.guard-policy-v1] ALWAYS-TRUE))
+
+  (expect "create-token events"
+    [ {"name": "marmalade-v2.guard-policy-v1.GUARDS","params": [(read-msg 'token-id) {"burn-guard": (read-keyset 'burn_guard),"mint-guard": (read-keyset 'mint_guard),"sale-guard": GUARD_SUCCESS,"transfer-guard": GUARD_SUCCESS,"uri-guard": GUARD_SUCCESS}] },
+      {"name": "marmalade-v2.ledger.TOKEN","params": [(read-msg 'token-id) 0 [marmalade-examples.soul-bound-policy-v1 marmalade-v2.guard-policy-v1] "test-default-guard" ALWAYS-TRUE]}]
+    (map (remove "module-hash")  (env-events true)))
+
+(commit-tx)
+
+(begin-tx "Mint soul bound token successfully")
+    (use marmalade-v2.ledger)
+    (use marmalade-examples.soul-bound-policy-v1)
+    (use mini-guard-utils)
+  (env-data {
+     "token-id": (create-token-id { 'uri: "test-default-guard", 'precision: 0, 'policies: [marmalade-examples.soul-bound-policy-v1 marmalade-v2.guard-policy-v1] } ALWAYS-TRUE)
+    ,"account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+    ,"account-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+  })
+
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+     ,'caps: [(marmalade-v2.ledger.MINT (read-msg 'token-id) (read-msg 'account) 1.0)
+            ,(marmalade-v2.guard-policy-v1.MINT (read-msg 'token-id) (read-string 'account) 1.0)]
+    }])
+  
+  (expect-failure "failed to mint amount bigger than 1"
+    "Amount must be 1.0 for soul-bound tokens"
+    (mint (read-msg 'token-id) (read-msg 'account) (read-keyset 'account-guard ) 2.0))
+      
+  (expect-failure "failed to mint amount lower than 1"
+    "Amount must be 1.0 for soul-bound tokens"
+    (mint (read-msg 'token-id) (read-msg 'account) (read-keyset 'account-guard ) 0.5))
+
+  (expect "Mint token succeeds"
+    true
+    (mint (read-msg 'token-id) (read-msg 'account) (read-keyset 'account-guard ) 1.0))
+
+  (expect "mint events"
+    [ {"name": "marmalade-v2.ledger.MINT","params": [(read-msg 'token-id) (read-msg 'account) 1.0]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-msg 'token-id) (read-msg 'account) (read-keyset 'account-guard)]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-msg 'token-id) 1.0 {"account": "","current": 0.0,"previous": 0.0} {"account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3","current": 1.0,"previous": 0.0}]} {"name": "marmalade-v2.ledger.SUPPLY","params": [(read-msg 'token-id) 1.0]}]
+    (map (remove "module-hash")  (env-events true)))
+    
+  (expect-failure "Fail to mint the same token again"
+    "Token was already minted"
+    (mint (read-msg 'token-id) (read-msg 'account) (read-keyset 'account-guard ) 1.0))
+
+(commit-tx)
+
+(begin-tx "Mint, burn and mint again the same token")
+    (use marmalade-v2.ledger)
+    (use marmalade-examples.soul-bound-policy-v1)
+    (use marmalade-v2.guard-policy-v1 [GUARD_SUCCESS])
+    (use mini-guard-utils)
+  (env-data {
+     "token-id": (create-token-id { 'uri: "mint-burn-mint", 'precision: 0, 'policies: [marmalade-examples.soul-bound-policy-v1 marmalade-v2.guard-policy-v1] } ALWAYS-TRUE)
+    ,"account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+    ,"account-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+    ,"mint_guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+    ,"burn_guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+  })
+
+  (expect "Token created successfully"
+    true
+    (create-token (read-msg 'token-id) 0 "mint-burn-mint" [marmalade-examples.soul-bound-policy-v1 marmalade-v2.guard-policy-v1] ALWAYS-TRUE))
+
+  (expect "create-token events"
+    [ {"name": "marmalade-v2.guard-policy-v1.GUARDS","params": [(read-msg 'token-id) {"burn-guard": (read-keyset 'burn_guard),"mint-guard": (read-keyset 'mint_guard),"sale-guard": GUARD_SUCCESS,"transfer-guard": GUARD_SUCCESS,"uri-guard": GUARD_SUCCESS}] },
+     {"name": "marmalade-v2.ledger.TOKEN","params": [(read-msg 'token-id) 0 [marmalade-examples.soul-bound-policy-v1 marmalade-v2.guard-policy-v1] "mint-burn-mint" ALWAYS-TRUE]} ]
+    (map (remove "module-hash")  (env-events true)))
+
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+     ,'caps: [(marmalade-v2.ledger.MINT (read-msg 'token-id) (read-msg 'account) 1.0)
+            ,(marmalade-v2.guard-policy-v1.MINT (read-msg 'token-id) (read-string 'account) 1.0)]
+    }])
+  
+  (expect "Mint token succeeds"
+    true
+    (mint (read-msg 'token-id) (read-msg 'account) (read-keyset 'account-guard ) 1.0))
+
+  (expect "mint events"
+    [ {"name": "marmalade-v2.ledger.MINT","params": [(read-msg 'token-id) (read-msg 'account) 1.0]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-msg 'token-id) (read-msg 'account) (read-keyset 'account-guard)]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-msg 'token-id) 1.0 {"account": "","current": 0.0,"previous": 0.0} {"account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3","current": 1.0,"previous": 0.0}]} {"name": "marmalade-v2.ledger.SUPPLY","params": [(read-msg 'token-id) 1.0]}]
+    (map (remove "module-hash")  (env-events true)))
+  
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+      ,'caps: [(marmalade-v2.ledger.BURN (read-msg 'token-id) (read-msg 'account) 1.0)
+            ,(marmalade-v2.guard-policy-v1.BURN (read-msg 'token-id) (read-string 'account) 1.0)]
+    }])
+
+  (expect "Burn token succeeds"
+    true
+    (burn (read-msg 'token-id) (read-msg 'account) 1.0))
+
+  (expect "burn events"
+    [ {"name": "marmalade-v2.ledger.BURN","params": [(read-msg 'token-id) (read-msg 'account) 1.0]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-msg 'token-id) 1.0 {"account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3","current": 0.0,"previous": 1.0} {"account": "","current": 0.0,"previous": 0.0}]} {"name": "marmalade-v2.ledger.SUPPLY","params": [(read-msg 'token-id) 0.0]}]
+    (map (remove "module-hash")  (env-events true)))
+
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+     ,'caps: [(marmalade-v2.ledger.MINT (read-msg 'token-id) (read-msg 'account) 1.0)
+          ,(marmalade-v2.guard-policy-v1.MINT (read-msg 'token-id) (read-string 'account) 1.0)]
+    }])
+  
+  (expect-failure "Fail to mint the same token again"
+    "Token was already minted"
+    (mint (read-msg 'token-id) (read-msg 'account) (read-keyset 'account-guard ) 1.0))
+
+  (env-data {
+    "token-id": (create-token-id { 'uri: "mint-burn-mint", 'precision: 0, 'policies: [marmalade-examples.soul-bound-policy-v1 marmalade-v2.guard-policy-v1] } ALWAYS-TRUE)
+    ,"account": "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+    ,"account-guard": {"keys": ["other-account"], "pred": "keys-all"}
+  })
+
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+    ,'caps: [(marmalade-v2.ledger.MINT (read-msg 'token-id) (read-msg 'account) 1.0)
+          ,(marmalade-v2.guard-policy-v1.MINT (read-msg 'token-id) (read-string 'account) 1.0)]
+    }])
+  
+  (expect-failure "Fail to mint the same token to a different account"
+    "Token was already minted"
+    (mint (read-msg 'token-id) (read-msg 'account) (read-keyset 'account-guard ) 1.0))
+ 
+(rollback-tx)
+
+(begin-tx "Burn soul bound token successfully")
+    (use marmalade-v2.ledger)
+    (use marmalade-examples.soul-bound-policy-v1)
+    (use mini-guard-utils)
+  (env-data {
+     "token-id": (create-token-id { 'uri: "test-default-guard", 'precision: 0, 'policies: [marmalade-examples.soul-bound-policy-v1 marmalade-v2.guard-policy-v1] } ALWAYS-TRUE)
+    ,"account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+    ,"account-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+  })
+
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+     ,'caps: [(marmalade-v2.ledger.BURN (read-msg 'token-id) (read-msg 'account) 1.0)
+          ,(marmalade-v2.guard-policy-v1.BURN (read-msg 'token-id) (read-string 'account) 1.0)]
+    }])
+
+  (expect-failure "failed to burn amount bigger than 1"
+    "Amount must be 1.0 for soul-bound tokens"
+    (burn (read-msg 'token-id) (read-msg 'account) 2.0))
+
+  (expect-failure "failed to burn amount lower than 1"
+    "Amount must be 1.0 for soul-bound tokens"
+    (burn (read-msg 'token-id) (read-msg 'account) 0.5))
+
+  (expect "Burn token succeeds"
+    true
+    (burn (read-msg 'token-id) (read-msg 'account) 1.0))
+
+  (expect "burn events"
+    [ {"name": "marmalade-v2.ledger.BURN","params": [(read-msg 'token-id) (read-msg 'account) 1.0]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-msg 'token-id) 1.0 {"account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3","current": 0.0,"previous": 1.0} {"account": "","current": 0.0,"previous": 0.0}]} {"name": "marmalade-v2.ledger.SUPPLY","params": [(read-msg 'token-id) 0.0]}]
+    (map (remove "module-hash")  (env-events true)))
+
+(rollback-tx)
+
+(begin-tx "Transfer fails on soul bound tokens")
+    (use marmalade-v2.ledger)
+    (use marmalade-examples.soul-bound-policy-v1)
+    (use mini-guard-utils)
+  (env-data {
+     "token-id": (create-token-id { 'uri: "test-default-guard", 'precision: 0, 'policies: [marmalade-examples.soul-bound-policy-v1 marmalade-v2.guard-policy-v1] } ALWAYS-TRUE)
+    ,"account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+    ,"receiver": "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+  })
+
+  (expect-failure "transfer token fails"
+    "Transfer is not allowed!"
+    (transfer (read-msg 'token-id) (read-msg 'account) (read-msg 'receiver) 1.0 ))
+
+(rollback-tx)
+
+(begin-tx "Crosschain transfer fails on soul bound tokens")
+    (use marmalade-v2.ledger)
+    (use marmalade-examples.soul-bound-policy-v1)
+    (use mini-guard-utils)
+  (env-data {
+     "token-id": (create-token-id { 'uri: "test-default-guard", 'precision: 0, 'policies: [marmalade-examples.soul-bound-policy-v1 marmalade-v2.guard-policy-v1] } ALWAYS-TRUE)
+    ,"account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+    ,"receiver": "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+    ,"receiver-guard": {"keys": ["receiver"], "pred": "keys-all"}
+    ,"target-chain": "8"
+  })
+
+  (expect-failure "Fail to transfer"
+    "cross chain not supported"
+    (transfer-crosschain (read-msg 'token-id) (read-msg 'account) (read-msg 'receiver) (read-keyset 'receiver-guard ) (read-msg 'target-chain) 1.0))
+    
+(rollback-tx)
+
+(begin-tx "Sale fails on soul bound tokens")
+  (env-hash (hash "offer-0"))
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+  (env-chain-data {"block-time": (time "2023-07-20T11:26:35Z")})
+
+  (env-data {
+    "token-id": (create-token-id { 'uri: "test-default-guard", 'precision: 0, 'policies: [marmalade-examples.soul-bound-policy-v1 marmalade-v2.guard-policy-v1] } ALWAYS-TRUE)
+    ,"account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+    ,"account-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+    })
+
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+     ,'caps: [(marmalade-v2.ledger.OFFER (read-string "token-id") (read-string "account") 1.0 (to-timestamp (time "2023-07-08T11:26:35Z")))]}
+  ])
+
+  (expect-failure "offer fails"
+    "Sale is not allowed!"
+    (sale (read-string "token-id") (read-string "account") 1.0 (to-timestamp (time "2023-07-08T11:26:35Z")))
+  )
+  
+(rollback-tx)

--- a/pact-tests/pact-tests/marmalade/examples/policies/soul-bound-policy/soul-bound-policy.md
+++ b/pact-tests/pact-tests/marmalade/examples/policies/soul-bound-policy/soul-bound-policy.md
@@ -1,0 +1,38 @@
+# Soul Bound Policy
+
+Soul Bound Policy is an example module of Marmalade which provides a simple method to bind a token to an account (soul). In this context, a soul-bound token refers to a token that is uniquely associated with a specific account.
+
+This token can be initiated, minted, and burned but not sold or transferred.
+
+The token can be minted only once, even if the token is burned in the future.
+
+## Requirements:
+
+Concrete policy `guard-policy` must be used in conjunction with `soul-bound-policy` to make sure only an authorized account can mint and burn the token.
+
+## Specification, tables, capabilities:
+
+**Schemas**: `mint-record` is a schema that stores information related to the issuance of the token.
+  - `account`: refers to an owner of the token.
+
+**Tables**: `records` table stores token supply information.
+  - `id` is composed of token id and account
+
+**Capabilities**:
+ - `GOVERNANCE`: enforces access control of contract upgrades.
+
+## Policy Functions
+
+**`enforce-init`:** Enforced during `marmalade-v2.ledger.create-token`, and will ensure the `precision` is set to 0 and concrete `guard-policy` is present.
+
+**`enforce-mint`:** Enforced during `marmalade-v2.ledger.mint`, and will ensure that an account can only own one instance of a token at any given time and initiate `guard-policy` checks.
+
+**`enforce-burn`:** Enforced during `marmalade-v2.ledger.burn`, and will ensure the whole amount is burned.
+
+**`enforce-offer`:** Enforced during `marmalade-v2.ledger.offer`, and throws `Sale is not allowed!`.
+
+**`enforce-buy`:** Enforced during `marmalade-v2.ledger.buy`, and throws `Sale is not allowed!`.
+
+**`enforce-withdraw`:** Enforced during `marmalade-v2.ledger.withdraw`, and throws `Sale is not allowed!`.
+
+**`enforce-transfer`:** Enforced during `marmalade-v2.ledger.transfer`, and throws `Transfer is not allowed!`.

--- a/pact-tests/pact-tests/marmalade/examples/policies/timed-mint-policy/timed-mint-policy-v1.pact
+++ b/pact-tests/pact-tests/marmalade/examples/policies/timed-mint-policy/timed-mint-policy-v1.pact
@@ -1,0 +1,139 @@
+(namespace (read-msg 'ns))
+
+(module timed-mint-policy-v1 GOVERNANCE
+
+  @doc "Policy for timed-mint tokens with royalty and quoted sale in coin."
+
+  (defconst ADMIN-KS:string "marmalade-examples.timed-mint-policy")
+
+  (defcap GOVERNANCE ()
+    (enforce-guard ADMIN-KS))
+
+  (defconst POLICY:string (format "{}" [timed-mint-policy-v1]))
+
+  (implements kip.token-policy-v2)
+  (use kip.token-policy-v2 [token-info])
+  (use marmalade-v2.policy-manager)
+  (use marmalade-v2.util-v1 [curr-time])
+
+  (defschema timed-mint-schema
+    max-supply:decimal
+    mint-start-time:integer
+    mint-end-time:integer
+  )
+
+  (deftable timed-mint:{timed-mint-schema})
+
+  (defconst TIMED-MINT-SPEC:string "timed_mint_spec")
+
+  (defun validate-specs (spec:object{timed-mint-schema})
+    @doc "Enforce that the time windows and max supply conforms \
+    \to the contract requirements."
+
+    (let* ( (max-supply:decimal (at 'max-supply spec))
+            (mint-start-time:integer (at 'mint-start-time spec))
+            (mint-end-time:integer (at 'mint-end-time spec)) )
+
+      (enforce (>= max-supply 0.0) "Max supply must be non-negative")
+      (enforce (>= mint-end-time mint-start-time) "Mint end time must be after mint start time")
+      (enforce (>= mint-start-time (curr-time)) "Mint start time must be in the future") ))
+
+   (defun enforce-init:bool
+     ( token:object{token-info}
+     )
+     (require-capability (INIT-CALL (at "id" token) (at "precision" token) (at "uri" token) POLICY))
+     (let* ( (spec:object{timed-mint-schema} (read-msg TIMED-MINT-SPEC))
+             (max-supply:decimal (at 'max-supply spec))
+             (mint-start-time:integer (at 'mint-start-time spec))
+             (mint-end-time:integer (at 'mint-end-time spec))
+           )
+       (validate-specs spec)
+       (insert timed-mint (at 'id token)
+         { 'max-supply: max-supply
+         , 'mint-start-time:mint-start-time
+         , 'mint-end-time:mint-end-time
+         }))
+     true
+   )
+
+  (defun enforce-mint:bool
+    ( token:object{token-info}
+      account:string
+      guard:guard
+      amount:decimal
+    )
+    (require-capability (MINT-CALL (at "id" token) account amount POLICY))
+    (let* ( (account-bal:decimal (try 0.0 (at 'balance (marmalade-v2.ledger.details (at 'id token) account))))
+            (total-supply:decimal (try 0.0 (marmalade-v2.ledger.total-supply (at 'id token))))
+            (timed-mint:object{timed-mint-schema} (get-timed-mint token))
+            (max-supply:decimal (at 'max-supply timed-mint))
+            (mint-start-time:integer (at 'mint-start-time timed-mint))
+            (mint-end-time:integer (at 'mint-end-time timed-mint)) )
+      (enforce (= account-bal 0.0) "Account has already minted")
+      (enforce (>= (curr-time) mint-start-time) "Mint has not started yet")
+      (enforce (< (curr-time) mint-end-time) "Mint has ended")
+      (enforce (>= amount 0.0) "Mint amount must be positive")
+      (if (= max-supply 0.0) true [
+        (if (> total-supply 0.0) (enforce (!= max-supply total-supply) "Mint has reached max supply") true)
+        (enforce (<= (+ total-supply amount) max-supply) "Exceeds max supply")
+      ])
+      true
+    )
+  )
+
+  (defun get-timed-mint:object{timed-mint-schema} (token:object{token-info})
+    (read timed-mint (at 'id token))
+  )
+
+  (defun enforce-burn:bool
+    ( token:object{token-info}
+      account:string
+      amount:decimal
+    )
+    true
+  )
+
+  (defun enforce-offer:bool
+    ( token:object{token-info}
+      seller:string
+      amount:decimal
+      timeout:integer
+      sale-id:string )
+    true
+  )
+
+  (defun enforce-buy:bool
+    ( token:object{token-info}
+      seller:string
+      buyer:string
+      buyer-guard:guard
+      amount:decimal
+      sale-id:string )
+    true
+  )
+
+  (defun enforce-withdraw:bool
+    ( token:object{token-info}
+      seller:string
+      amount:decimal
+      timeout:integer
+      sale-id:string )
+    true
+  )
+
+  (defun enforce-transfer:bool
+    ( token:object{token-info}
+      sender:string
+      guard:guard
+      receiver:string
+      amount:decimal )
+    (enforce false "Transfer prohibited")
+  )
+)
+
+(if (read-msg 'upgrade)
+  true
+  (create-table timed-mint)
+)
+
+(enforce-guard ADMIN-KS)

--- a/pact-tests/pact-tests/marmalade/examples/policies/timed-mint-policy/timed-mint-policy-v1.repl
+++ b/pact-tests/pact-tests/marmalade/examples/policies/timed-mint-policy/timed-mint-policy-v1.repl
@@ -1,0 +1,201 @@
+
+;;load policy manager, ledger
+(load "../../../pact/marmalade.repl")
+
+(begin-tx "load timed mint policy")
+  (env-data {
+    "ns": "marmalade-examples"
+  , "timed-mint-policy": ["timed-mint-policy"]
+  , "upgrade": false}
+  )
+  (env-sigs [
+    { 'key: 'timed-mint-policy
+     ,'caps: []
+  }])
+
+  (ns.write-registry (read-msg 'ns) (read-keyset 'timed-mint-policy) true)
+  (define-namespace
+    (read-msg 'ns)
+    (read-keyset 'timed-mint-policy) (read-keyset 'timed-mint-policy)
+  )
+
+  (namespace (read-msg 'ns))
+
+  (define-keyset (+ (read-msg 'ns) ".timed-mint-policy") (read-keyset 'timed-mint-policy))
+  
+  (load "timed-mint-policy-v1.pact")
+  (typecheck "marmalade-examples.timed-mint-policy-v1")
+(commit-tx)
+
+
+(begin-tx "create timed mint token")
+
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-examples.timed-mint-policy-v1)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+  (env-chain-data {"block-time": (time "2023-07-08T12:00:00Z")})
+
+  ; validate start date
+  (env-data {
+    "token-id": (create-token-id { 'uri: "timed-mint-policy-v1-0", 'precision: 0, 'policies: [marmalade-examples.timed-mint-policy-v1] } ALWAYS-TRUE),
+    "timed_mint_spec": {
+        'max-supply: 0.0,
+        'mint-start-time: (to-timestamp (time "2023-07-06T12:00:00Z")),
+        'mint-end-time: (to-timestamp (time "2023-07-10T12:00:00Z")) } } )
+
+  (expect-failure "Fail if start date is in the past"
+      "Mint start time must be in the future"
+      (create-token (read-msg 'token-id) 0 "timed-mint-policy-v1-0" [marmalade-examples.timed-mint-policy-v1] ALWAYS-TRUE))
+
+  ; validate end date
+  (env-data {
+    "token-id": (create-token-id { 'uri: "timed-mint-policy-v1-0", 'precision: 0, 'policies: [marmalade-examples.timed-mint-policy-v1] } ALWAYS-TRUE),
+    "timed_mint_spec": {
+        'max-supply: 0.0,
+        'mint-start-time: (to-timestamp (time "2023-07-09T12:00:00Z")),
+        'mint-end-time: (to-timestamp (time "2023-07-06T12:00:00Z")) } } )
+
+  (expect-failure "Fail if end date is before the start date"
+      "Mint end time must be after mint start time"
+      (create-token (read-msg 'token-id) 0 "timed-mint-policy-v1-0" [marmalade-examples.timed-mint-policy-v1] ALWAYS-TRUE))
+
+  ; validate max-supply
+  (env-data {
+    "token-id": (create-token-id { 'uri: "timed-mint-policy-v1-0", 'precision: 0, 'policies: [marmalade-examples.timed-mint-policy-v1] } ALWAYS-TRUE),
+    "timed_mint_spec": {
+        'max-supply: -1.0,
+        'mint-start-time: (to-timestamp (time "2023-07-09T12:00:00Z")),
+        'mint-end-time: (to-timestamp (time "2023-07-10T12:00:00Z")) } } )
+
+  (expect-failure "Fail if max-supply is negative"
+      "Max supply must be non-negative"
+      (create-token (read-msg 'token-id) 0 "timed-mint-policy-v1-0" [marmalade-examples.timed-mint-policy-v1] ALWAYS-TRUE))
+
+  ; create token
+  (env-data {
+    "token-id": (create-token-id { 'uri: "timed-mint-policy-v1-0", 'precision: 0, 'policies: [marmalade-examples.timed-mint-policy-v1] } ALWAYS-TRUE),
+    "timed_mint_spec": {
+        'max-supply: 1.0,
+        'mint-start-time: (to-timestamp (time "2023-07-09T12:00:00Z")),
+        'mint-end-time: (to-timestamp (time "2023-07-10T12:00:00Z")) } } )
+
+  (expect "create a token with timed mint policy"
+    true
+    (create-token (read-msg 'token-id) 0 "timed-mint-policy-v1-0" [marmalade-examples.timed-mint-policy-v1] ALWAYS-TRUE))
+
+
+  (expect "create-token events"
+    [ {"name": "marmalade-v2.ledger.TOKEN","params": [(read-msg 'token-id) 0 [marmalade-examples.timed-mint-policy-v1] "timed-mint-policy-v1-0" ALWAYS-TRUE]} ]
+    (map (remove "module-hash")  (env-events true)))
+
+(commit-tx)
+
+
+(begin-tx "mint")
+
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-examples.timed-mint-policy-v1)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+  
+  (env-data {
+    "token-id": (create-token-id { 'uri: "timed-mint-policy-v1-0", 'precision: 0, 'policies: [marmalade-examples.timed-mint-policy-v1] } ALWAYS-TRUE)
+    ,"account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+    ,"account-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+  })
+
+  (env-sigs [
+    { 'key: 'account
+     ,'caps: [(marmalade-v2.ledger.MINT (read-msg 'token-id) (read-msg 'account) 1.0)]
+    }])
+
+  ; mint before start
+  (env-chain-data {"block-time": (time "2023-07-08T12:00:00Z")})
+
+  (expect-failure "Fail if mint before start"
+    "Mint has not started yet"
+    (mint (read-msg 'token-id) (read-msg 'account) (read-keyset 'account-guard ) 1.0))
+
+  ; mint after end
+  (env-chain-data {"block-time": (time "2023-07-12T12:00:00Z")})
+
+  (expect-failure "Fail if mint after end"
+    "Mint has ended"
+    (mint (read-msg 'token-id) (read-msg 'account) (read-keyset 'account-guard ) 1.0))
+    
+  ; mint before max-supply reached but would reach wit the amount minting
+  (env-chain-data {"block-time": (time "2023-07-09T15:00:00Z")})
+
+  (expect-failure "Fail if mint after end"
+    "Exceeds max supply"
+    (mint (read-msg 'token-id) (read-msg 'account) (read-keyset 'account-guard ) 3.0))
+
+  ; mint successfully
+  (env-chain-data {"block-time": (time "2023-07-09T15:00:00Z")})
+
+  (expect "Minted successfully"
+    true
+    (mint (read-msg 'token-id) (read-msg 'account) (read-keyset 'account-guard ) 1.0))
+
+  (expect "mint events"
+    [ {"name": "marmalade-v2.ledger.MINT","params": [(read-msg 'token-id) (read-msg 'account) 1.0]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-msg 'token-id) (read-msg 'account) (read-keyset 'account-guard)]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-msg 'token-id) 1.0 {"account": "","current": 0.0,"previous": 0.0} {"account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3","current": 1.0,"previous": 0.0}]} {"name": "marmalade-v2.ledger.SUPPLY","params": [(read-msg 'token-id) 1.0]}]
+    (map (remove "module-hash")  (env-events true)))
+
+  ; ensure only one mint per account
+  (env-chain-data {"block-time": (time "2023-07-09T15:00:00Z")})
+
+  (expect-failure "Fail if account had already minted"
+    "Account has already minted"
+    (mint (read-msg 'token-id) (read-msg 'account) (read-keyset 'account-guard ) 1.0))
+    
+  ; mint after max-supply reached
+  (env-chain-data {"block-time": (time "2023-07-09T15:00:00Z")})
+  (env-data {
+    "token-id": (create-token-id { 'uri: "timed-mint-policy-v1-0", 'precision: 0, 'policies: [marmalade-examples.timed-mint-policy-v1] } ALWAYS-TRUE)
+    ,"account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e32"
+    ,"account-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e32"], "pred": "keys-all"}
+  })
+  (env-sigs [
+    { 'key: 'account
+     ,'caps: [(marmalade-v2.ledger.MINT (read-msg 'token-id) (read-msg 'account) 1.0)]
+    }])
+
+  (expect-failure "Fail if mint has reached max supply"
+    "Mint has reached max supply"
+    (mint (read-msg 'token-id) (read-msg 'account) (read-keyset 'account-guard ) 1.0))
+
+(commit-tx)
+
+
+(begin-tx "fail transfer")
+
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-examples.timed-mint-policy-v1)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+
+  (env-data {
+    "token-id": (create-token-id { 'uri: "timed-mint-policy-v1-0", 'precision: 0, 'policies: [marmalade-examples.timed-mint-policy-v1] } ALWAYS-TRUE)
+    ,"account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+    ,"receiver": "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+    ,"receiver-guard": {"keys": ["receiver"], "pred": "keys-all"}
+    ,"target-chain": "8"
+  })
+
+  ; fail transfer
+  (expect-failure "Fail to transfer"
+    "Transfer prohibited"
+    (transfer (read-msg 'token-id) (read-msg 'account) (read-msg 'receiver) 1.0))
+
+  ; fail crosschain transfer
+  (expect-failure "Fail to transfer crosschain"
+  "cross chain not supported"
+  (transfer-crosschain (read-msg 'token-id) (read-msg 'account) (read-msg 'receiver) (read-keyset 'receiver-guard ) (read-msg 'target-chain) 1.0))
+
+(commit-tx)

--- a/pact-tests/pact-tests/marmalade/examples/policies/timed-mint-policy/timed-mint-policy.md
+++ b/pact-tests/pact-tests/marmalade/examples/policies/timed-mint-policy/timed-mint-policy.md
@@ -1,0 +1,35 @@
+# Timed Mint Policy
+
+The Timed Mint Policy is a module of Marmalade that enables the minting of tokens within a specific time window. This policy restricts the minting of tokens to a predefined period and provides control over the minting process.
+
+## Specification, tables, capabilities:
+
+**Schemas**: `timed-mint-schema` is a schema that store information related to the time window and max supply.
+   - `max-supply`: refers to the maximum number of supply that tokens can be minted to. If max-supply equals `0.0`, then the token is considered to have unlimited supply .
+   - `mint-start-time`: mint-start-time is the beginning of the minting time window.
+   - `mint-end-time`: mint-end-time is the end of the minting time window.
+
+**Tables**: `timed-mint` table stores time window and max supply information.
+
+**Capabilities**:
+- `GOVERNANCE`: Enforces access control of contract upgrades.
+
+## Policy Functions
+
+**`enforce-init`:** Requires `TIMED-MINT-SPEC` object to be included while calling `create-token`.
+
+**`enforce-mint`:** Enforced during the specified time window, throws `Minting is not allowed outside the time window!`.
+
+**`enforce-burn`:** Enabled without limitation.
+
+**`enforce-offer`:** Enabled without limitation.
+
+**`enforce-buy`:** Enabled without limitation.
+
+**`enforce-withdraw`:** Enabled without limitation.
+
+**`enforce-transfer`:** Enabled without limitation.
+
+## Custom Functions
+
+**`get-timed-mint`:** This function is used to retrieve time window and max supply

--- a/pact-tests/pact-tests/marmalade/pact/concrete-policies/collection-policy/collection-policy-v1.pact
+++ b/pact-tests/pact-tests/marmalade/pact/concrete-policies/collection-policy/collection-policy-v1.pact
@@ -1,0 +1,191 @@
+
+(namespace (read-string 'ns))
+
+(module collection-policy-v1 GOVERNANCE
+
+  @doc "Collection token policy."
+
+  (defconst ADMIN-KS:string "marmalade-v2.marmalade-contract-admin")
+  (defconst POLICY:string (format "{}" [collection-policy-v1]))
+
+  (defcap GOVERNANCE ()
+    (enforce-guard ADMIN-KS))
+
+  (implements kip.token-policy-v2)
+  (implements kip.updatable-uri-policy-v1)
+
+  (use marmalade-v2.policy-manager)
+  (use kip.token-policy-v2 [token-info])
+
+  (defschema collection
+    id:string
+    name:string
+    size:integer
+    max-size:integer
+    operator-guard:guard
+  )
+
+  (defschema token
+    id:string
+    collection-id:string
+  )
+
+  (deftable collections:{collection})
+  (deftable tokens:{token})
+
+  (defconst COLLECTION-ID-MSG-KEY:string "collection_id")
+
+  (defcap COLLECTION:bool (collection-id:string collection-name:string collection-size:integer operator-guard:guard)
+    @doc "Capability to grant creation of a collection and emit COLLECTION event for discovery"
+    @event
+    (enforce-guard operator-guard)
+  )
+
+  (defcap TOKEN-COLLECTION (collection-id:string token-id:string)
+    @doc "Capability to grant creation of a collection's token and emit TOKEN-COLLECTION event for discovery"
+    @event
+    (with-read collections collection-id {
+      'operator-guard:= operator-guard:guard
+      }
+      (enforce-guard operator-guard))
+  )
+
+  (defun create-collection:bool
+    ( collection-id:string
+      collection-name:string
+      collection-size:integer
+      operator-guard:guard
+      )
+      @doc "Executed directly on the policy, required to succeed before `create-token` \
+      \ step for collection tokens and emits COLLECTION event for discovery"
+      (enforce (>= collection-size 0) "Collection size must be positive")
+      (enforce (= collection-id (create-collection-id collection-name operator-guard) ) "collection id violation")
+      (with-capability (COLLECTION collection-id collection-name collection-size operator-guard)
+        (insert collections collection-id {
+        "id": collection-id
+        ,"name": collection-name
+        ,"max-size": collection-size
+        ,"size": 0
+        ,"operator-guard": operator-guard
+        })
+        true
+      )
+  )
+
+  (defun enforce-init:bool (token:object{token-info})
+    @doc "Executed at `create-token` step of marmalade.ledger.                 \
+    \ Required msg-data keys:                                                  \
+    \ * collection_id:string - registers the token to a collection and emits   \
+    \ TOKEN-COLLECTION event for collection token discovery"
+    (require-capability (INIT-CALL (at "id" token) (at "precision" token) (at "uri" token) POLICY))
+    (let* ( (token-id:string  (at 'id token))
+            (collection-id:string (read-msg COLLECTION-ID-MSG-KEY)) )
+    ;;Enforce operator guard
+    (with-capability (TOKEN-COLLECTION collection-id token-id)
+      (with-read collections collection-id {
+        "max-size":= max-size
+       ,"size":= size
+        }
+
+      ; max-size=0 means unlimited collection
+      (enforce (or? (= 0) (< size) max-size) "Exceeds collection size")
+
+      (update collections collection-id {
+        "size": (+ 1 size)
+      }))
+      (insert tokens token-id
+        { "id" : token-id
+         ,"collection-id" : collection-id
+      })
+      )
+    )
+    true
+  )
+
+  (defun enforce-mint:bool
+    ( token:object{token-info}
+      account:string
+      guard:guard
+      amount:decimal
+    )
+    true
+  )
+
+
+  (defun enforce-burn:bool
+    ( token:object{token-info}
+      account:string
+      amount:decimal
+    )
+    true
+  )
+
+  (defun enforce-offer:bool
+    ( token:object{token-info}
+      seller:string
+      amount:decimal
+      timeout:integer
+      sale-id:string
+    )
+    true
+  )
+
+  (defun enforce-buy:bool
+    ( token:object{token-info}
+      seller:string
+      buyer:string
+      buyer-guard:guard
+      amount:decimal
+      sale-id:string
+    )
+    true
+  )
+
+  (defun enforce-withdraw:bool
+    ( token:object{token-info}
+      seller:string
+      amount:decimal
+      timeout:integer
+      sale-id:string
+    )
+    true
+  )
+
+  (defun enforce-transfer:bool
+    ( token:object{token-info}
+      sender:string
+      guard:guard
+      receiver:string
+      amount:decimal
+    )
+    true
+  )
+
+
+  (defun enforce-update-uri:bool
+    ( token:object{token-info}
+      new-uri:string )
+      true
+  )
+  ;;UTILITY FUNCTIONS
+
+  (defun create-collection-id:string (collection-name:string operator-guard:guard)
+    (format "collection:{}" [(hash [collection-name operator-guard (at 'chain-id (chain-data))])])
+  )
+
+  (defun get-collection:object{collection} (collection-id:string )
+    (read collections collection-id)
+  )
+
+  (defun get-token:object{token} (token-id:string)
+    (read tokens token-id)
+  )
+
+)
+
+(if (read-msg 'upgrade )
+  ["upgrade complete"]
+  [ (create-table tokens)
+    (create-table collections) ])
+
+(enforce-guard ADMIN-KS)

--- a/pact-tests/pact-tests/marmalade/pact/concrete-policies/collection-policy/collection-policy-v1.repl
+++ b/pact-tests/pact-tests/marmalade/pact/concrete-policies/collection-policy/collection-policy-v1.repl
@@ -1,0 +1,276 @@
+;;load policy manager, ledger
+(load "../../policy-manager/policy-manager.repl")
+(typecheck "marmalade-v2.collection-policy-v1")
+
+(begin-tx)
+  (env-data {
+    "creator-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+  })
+  (coin.create-account "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3" (read-keyset 'creator-guard))
+(commit-tx)
+
+(begin-tx "Creating collection fails without operator guard")
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+  (env-data {
+    "operator-account": "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3",
+    "operator": {"keys": ["6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"], "pred": "keys-all"},
+    "collection-id": "collection:bJ-99z8hNtdyiLxS0LdS418oW90ck9dGd1t0w-LOAY4"
+  })
+
+ (expect-failure "create collection fails if operator guard isn't present"
+    "Keyset failure"
+    (marmalade-v2.collection-policy-v1.create-collection (read-msg "collection-id") "test-collection0" 10 (read-keyset 'operator)))
+
+(rollback-tx)
+
+(begin-tx "Creating collection with a non-principal account fails")
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+  (env-data {
+    "operator": {"keys": ["6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"], "pred": "keys-all"},
+    "collection-id" : "collection:bJ-99z8hNtdyiLxS0LdS418oW90ck9dGd1t0w-LOAY4"
+  })
+
+  (env-sigs [
+    { 'key: "6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+    ,'caps: [(marmalade-v2.collection-policy-v1.COLLECTION "collection:bJ-99z8hNtdyiLxS0LdS418oW90ck9dGd1t0w-LOAY4" "test-collection0" 10 (read-keyset 'operator ) )]
+    }])
+
+  (expect "Create a collection"
+    true
+    (marmalade-v2.collection-policy-v1.create-collection (read-msg "collection-id") "test-collection0" 10 (read-keyset 'operator ) ))
+(rollback-tx)
+
+(begin-tx "Creating collection")
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+  (env-data {
+    "token-id": (create-token-id { 'uri: "test-collection-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY)} ALWAYS-TRUE)
+  ,"account": "k:ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"
+  ,"account-guard": {"keys": ["ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"], "pred": "keys-all"}
+  ,"royalty_spec": {
+      "fungible": coin
+    ,"creator": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+    ,"creator-guard":  {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+    ,"royalty-rate": 0.05
+    }
+  ,"collection_id": "collection:bJ-99z8hNtdyiLxS0LdS418oW90ck9dGd1t0w-LOAY4"
+  ,"operator-account": "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+  ,"operator": {"keys": ["6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"], "pred": "keys-all"}
+  })
+
+  (expect "collection id generation based on name and operator"
+    "collection:bJ-99z8hNtdyiLxS0LdS418oW90ck9dGd1t0w-LOAY4"
+    (marmalade-v2.collection-policy-v1.create-collection-id "test-collection0" (read-keyset 'operator )))
+
+  (env-sigs [
+    { 'key: "6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+    ,'caps: [(marmalade-v2.collection-policy-v1.COLLECTION (read-msg "collection_id") "test-collection0" 10 (read-keyset 'operator ))]
+    }])
+
+  (expect "initiate a collection with `create-collection`"
+    true
+    (marmalade-v2.collection-policy-v1.create-collection (read-msg "collection_id") "test-collection0" 10 (read-keyset 'operator)))
+
+  (expect "create-collection events"
+    [ {"name": "marmalade-v2.collection-policy-v1.COLLECTION","params": ["collection:bJ-99z8hNtdyiLxS0LdS418oW90ck9dGd1t0w-LOAY4" "test-collection0" 10 (read-keyset 'operator) ]}]
+    (map (remove "module-hash")  (env-events true))
+  )
+(commit-tx)
+
+(begin-tx "Create token without operator guard fails")
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+
+  (env-sigs [])
+
+ (expect-failure "create token fails if operator guard isn't present"
+   "Keyset failure"
+   (create-token (read-msg 'token-id) 0 "test-collection-royalty-uri" (create-policies DEFAULT_COLLECTION_ROYALTY) ALWAYS-TRUE))
+
+(rollback-tx)
+
+(begin-tx "Create token")
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+
+  (env-sigs [
+    { 'key: "6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+    ,'caps: [(marmalade-v2.collection-policy-v1.TOKEN-COLLECTION "collection:bJ-99z8hNtdyiLxS0LdS418oW90ck9dGd1t0w-LOAY4" (read-msg 'token-id) )]
+    }])
+
+  (expect "create a default token with collection-policy, quote-policy, non-fungible-policy, royalty-policy"
+    true
+    (create-token (read-msg 'token-id) 0 "test-collection-royalty-uri" (create-policies DEFAULT_COLLECTION_ROYALTY) ALWAYS-TRUE))
+
+  (expect "create-token events"
+     [ {"name": "marmalade-v2.royalty-policy-v1.ROYALTY","params": [(read-msg 'token-id) (read-msg 'royalty_spec)]}
+       {"name": "marmalade-v2.collection-policy-v1.TOKEN-COLLECTION","params": ["collection:bJ-99z8hNtdyiLxS0LdS418oW90ck9dGd1t0w-LOAY4" (read-msg 'token-id)]}
+       {"name": "marmalade-v2.guard-policy-v1.GUARDS","params": [(read-msg 'token-id) {"burn-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"mint-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"sale-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"transfer-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS, "uri-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS}]}
+       {"name": "marmalade-v2.ledger.TOKEN","params": [(read-msg 'token-id) 0 [marmalade-v2.non-fungible-policy-v1 marmalade-v2.royalty-policy-v1 marmalade-v2.collection-policy-v1 marmalade-v2.guard-policy-v1] "test-collection-royalty-uri" ALWAYS-TRUE]} ]
+    (map (remove "module-hash")  (env-events true))
+  )
+(commit-tx)
+
+(begin-tx "Mint token without mint-guard fails")
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+
+  (env-sigs [
+    { 'key: 'ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c
+    ,'caps: [(marmalade-v2.ledger.MINT (read-msg 'token-id) (read-string 'account ) 1.0)]
+    }])
+
+  (expect "mint a default token with collection-policy, quote-policy, non-fungible-policy, royalty-policy"
+    true
+    (marmalade-v2.ledger.mint (read-msg 'token-id )  (read-string 'account) (read-keyset 'account-guard ) 1.0))
+
+  (expect "collection should be present and size should be updated"
+    {
+      "id": "collection:bJ-99z8hNtdyiLxS0LdS418oW90ck9dGd1t0w-LOAY4"
+      ,"name": "test-collection0"
+      ,"size": 1
+      ,"max-size": 10
+      ,"operator-guard": (read-keyset 'operator )
+    }
+    (marmalade-v2.collection-policy-v1.get-collection (read-msg 'collection_id)))
+
+  (expect "token should be part of collection"
+    {
+      "id": (read-msg 'token-id)
+     ,"collection-id": "collection:bJ-99z8hNtdyiLxS0LdS418oW90ck9dGd1t0w-LOAY4"
+    }
+    (marmalade-v2.collection-policy-v1.get-token (read-msg 'token-id))
+  )
+
+  (expect "mint events"
+     [ {"name": "marmalade-v2.ledger.MINT","params": [(read-msg 'token-id) (read-string 'account) 1.0]}
+       {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-msg 'token-id) (read-string 'account) (read-keyset 'account-guard)]}
+       {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-msg 'token-id) 1.0 {"account": "","current": 0.0,"previous": 0.0} {"account": (read-string 'account),"current": 1.0,"previous": 0.0}]}
+       {"name": "marmalade-v2.ledger.SUPPLY","params": [(read-msg 'token-id) 1.0]} ]
+    (map (remove "module-hash")  (env-events true))
+  )
+
+(commit-tx)
+
+(begin-tx "Creating collection and validate size")
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+
+  (env-data {
+    "token-id1": (create-token-id { 'uri: "test-collection-size-uri1", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY) } ALWAYS-TRUE )
+  ,"token-id2": (create-token-id { 'uri: "test-collection-size-uri2", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY) } ALWAYS-TRUE)
+  ,"account": "k:ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"
+  ,"account-guard": {"keys": ["ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"], "pred": "keys-all"}
+  ,"royalty_spec": {
+      "fungible": coin
+      ,"creator": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+      ,"creator-guard":  {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+    ,"royalty-rate": 0.05
+    }
+  ,"collection_id": "collection:i3ow_SSJWmzviydQ1pqxGhrXT6XU07DsXdtVCyLFsxw"
+  ,"operator": {"keys": ["6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"], "pred": "keys-all"}
+  })
+
+  (env-sigs [
+      { 'key: "6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+      ,'caps: [(marmalade-v2.collection-policy-v1.COLLECTION (read-string 'collection_id) "test-collection-size" 1 (read-keyset 'operator ))]
+      }])
+
+  (expect "initiate a collection with `create-collection`"
+    true
+    (marmalade-v2.collection-policy-v1.create-collection "collection:i3ow_SSJWmzviydQ1pqxGhrXT6XU07DsXdtVCyLFsxw" "test-collection-size" 1 (read-keyset 'operator) ))
+
+  (env-sigs [
+    { 'key: "6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+    ,'caps: [(marmalade-v2.collection-policy-v1.TOKEN-COLLECTION (read-string 'collection_id) (read-msg 'token-id1))
+             (marmalade-v2.collection-policy-v1.TOKEN-COLLECTION (read-string 'collection_id) (read-msg 'token-id2))]
+    }])
+
+  (expect "create a default token with collection-policy, quote-policy, non-fungible-policy, royalty-policy"
+    true
+    (create-token (read-msg 'token-id1) 0 "test-collection-size-uri1" (create-policies DEFAULT_COLLECTION_ROYALTY) ALWAYS-TRUE))
+
+  (expect-failure "creating another token will exceed collection-size"
+    "Exceeds collection size"
+    (create-token (read-msg 'token-id2) 0 "test-collection-size-uri2" (create-policies DEFAULT_COLLECTION_ROYALTY) ALWAYS-TRUE))
+
+  (expect "create-collection, create-token events"
+    [ {"name": "marmalade-v2.collection-policy-v1.COLLECTION","params": ["collection:i3ow_SSJWmzviydQ1pqxGhrXT6XU07DsXdtVCyLFsxw" "test-collection-size" 1 (read-keyset 'operator)  ]}
+      {"name": "marmalade-v2.royalty-policy-v1.ROYALTY","params": ["t:We0gk3NJYFd0k1B37NcDU7sqE_vfN6sdA2hvdzIc2xM" (read-msg 'royalty_spec)] }
+      {"name": "marmalade-v2.collection-policy-v1.TOKEN-COLLECTION","params": ["collection:i3ow_SSJWmzviydQ1pqxGhrXT6XU07DsXdtVCyLFsxw" "t:We0gk3NJYFd0k1B37NcDU7sqE_vfN6sdA2hvdzIc2xM"]}
+      {"name": "marmalade-v2.guard-policy-v1.GUARDS","params": ["t:We0gk3NJYFd0k1B37NcDU7sqE_vfN6sdA2hvdzIc2xM" {"burn-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"mint-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"sale-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"transfer-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS, "uri-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS}]}
+      {"name": "marmalade-v2.ledger.TOKEN","params": ["t:We0gk3NJYFd0k1B37NcDU7sqE_vfN6sdA2hvdzIc2xM" 0 [marmalade-v2.non-fungible-policy-v1 marmalade-v2.royalty-policy-v1 marmalade-v2.collection-policy-v1 marmalade-v2.guard-policy-v1] "test-collection-size-uri1" ALWAYS-TRUE]}]
+    (map (remove "module-hash")  (env-events true)))
+(rollback-tx)
+
+(begin-tx "Create collection with unlimited size and add two tokens")
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+
+  (env-data {
+    "token-id1": (create-token-id { 'uri: "test-collection-size-uri1", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY) } ALWAYS-TRUE)
+  ,"token-id2": (create-token-id { 'uri: "test-collection-size-uri2", 'precision: 0, 'policies: (create-policies DEFAULT_COLLECTION_ROYALTY) } ALWAYS-TRUE)
+  ,"account": "k:ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"
+  ,"account-guard": {"keys": ["ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"], "pred": "keys-all"}
+  ,"royalty_spec": {
+      "fungible": coin
+    ,"creator": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+    ,"creator-guard":  {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+    ,"royalty-rate": 0.05
+    }
+  ,"collection_id": "collection:i3ow_SSJWmzviydQ1pqxGhrXT6XU07DsXdtVCyLFsxw"
+  ,"operator": {"keys": ["6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"], "pred": "keys-all"}
+  })
+
+  (env-sigs [
+      { 'key: "6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+      ,'caps: [
+        (marmalade-v2.collection-policy-v1.COLLECTION (read-string 'collection_id) "test-collection-size" 0 (read-keyset 'operator )  )]
+      }])
+
+  (expect "initiate a collection with `create-collection`"
+    true
+    (marmalade-v2.collection-policy-v1.create-collection (read-msg "collection_id") "test-collection-size" 0 (read-keyset 'operator)))
+
+  (env-sigs [
+      { 'key: "6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+      ,'caps: [(marmalade-v2.collection-policy-v1.TOKEN-COLLECTION (read-string 'collection_id) (read-msg 'token-id1))
+               (marmalade-v2.collection-policy-v1.TOKEN-COLLECTION (read-string 'collection_id) (read-msg 'token-id2))]
+      }])
+
+  (expect "create a default token with collection-policy, quote-policy, non-fungible-policy, royalty-policy"
+    true
+    (create-token (read-msg 'token-id1) 0 "test-collection-size-uri1" (create-policies DEFAULT_COLLECTION_ROYALTY) ALWAYS-TRUE))
+
+  (expect "create another token with collection-policy, quote-policy, non-fungible-policy, royalty-policy"
+    true
+    (create-token (read-msg 'token-id2) 0 "test-collection-size-uri2" (create-policies DEFAULT_COLLECTION_ROYALTY) ALWAYS-TRUE))
+
+  (expect "create-collection, create-token events"
+    [ {"name": "marmalade-v2.collection-policy-v1.COLLECTION","params": ["collection:i3ow_SSJWmzviydQ1pqxGhrXT6XU07DsXdtVCyLFsxw" "test-collection-size" 0 (read-keyset 'operator) ]}
+      {"name": "marmalade-v2.royalty-policy-v1.ROYALTY","params": ["t:We0gk3NJYFd0k1B37NcDU7sqE_vfN6sdA2hvdzIc2xM" (read-msg 'royalty_spec) ]}
+      {"name": "marmalade-v2.collection-policy-v1.TOKEN-COLLECTION","params": ["collection:i3ow_SSJWmzviydQ1pqxGhrXT6XU07DsXdtVCyLFsxw" "t:We0gk3NJYFd0k1B37NcDU7sqE_vfN6sdA2hvdzIc2xM"]}
+      {"name": "marmalade-v2.guard-policy-v1.GUARDS","params": ["t:We0gk3NJYFd0k1B37NcDU7sqE_vfN6sdA2hvdzIc2xM" {"burn-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"mint-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"sale-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"transfer-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS, "uri-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS}]}
+      {"name": "marmalade-v2.ledger.TOKEN","params": ["t:We0gk3NJYFd0k1B37NcDU7sqE_vfN6sdA2hvdzIc2xM" 0 [marmalade-v2.non-fungible-policy-v1 marmalade-v2.royalty-policy-v1 marmalade-v2.collection-policy-v1 marmalade-v2.guard-policy-v1] "test-collection-size-uri1" ALWAYS-TRUE]}
+      {"name": "marmalade-v2.royalty-policy-v1.ROYALTY","params": ["t:djpXia3yvtko9EoOspAcJ9Y0gLo0775qREGgWsH7dFE" (read-msg 'royalty_spec) ]}
+      {"name": "marmalade-v2.collection-policy-v1.TOKEN-COLLECTION","params": ["collection:i3ow_SSJWmzviydQ1pqxGhrXT6XU07DsXdtVCyLFsxw" "t:djpXia3yvtko9EoOspAcJ9Y0gLo0775qREGgWsH7dFE"]}
+      {"name": "marmalade-v2.guard-policy-v1.GUARDS","params": ["t:djpXia3yvtko9EoOspAcJ9Y0gLo0775qREGgWsH7dFE" {"burn-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"mint-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"sale-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"transfer-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS, "uri-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS}]}
+      {"name": "marmalade-v2.ledger.TOKEN","params": ["t:djpXia3yvtko9EoOspAcJ9Y0gLo0775qREGgWsH7dFE" 0 [marmalade-v2.non-fungible-policy-v1 marmalade-v2.royalty-policy-v1 marmalade-v2.collection-policy-v1 marmalade-v2.guard-policy-v1] "test-collection-size-uri2" ALWAYS-TRUE]}]
+    (map (remove "module-hash")  (env-events true)))
+(rollback-tx)

--- a/pact-tests/pact-tests/marmalade/pact/concrete-policies/guard-policy/guard-policy-v1.pact
+++ b/pact-tests/pact-tests/marmalade/pact/concrete-policies/guard-policy/guard-policy-v1.pact
@@ -1,0 +1,275 @@
+
+(namespace (read-string 'ns))
+
+(module guard-policy-v1 GOVERNANCE
+
+  (defconst ADMIN-KS:string "marmalade-v2.marmalade-contract-admin")
+  (defconst POLICY:string (format "{}" [guard-policy-v1]))
+
+  (defcap GOVERNANCE ()
+    (enforce-guard ADMIN-KS))
+
+  (implements kip.token-policy-v2)
+  (implements kip.updatable-uri-policy-v1)
+
+  (use kip.token-policy-v2 [token-info])
+  (use marmalade-v2.policy-manager)
+
+  (defschema all-guards
+    mint-guard:guard
+    burn-guard:guard
+    sale-guard:guard
+    transfer-guard:guard
+    uri-guard:guard
+  )
+
+  (defschema guards
+    mint-guard:guard
+    burn-guard:guard
+    sale-guard:guard
+    transfer-guard:guard
+  )
+
+  (defschema uri-guard
+    uri-guard:guard
+  )
+
+  (deftable policy-guards:{guards})
+  (deftable uri-guards:{uri-guard})
+
+  (defconst MINT-GUARD-MSG-KEY:string "mint_guard")
+  (defconst BURN-GUARD-MSG-KEY:string "burn_guard")
+  (defconst SALE-GUARD-MSG-KEY:string "sale_guard")
+  (defconst TRANSFER-GUARD-MSG-KEY:string "transfer_guard")
+  (defconst URI-GUARD-MSG-KEY:string "uri_guard")
+
+  (defconst GUARD_SUCCESS:guard (create-user-guard (success)))
+  (defconst GUARD_FAILURE:guard (create-user-guard (failure)))
+
+  (defcap GUARDS:bool (token-id:string guards:object{all-guards})
+    @doc "Emits event for discovery"
+    @event
+    true
+  )
+
+  (defcap MINT (token-id:string account:string amount:decimal)
+    (enforce-guard (get-mint-guard token-id))
+  )
+
+  (defcap BURN (token-id:string account:string amount:decimal)
+    (enforce-guard (get-burn-guard token-id))
+  )
+
+  (defcap SALE (token-id:string seller:string amount:decimal)
+    (enforce-guard (get-sale-guard token-id))
+  )
+
+  (defcap TRANSFER (token-id:string sender:string receiver:string amount:decimal)
+    (enforce-guard (get-transfer-guard token-id))
+  )
+
+  (defcap UPDATE-URI (token-id:string new-uri:string)
+    (enforce-guard (get-uri-guard token-id))
+  )
+
+  (defun success:bool ()
+    true
+  )
+
+  (defun failure:bool ()
+    (enforce false "Disabled")
+    true
+  )
+
+  (defun get-mint-guard:guard (token-id:string)
+    (with-read policy-guards token-id {
+      'mint-guard:= mint-guard
+    }
+    mint-guard
+    )
+  )
+
+  (defun get-burn-guard:guard (token-id:string)
+    (with-read policy-guards token-id {
+      "burn-guard":= burn-guard
+    }
+    burn-guard
+    )
+  )
+
+  (defun get-sale-guard:guard (token-id:string)
+    (with-read policy-guards token-id {
+      "sale-guard":= sale-guard
+    }
+    sale-guard
+    )
+  )
+
+  (defun get-transfer-guard:guard (token-id:string)
+    (with-read policy-guards token-id {
+      "transfer-guard":= transfer-guard
+    }
+    transfer-guard
+    )
+  )
+
+  (defun get-uri-guard:guard (token-id:string)
+    (let ((version:integer (marmalade-v2.ledger.get-version token-id)))
+      (if (= version 0)
+        GUARD_FAILURE
+        (with-read uri-guards token-id
+          {
+            "uri-guard":= uri-guard
+          }
+          uri-guard
+        )
+      )
+    )
+  )
+
+  (defun get-guards:object{all-guards} (token:object{token-info})
+    (with-read policy-guards (at 'id token) {
+       'mint-guard:= mint-guard
+      ,'burn-guard:= burn-guard
+      ,'sale-guard:= sale-guard
+      ,'transfer-guard:= transfer-guard
+      }
+      (with-default-read uri-guards (at 'id token)
+        {'uri-guard: GUARD_FAILURE}
+        {'uri-guard:= uri-guard}
+      {'uri-guard: uri-guard
+      ,'mint-guard: mint-guard
+      ,'burn-guard: burn-guard
+      ,'sale-guard: sale-guard
+      ,'transfer-guard: transfer-guard
+      })
+    )
+  )
+
+  (defun enforce-init:bool
+    ( token:object{token-info}
+    )
+    @doc "Executed at `create-token` step of marmalade.ledger. Registers  guards for \
+    \ 'mint', 'burn', 'sale', 'transfer' operations of the created token.            \
+    \ Required msg-data keys:                                                        \
+    \ * (optional) uri-guard:string -  uri-guard and adds failure guard if absent. \
+    \ * (optional) mint_guard:string -  mint-guard and adds success guard if absent. \
+    \ * (optional) burn_guard:string -  burn-guard and adds success guard if absent. \
+    \ * (optional) sale_guard:string -  sale-guard and adds success guard if absent. \
+    \ * (optional) transfer_guard:string -  transfer-guard and adds success guard if absent. \
+    \ the created token"
+    (require-capability (INIT-CALL (at "id" token) (at "precision" token) (at "uri" token) POLICY))
+    (let ((guards:object{guards}
+          { 'mint-guard: (try GUARD_SUCCESS (read-msg MINT-GUARD-MSG-KEY) )
+          , 'burn-guard: (try GUARD_SUCCESS (read-msg BURN-GUARD-MSG-KEY) )
+          , 'sale-guard: (try GUARD_SUCCESS (read-msg SALE-GUARD-MSG-KEY) )
+          , 'transfer-guard: (try GUARD_SUCCESS (read-msg TRANSFER-GUARD-MSG-KEY) ) } )
+          (uri-guard:object{uri-guard}
+            { 'uri-guard: (try GUARD_SUCCESS (read-msg URI-GUARD-MSG-KEY) ) }))
+      (insert policy-guards (at 'id token)
+        guards)
+      (insert uri-guards (at 'id token)
+        uri-guard)
+      (emit-event (GUARDS (at "id" token) (+ uri-guard guards))) )
+      true
+  )
+
+  (defun enforce-mint:bool
+    ( token:object{token-info}
+      account:string
+      guard:guard
+      amount:decimal
+    )
+    (require-capability (MINT-CALL (at "id" token) account amount POLICY))
+    (with-capability (MINT (at 'id token) account amount)
+      true
+    )
+  )
+
+  (defun enforce-burn:bool
+    ( token:object{token-info}
+      account:string
+      amount:decimal
+    )
+    (require-capability (BURN-CALL (at "id" token) account amount POLICY))
+    (with-capability (BURN (at 'id token) account amount)
+      true
+    )
+  )
+
+  (defun enforce-offer:bool
+    ( token:object{token-info}
+      seller:string
+      amount:decimal
+      timeout:integer
+      sale-id:string )
+    (require-capability (OFFER-CALL (at "id" token) seller amount sale-id timeout POLICY))
+    (enforce-sale-pact sale-id)
+    (with-capability (SALE (at 'id token) seller amount)
+      true
+    )
+  )
+
+  (defun enforce-buy:bool
+    ( token:object{token-info}
+      seller:string
+      buyer:string
+      buyer-guard:guard
+      amount:decimal
+      sale-id:string )
+    (require-capability (BUY-CALL (at "id" token) seller buyer amount sale-id POLICY))
+    (enforce-sale-pact sale-id)
+    (with-capability (SALE (at 'id token) seller amount)
+      true
+    )
+  )
+
+  (defun enforce-withdraw:bool
+    ( token:object{token-info}
+      seller:string
+      amount:decimal
+      timeout:integer
+      sale-id:string )
+    (require-capability (WITHDRAW-CALL (at "id" token) seller amount sale-id timeout POLICY))
+    (enforce-sale-pact sale-id)
+    (with-capability (SALE (at 'id token) seller amount)
+      true
+    )
+  )
+
+  (defun enforce-transfer:bool
+    ( token:object{token-info}
+      sender:string
+      guard:guard
+      receiver:string
+      amount:decimal )
+    (require-capability (TRANSFER-CALL (at "id" token) sender receiver amount POLICY))
+    (with-capability (TRANSFER (at 'id token) sender receiver amount)
+      true
+    )
+  )
+
+  (defun enforce-update-uri:bool
+    ( token:object{token-info}
+      new-uri:string )
+    (require-capability (UPDATE-URI-CALL (at "id" token) new-uri POLICY))
+    (with-capability (UPDATE-URI (at 'id token) new-uri)
+      true
+    )
+  )
+
+  (defun enforce-sale-pact:bool (sale-id:string)
+    "Enforces that SALE is id for currently executing pact"
+    (enforce (= sale-id (pact-id)) "Invalid pact/sale id")
+  )
+)
+
+(if (read-msg 'upgrade )
+  (if (read-msg 'upgrade_version_1 )
+    [ (create-table uri-guards) ]
+    ["upgrade complete"]
+  )
+  [ (create-table policy-guards) ]
+)
+
+(enforce-guard ADMIN-KS)

--- a/pact-tests/pact-tests/marmalade/pact/concrete-policies/guard-policy/guard-policy-v1.repl
+++ b/pact-tests/pact-tests/marmalade/pact/concrete-policies/guard-policy/guard-policy-v1.repl
@@ -1,0 +1,147 @@
+;;load policy manager, ledger
+(load "../../policy-manager/policy-manager.repl")
+(typecheck "marmalade-v2.guard-policy-v1")
+
+(begin-tx "Create token without mint guard")
+    (use marmalade-v2.ledger)
+    (use marmalade-v2.guard-policy-v1)
+    (use marmalade-v2.util-v1)
+    (use mini-guard-utils)
+  (env-data {
+     "token-id": (create-token-id { 'uri: "test-default-guard", 'precision: 0, 'policies: (create-policies DEFAULT) } ALWAYS-TRUE)
+    ,"account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+    ,"account-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+  })
+
+  (env-sigs [
+    { 'key: 'account
+     ,'caps: [(marmalade-v2.ledger.MINT (read-msg 'token-id) (read-string 'account) 1.0)]
+    }])
+
+  (expect "create token succeeds without mint-guard"
+    true
+    (create-token (read-msg 'token-id) 0 "test-default-guard" (create-policies DEFAULT) ALWAYS-TRUE))
+
+  (expect "Mint token succeeds without mint-guard"
+    true
+    (mint (read-msg 'token-id) (read-msg 'account) (read-keyset 'account-guard ) 1.0))
+
+  (expect "create-token, mint events"
+    [ {"name": "marmalade-v2.guard-policy-v1.GUARDS","params": [(read-msg 'token-id) {"burn-guard": GUARD_SUCCESS,"mint-guard": GUARD_SUCCESS,"sale-guard": GUARD_SUCCESS,"transfer-guard": GUARD_SUCCESS, "uri-guard": GUARD_SUCCESS}]}
+      {"name": "marmalade-v2.ledger.TOKEN","params": [(read-msg 'token-id) 0 [marmalade-v2.non-fungible-policy-v1 marmalade-v2.guard-policy-v1] "test-default-guard" ALWAYS-TRUE]}
+      {"name": "marmalade-v2.ledger.MINT","params": [(read-msg 'token-id) (read-string 'account) 1.0]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-msg 'token-id) (read-string 'account) (read-keyset 'account-guard)]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-msg 'token-id) 1.0 {"account": "","current": 0.0,"previous": 0.0} {"account": (read-string 'account),"current": 1.0,"previous": 0.0}]} {"name": "marmalade-v2.ledger.SUPPLY","params": [(read-msg 'token-id) 1.0]}]
+    (map (remove "module-hash")  (env-events true)))
+
+ (rollback-tx)
+
+(begin-tx "Create token without operator guard fails")
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.guard-policy-v1)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+  (env-data {
+     "token-id": (create-token-id { 'uri: "test-default-guard", 'precision: 0, 'policies: (create-policies DEFAULT) } ALWAYS-TRUE)
+    ,"account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+    ,"mint_guard": {"keys": ["mint"], "pred": "keys-all"}
+    ,"account-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+  })
+
+  (expect "create token succeeds with mint-guard"
+   true
+   (create-token (read-msg 'token-id) 0 "test-default-guard" (create-policies DEFAULT) ALWAYS-TRUE))
+
+   (env-sigs [
+     { 'key: 'mint-false
+      ,'caps: [ (marmalade-v2.ledger.MINT (read-msg 'token-id) (read-string 'account) 1.0)
+                (marmalade-v2.guard-policy-v1.MINT (read-msg 'token-id) (read-string 'account) 1.0)]
+     }])
+
+  (expect-failure "Mint token fails without mint-guard"
+    "Keyset failure"
+    (mint (read-msg 'token-id) (read-msg 'account) (read-keyset 'account-guard ) 1.0))
+
+  (env-sigs [
+    { 'key: 'mint
+     ,'caps: [(marmalade-v2.ledger.MINT (read-msg 'token-id) (read-string 'account) 1.0)
+              (marmalade-v2.guard-policy-v1.MINT (read-msg 'token-id) (read-string 'account) 1.0)
+     ]
+    }])
+
+  (expect "Mint token succeeds with mint-guard"
+    true
+    (mint (read-msg 'token-id) (read-msg 'account) (read-keyset 'account-guard ) 1.0))
+
+  (env-sigs [
+    { 'key: 'any
+     ,'caps: [(marmalade-v2.ledger.UPDATE-URI (read-msg 'token-id) "updated-uri")]
+    }])
+
+  (expect "update uri succeeds without a signature when token is created with a guards policy without uri-guard attached"
+    true
+    (marmalade-v2.ledger.update-uri (read-msg 'token-id) "updated-uri")
+  )
+
+  (expect "create-token, mint events"
+    [ {"name": "marmalade-v2.guard-policy-v1.GUARDS","params": [(read-msg 'token-id) {"burn-guard": GUARD_SUCCESS,"mint-guard": (read-keyset 'mint_guard),"sale-guard": GUARD_SUCCESS,"transfer-guard": GUARD_SUCCESS, "uri-guard": GUARD_SUCCESS}]}
+      {"name": "marmalade-v2.ledger.TOKEN","params": [(read-msg 'token-id) 0 [marmalade-v2.non-fungible-policy-v1 marmalade-v2.guard-policy-v1] "test-default-guard" ALWAYS-TRUE]}
+      {"name": "marmalade-v2.ledger.MINT","params": [(read-msg 'token-id) (read-string 'account) 1.0]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-msg 'token-id) (read-string 'account) (read-keyset 'account-guard)]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-msg 'token-id) 1.0 {"account": "","current": 0.0,"previous": 0.0} {"account": (read-string 'account),"current": 1.0,"previous": 0.0}]}
+      {"name": "marmalade-v2.ledger.SUPPLY","params": [(read-msg 'token-id) 1.0]}
+      {"name": "marmalade-v2.ledger.UPDATE-URI","params": [(read-msg 'token-id) "updated-uri"]}]
+    (map (remove "module-hash")  (env-events true)))
+(commit-tx)
+
+(begin-tx "Create token without operator guard fails")
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.guard-policy-v1)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+  (env-data {
+     "token-id": (create-token-id { 'uri: "test-uri-guard", 'precision: 0, 'policies: (create-policies DEFAULT) } ALWAYS-TRUE)
+    ,"account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+    ,"uri_guard": {"keys": ["uri"], "pred": "keys-all"}
+    ,"account-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+  })
+
+  (expect "create token succeeds with uri-guard"
+   true
+   (create-token (read-msg 'token-id) 0 "test-uri-guard" (create-policies DEFAULT) ALWAYS-TRUE))
+
+  (expect "create token succeeds with uri-guard"
+    (read-keyset 'uri_guard )
+    (get-uri-guard (read-msg 'token-id )))
+
+  (expect "get-guards returns all-guards object"
+    {'uri-guard: (read-keyset 'uri_guard )
+    ,'mint-guard: GUARD_SUCCESS
+    ,'burn-guard: GUARD_SUCCESS
+    ,'transfer-guard: GUARD_SUCCESS
+    ,'sale-guard: GUARD_SUCCESS
+    }
+    (get-guards (marmalade-v2.ledger.get-token-info (read-msg 'token-id ))))
+
+   (env-sigs [
+     { 'key: 'uri
+      ,'caps: [ (marmalade-v2.ledger.UPDATE-URI (read-msg 'token-id) "updated-uri")
+                (marmalade-v2.guard-policy-v1.UPDATE-URI (read-msg 'token-id) "updated-uri")]
+     }])
+
+  (expect "update uri succeeds regardless of token owner, or supply"
+    true
+    (marmalade-v2.ledger.update-uri (read-msg 'token-id) "updated-uri")
+  )
+
+  (expect "URI is updated on ledger"
+    "updated-uri"
+    (marmalade-v2.ledger.get-uri (read-msg 'token-id) )
+  )
+
+  (expect "create-token, mint events"
+    [{"name": "marmalade-v2.guard-policy-v1.GUARDS","params": [(read-msg 'token-id) {"burn-guard": GUARD_SUCCESS,"mint-guard": GUARD_SUCCESS,"sale-guard": GUARD_SUCCESS,"transfer-guard": GUARD_SUCCESS, "uri-guard": (read-keyset 'uri_guard)}]}
+     {"name": "marmalade-v2.ledger.TOKEN","params": [(read-msg 'token-id) 0 [marmalade-v2.non-fungible-policy-v1 marmalade-v2.guard-policy-v1] "test-uri-guard" mini-guard-utils.ALWAYS-TRUE]}
+     {"name": "marmalade-v2.ledger.UPDATE-URI","params": [(read-msg 'token-id) "updated-uri"]}]
+    (map (remove "module-hash")  (env-events true)))
+(commit-tx)

--- a/pact-tests/pact-tests/marmalade/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.pact
+++ b/pact-tests/pact-tests/marmalade/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.pact
@@ -1,0 +1,92 @@
+(namespace (read-string 'ns))
+
+(module non-fungible-policy-v1 GOVERNANCE
+
+  @doc "Concrete policy for issuing an nft with a fixed supply of 1 and precision of 0"
+
+  (defconst ADMIN-KS:string "marmalade-v2.marmalade-contract-admin")
+  (defconst POLICY:string (format "{}" [non-fungible-policy-v1]))
+
+  (defcap GOVERNANCE ()
+    (enforce-guard ADMIN-KS))
+
+  (implements kip.token-policy-v2)
+  (implements kip.updatable-uri-policy-v1)
+
+  (use marmalade-v2.policy-manager)
+  (use kip.token-policy-v2 [token-info])
+
+  (defun enforce-init:bool
+    ( token:object{token-info}
+    )
+    (require-capability (INIT-CALL (at "id" token) (at "precision" token) (at "uri" token) POLICY))
+    (enforce (= 0 (at 'precision token)) "Precision must be 0")
+    true
+  )
+
+  (defun enforce-mint:bool
+    ( token:object{token-info}
+      account:string
+      guard:guard
+      amount:decimal
+    )
+    (require-capability (MINT-CALL (at "id" token) account amount POLICY))
+    (enforce (= amount 1.0) "Mint can only be 1")
+    (enforce (= (at 'supply token) 0.0) "Only one mint allowed")
+  )
+
+  (defun enforce-burn:bool
+    ( token:object{token-info}
+      account:string
+      amount:decimal
+    )
+    (enforce false "Burn prohibited")
+  )
+
+  (defun enforce-offer:bool
+    ( token:object{token-info}
+      seller:string
+      amount:decimal
+      timeout:integer
+      sale-id:string
+    )
+    true
+  )
+
+  (defun enforce-buy:bool
+    ( token:object{token-info}
+      seller:string
+      buyer:string
+      buyer-guard:guard
+      amount:decimal
+      sale-id:string )
+    true
+  )
+
+  (defun enforce-withdraw:bool
+    ( token:object{token-info}
+      seller:string
+      amount:decimal
+      timeout:integer
+      sale-id:string )
+    true
+  )
+
+  (defun enforce-transfer:bool
+    ( token:object{token-info}
+      sender:string
+      guard:guard
+      receiver:string
+      amount:decimal )
+    true
+  )
+
+  (defun enforce-update-uri:bool
+    ( token:object{token-info}
+      new-uri:string )
+      true
+  )
+
+)
+
+(enforce-guard ADMIN-KS)

--- a/pact-tests/pact-tests/marmalade/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.repl
+++ b/pact-tests/pact-tests/marmalade/pact/concrete-policies/non-fungible-policy/non-fungible-policy-v1.repl
@@ -1,0 +1,130 @@
+;;load policy manager, ledger
+(load "../../policy-manager/policy-manager.repl")
+(typecheck "marmalade-v2.non-fungible-policy-v1")
+
+(begin-tx)
+  (use marmalade-v2.policy-manager [ NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY])
+  (use marmalade-v2.util-v1 [concrete-policy-bool])
+  (use mini-guard-utils)
+
+  (module util GOV
+    (defcap GOV () true)
+
+    (defconst DEFAULT_NON_FUNGIBLE_CONCRETE_POLICY:object{concrete-policy-bool}
+      { 'non-fungible-policy: true
+       ,'royalty-policy: false
+       ,'collection-policy:false
+       ,'guard-policy: true
+      }
+    )
+  )
+(commit-tx)
+
+(begin-tx)
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+  (env-data {
+    "creator-account": "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3",
+    "creator-guard": {"keys": ["6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"], "pred": "keys-all"}
+  })
+  (marmalade-v2.abc.create-account (read-string "creator-account") (read-keyset 'creator-guard))
+(commit-tx)
+
+(begin-tx "Create a non-fungible token fails when precision is not 0")
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+
+  (env-data {
+    "token-id": (create-token-id { 'uri: "test-non-fungible-uri", 'precision: 1, 'policies: (create-policies util.DEFAULT_NON_FUNGIBLE_CONCRETE_POLICY) } ALWAYS-TRUE)
+    ,"account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+    ,"mint-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+  })
+
+  (expect-failure  "Precision should be 0"
+    (create-token (read-msg "token-id") 0 "test-non-fungible-uri" (create-policies util.DEFAULT_NON_FUNGIBLE_CONCRETE_POLICY) ALWAYS-TRUE))
+
+(rollback-tx)
+
+
+(begin-tx "Create a non-fungible token")
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.guard-policy-v1)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+  (env-data {
+    "token-id": (create-token-id { 'uri: "test-non-fungible-uri", 'precision: 0, 'policies: (create-policies util.DEFAULT_NON_FUNGIBLE_CONCRETE_POLICY) } ALWAYS-TRUE)
+    ,"account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+    ,"mint-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+  })
+
+(expect  "create-token succeeds with non-fungible-policy"
+   true
+  (create-token (read-msg "token-id") 0 "test-non-fungible-uri" (create-policies util.DEFAULT_NON_FUNGIBLE_CONCRETE_POLICY) ALWAYS-TRUE))
+
+(expect "create-token events"
+   [ {"name": "marmalade-v2.guard-policy-v1.GUARDS","params": [(read-msg 'token-id) {"burn-guard": GUARD_SUCCESS,"mint-guard": GUARD_SUCCESS,"sale-guard": GUARD_SUCCESS,"transfer-guard": GUARD_SUCCESS, "uri-guard": GUARD_SUCCESS}]}
+     {"name": "marmalade-v2.ledger.TOKEN","params": [(read-msg 'token-id) 0 [marmalade-v2.non-fungible-policy-v1 marmalade-v2.guard-policy-v1] "test-non-fungible-uri" ALWAYS-TRUE]}]
+  (map (remove "module-hash")  (env-events true)))
+(commit-tx)
+
+(begin-tx "Mint with a supply other then 1 fails ")
+
+  (use marmalade-v2.ledger)
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+     ,'caps: [(marmalade-v2.ledger.MINT (read-msg 'token-id) "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3" 5.0)
+    ]
+    }])
+
+  (expect-failure "minting with amount of 5 fails"
+    "Mint can only be 1"
+    (mint (read-msg "token-id" )  (read-msg "account" ) (read-keyset "mint-guard" ) 5.0))
+
+(commit-tx)
+
+(begin-tx "Mint with a fractional amount fails ")
+  (use marmalade-v2.ledger)
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+    ,'caps: [(marmalade-v2.ledger.MINT (read-msg 'token-id) "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3" 0.5)]
+    }])
+
+  (expect-failure "minting with amout of 0.5 fails"
+    "Mint can only be 1"
+    (mint (read-msg "token-id" )  (read-msg "account" ) (read-keyset "mint-guard" ) 0.5))
+(commit-tx)
+
+(begin-tx "Mint with amount of 1 succeeds")
+  (use marmalade-v2.ledger)
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+    ,'caps: [(marmalade-v2.ledger.MINT (read-msg 'token-id) (read-string "account") 1.0)
+             (marmalade-v2.guard-policy-v1.MINT (read-msg 'token-id) (read-string "account" ) 1.0)
+            ]
+    }])
+
+  (expect "minting succeeds"
+    true
+    (mint (read-msg "token-id" )  (read-msg "account" ) (read-keyset "mint-guard" ) 1.0))
+
+  (expect "mint events"
+   [ {"name": "marmalade-v2.ledger.MINT","params": [(read-msg 'token-id) (read-string "account") 1.0]}
+     {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-msg 'token-id) (read-string "account") (read-keyset 'mint-guard)]}
+     {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-msg 'token-id) 1.0 {"account": "","current": 0.0,"previous": 0.0} {"account": (read-string "account" ),"current": 1.0,"previous": 0.0}]}
+     {"name": "marmalade-v2.ledger.SUPPLY","params": [(read-msg 'token-id) 1.0]}]
+    (map (remove "module-hash")  (env-events true)))
+(commit-tx)
+
+(begin-tx "Burn a non-fungible token")
+  (use marmalade-v2.ledger)
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+    ,'caps: [(marmalade-v2.ledger.BURN (read-msg 'token-id) (read-string "account") 1.0)]
+    }])
+
+  (expect-failure "Burning is not allowed"
+    "Burn prohibited"
+    (burn (read-msg "token-id" )  (read-string "account") 1.0))
+(commit-tx)

--- a/pact-tests/pact-tests/marmalade/pact/concrete-policies/royalty-policy/royalty-policy-v1.pact
+++ b/pact-tests/pact-tests/marmalade/pact/concrete-policies/royalty-policy/royalty-policy-v1.pact
@@ -1,0 +1,179 @@
+(namespace (read-string 'ns))
+
+(module royalty-policy-v1 GOVERNANCE
+
+  @doc "Concrete policy to support royalty payouts in a specified fungible during sale."
+
+  (defconst ADMIN-KS:string "marmalade-v2.marmalade-contract-admin")
+  (defconst POLICY:string (format "{}" [royalty-policy-v1]))
+
+  (defcap GOVERNANCE ()
+    (enforce-guard ADMIN-KS))
+
+  (use marmalade-v2.policy-manager)
+  (use marmalade-v2.policy-manager [QUOTE-MSG-KEY quote-spec quote-schema])
+  (use kip.token-policy-v2 [token-info])
+
+  (implements kip.token-policy-v2)
+  (implements kip.updatable-uri-policy-v1)
+
+  (defschema royalty-schema
+    fungible:module{fungible-v2}
+    creator:string
+    creator-guard:guard
+    royalty-rate:decimal
+  )
+
+  (deftable royalties:{royalty-schema})
+
+  (defconst ROYALTY-SPEC-MSG-KEY "royalty_spec"
+    @doc "Payload field for royalty spec")
+
+  (defcap ROYALTY:bool (token-id:string royalty_spec:object{royalty-schema})
+    @doc "Emits event with royalty information for discovery"
+    @event
+    true
+  )
+
+  (defcap ROYALTY-PAYOUT:bool
+    ( sale-id:string
+      token-id:string
+      royalty-payout:decimal
+      creator:string
+    )
+    @doc "Emits event with royalty payout information at sale's completion"
+    @event
+    true
+  )
+
+  (defun get-royalty:object{royalty-schema} (token:object{token-info})
+    (read royalties (at 'id token))
+  )
+
+  (defun enforce-init:bool
+    ( token:object{token-info}
+    )
+    @doc "Executed at `create-token` step of marmalade.ledger.      \
+    \ Required msg-data keys:                                                  \
+    \ * royalty_spec:object{royalty-schema} - registers royalty information of \
+    \ the created token"
+    (require-capability (INIT-CALL (at "id" token) (at "precision" token) (at "uri" token) POLICY))
+    (let* ( (spec:object{royalty-schema} (read-msg ROYALTY-SPEC-MSG-KEY))
+            (fungible:module{fungible-v2} (at 'fungible spec))
+            (creator:string (at 'creator spec))
+            (creator-guard:guard (at 'creator-guard spec))
+            (royalty-rate:decimal (at 'royalty-rate spec))
+            (creator-details:object (fungible::details creator ))
+            )
+      (enforce (= (format "{}" [fungible]) (format "{}" [coin]))
+        "Royalty support is restricted to coin")
+      (enforce (=
+        (at 'guard creator-details) creator-guard)
+        "Creator guard does not match")
+      (enforce (and
+        (>= royalty-rate 0.0) (<= royalty-rate 1.0))
+        "Invalid royalty rate")
+      (insert royalties (at 'id token)
+        { 'fungible: fungible
+        , 'creator: creator
+        , 'creator-guard: creator-guard
+        , 'royalty-rate: royalty-rate
+        })
+      (emit-event (ROYALTY (at 'id token) spec)))
+  )
+
+  (defun enforce-mint:bool
+    ( token:object{token-info}
+      account:string
+      guard:guard
+      amount:decimal
+    )
+    true
+  )
+
+  (defun enforce-burn:bool
+    ( token:object{token-info}
+      account:string
+      amount:decimal
+    )
+    (enforce false "Burn prohibited")
+  )
+
+  (defun enforce-offer:bool
+    ( token:object{token-info}
+      seller:string
+      amount:decimal
+      timeout:integer
+      sale-id:string
+    )
+    @doc "Capture quote spec for SALE of TOKEN from message"
+    (require-capability (OFFER-CALL (at "id" token) seller amount sale-id timeout POLICY))
+    (enforce (exists-msg-quote QUOTE-MSG-KEY) "Offer is restricted to quoted sale")
+    (bind (get-royalty token)
+      { 'fungible := fungible:module{fungible-v2} }
+      (let* (
+          (quote-spec:object{quote-spec} (read-msg QUOTE-MSG-KEY)) )
+        (enforce (= fungible (at 'fungible quote-spec)) (format "Offer is restricted to sale using fungible: {}" [fungible]))
+      )
+    )
+  )
+
+  (defun enforce-buy:bool
+    ( token:object{token-info}
+      seller:string
+      buyer:string
+      buyer-guard:guard
+      amount:decimal
+      sale-id:string )
+    (require-capability (BUY-CALL (at "id" token) seller buyer amount sale-id POLICY))
+    (enforce-sale-pact sale-id)
+    (bind (get-royalty token)
+      { 'fungible := fungible:module{fungible-v2}
+      , 'creator:= creator:string
+      , 'royalty-rate:= royalty-rate:decimal
+      }
+      (let* ( (quote-spec:object{quote-schema} (get-quote-info sale-id))
+              (sale-price:decimal (at 'sale-price quote-spec))
+              (escrow-account:string (at 'account (get-escrow-account sale-id)))
+              (royalty-payout:decimal
+                 (floor (* sale-price royalty-rate) (fungible::precision))))
+        (if
+          (> royalty-payout 0.0)
+          (let ((_ ""))
+            (install-capability (fungible::TRANSFER escrow-account creator sale-price))
+            (emit-event (ROYALTY-PAYOUT sale-id (at 'id token) royalty-payout creator))
+            (fungible::transfer escrow-account creator royalty-payout))
+          "No royalty"
+          )))
+        true)
+
+  (defun enforce-withdraw:bool
+    ( token:object{token-info}
+      seller:string
+      amount:decimal
+      timeout:integer
+      sale-id:string )
+    true
+  )
+
+  (defun enforce-transfer:bool
+    ( token:object{token-info}
+      sender:string
+      guard:guard
+      receiver:string
+      amount:decimal )
+    (enforce false "Transfer prohibited")
+  )
+
+  (defun enforce-update-uri:bool
+    ( token:object{token-info}
+      new-uri:string )
+    true
+  )
+)
+
+(if (read-msg 'upgrade)
+  ["upgrade complete"]
+  [ (create-table royalties)])
+
+(enforce-guard ADMIN-KS)

--- a/pact-tests/pact-tests/marmalade/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
+++ b/pact-tests/pact-tests/marmalade/pact/concrete-policies/royalty-policy/royalty-policy-v1.repl
@@ -1,0 +1,495 @@
+;;load policy manager, ledger
+(load "../../policy-manager/policy-manager.repl")
+(typecheck "marmalade-v2.royalty-policy-v1")
+
+(begin-tx)
+  (use marmalade-v2.policy-manager [concrete-policy concrete-policy])
+  (use marmalade-v2.ledger)
+
+  (env-data {
+    "creator-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"},
+    "bad-actor-guard": {"keys": ["6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"], "pred": "keys-all"}
+  })
+
+  (marmalade-v2.abc.create-account "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3" (read-keyset 'creator-guard))
+  (marmalade-v2.abc.create-account "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3" (read-keyset 'bad-actor-guard))
+
+  (coin.create-account "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3" (read-keyset 'creator-guard))
+  (coin.create-account "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3" (read-keyset 'bad-actor-guard))
+
+(commit-tx)
+
+(begin-tx)
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+
+  (env-data {
+    "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} ALWAYS-TRUE)
+   ,"account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+   ,"account-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+   ,"royalty_spec": {
+      "fungible": marmalade-v2.abc
+     ,"creator": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+     ,"creator-guard":  {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+     ,"royalty-rate": 0.000001
+    }
+  })
+
+
+  (expect-failure "create-token with royalty_spec with fungible other than coin fails"
+    "Royalty support is restricted to coin"
+    (create-token (read-msg 'token-id) 0 "test-royalty-uri" (create-policies DEFAULT_ROYALTY) ALWAYS-TRUE))
+
+(rollback-tx)
+
+(begin-tx)
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+
+  (env-data {
+    "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} ALWAYS-TRUE)
+   ,"account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+   ,"account-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+   ,"royalty_spec": {
+      "fungible": coin
+     ,"creator": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+     ,"creator-guard":  {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+     ,"royalty-rate": -0.000001
+    }
+  })
+
+  (expect-failure "create-token with negative royalty rate fails"
+    "Invalid royalty rate"
+    (create-token (read-msg 'token-id) 0 "test-royalty-uri" (create-policies DEFAULT_ROYALTY) ALWAYS-TRUE))
+(rollback-tx)
+
+(begin-tx)
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.guard-policy-v1)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+
+  (env-data {
+    "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE)
+   ,"account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+   ,"account-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+   ,"royalty_spec": {
+      "fungible": coin
+     ,"creator": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+     ,"creator-guard":  {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+     ,"royalty-rate": 0.05
+    }
+  })
+
+  (expect "create a default token with quote-policy, non-fungible-policy"
+    true
+    (create-token (read-msg 'token-id) 0 "test-royalty-uri" (create-policies DEFAULT_ROYALTY) ALWAYS-TRUE))
+
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+    ,'caps: [(marmalade-v2.ledger.MINT (read-msg 'token-id) (read-string 'account) 1.0)]
+    }])
+
+  (expect "mint a default token with quote-policy, non-fungible-policy"
+    true
+    (mint (read-msg 'token-id )  (read-string 'account) (read-keyset 'account-guard ) 1.0))
+
+  (expect "create-token and mint events"
+     [{"name": "marmalade-v2.royalty-policy-v1.ROYALTY","params": [(read-msg 'token-id) {"creator": (read-string 'account),"creator-guard": (at 'creator-guard (read-msg 'royalty_spec)),"fungible": coin,"royalty-rate": 0.05}]}
+      {"name": "marmalade-v2.guard-policy-v1.GUARDS","params": [(read-msg 'token-id) {"burn-guard": GUARD_SUCCESS,"mint-guard": GUARD_SUCCESS,"sale-guard": GUARD_SUCCESS,"transfer-guard": GUARD_SUCCESS, "uri-guard": GUARD_SUCCESS}]}
+      {"name": "marmalade-v2.ledger.TOKEN","params": [(read-msg 'token-id) 0 [marmalade-v2.non-fungible-policy-v1 marmalade-v2.royalty-policy-v1 marmalade-v2.guard-policy-v1] "test-royalty-uri" ALWAYS-TRUE]}
+      {"name": "marmalade-v2.ledger.MINT","params": [(read-msg 'token-id) (read-string 'account) 1.0]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-msg 'token-id) (read-string 'account) (read-keyset 'account-guard)]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-msg 'token-id) 1.0 {"account":"", "current": 0.0,"previous": 0.0} {"account": (read-string 'account),"current": 1.0,"previous": 0.0}]} {"name": "marmalade-v2.ledger.SUPPLY","params": [(read-msg 'token-id) 1.0]}]
+    (map (remove "module-hash")  (env-events true)))
+(commit-tx)
+
+(begin-tx "Create token - test guards")
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+
+  (env-data {
+    "token-id": (create-token-id { 'uri: "test2-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE)
+   ,"account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+   ,"account-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+   ,"royalty_spec": {
+      "fungible": coin
+     ,"creator": "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+     ,"creator-guard":  {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+     ,"royalty-rate": 0.05
+    }
+  })
+
+  (expect-failure "Creator guard does not match creator"
+    "Creator guard does not match"
+    (create-token (read-msg 'token-id) 0 "test2-royalty-uri" (create-policies DEFAULT_ROYALTY) ALWAYS-TRUE))
+
+  (env-data {
+    "token-id": (create-token-id { 'uri: "test2-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE)
+   ,"account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+   ,"account-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+   ,"royalty_spec": {
+      "fungible": marmalade-v2.def
+     ,"creator": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+     ,"creator-guard":  {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+     ,"royalty-rate": 0.05
+    }
+  })
+
+  (expect-failure "Account does not exist on fungible"
+    "row not found: k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+    (create-token (read-msg 'token-id) 0 "test2-royalty-uri" (create-policies DEFAULT_ROYALTY) ALWAYS-TRUE))
+
+(commit-tx)
+
+(begin-tx "Royalty rates")
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+
+  (env-data {
+    "token-id": (create-token-id { 'uri: "test3-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE)
+   ,"account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+   ,"account-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+   ,"royalty_spec": {
+      "fungible": coin
+     ,"creator": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+     ,"creator-guard":  {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+     ,"royalty-rate": 1
+    }
+  })
+
+
+  (expect-failure "Royalty rate should be decimal"
+    "expected decimal, found integer"
+    (create-token (read-msg 'token-id) 0 "test3-royalty-uri" (create-policies DEFAULT_ROYALTY) ALWAYS-TRUE))
+
+  (env-data {
+    "token-id": (create-token-id { 'uri: "test3-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE)
+   ,"account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+   ,"account-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+   ,"royalty_spec": {
+      "fungible": coin
+     ,"creator": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+     ,"creator-guard":  {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+     ,"royalty-rate": 2.0
+    }
+  })
+
+  (expect-failure "Royalty rate be between 0.0 and 1.0"
+    "Invalid royalty rate"
+    (create-token (read-msg 'token-id) 0 "test3-royalty-uri" (create-policies DEFAULT_ROYALTY) ALWAYS-TRUE))
+
+(commit-tx)
+
+(begin-tx "start an offer")
+
+  (env-hash (hash "offer-royalty-0"))
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+
+  (env-data {
+    "seller-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+  })
+
+  (marmalade-v2.def.create-account "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3" (read-keyset 'seller-guard))
+
+  (env-data {
+    "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE)
+    ,"quote":{
+         "fungible": marmalade-v2.def
+         ,"sale-price": 2.0
+         ,"seller-fungible-account": {
+             "account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+            ,"guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+           }
+         ,"sale-type": ""
+       }
+   })
+
+  (env-chain-data {"block-time": (time "2023-07-20T11:26:35Z")})
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+     ,'caps: [
+     (marmalade-v2.ledger.OFFER (read-msg 'token-id) "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3" 1.0 (to-timestamp (time "2023-07-22T11:26:35Z")) )]
+     }])
+
+  (expect-failure "Offer fails when quote uses a different fungible from registered fungible"
+    "(enforce (= fungible (at 'fung...: Failure: Tx Failed: Offer is restricted to sale using fungible: coin"
+    (sale (read-msg 'token-id) "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3" 1.0 (to-timestamp (time "2023-07-22T11:26:35Z"))))
+
+(rollback-tx)
+
+(begin-tx "Fund buyer fungible account")
+
+  (env-data {
+    "buyer": "k:ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"
+   ,"buyer_fungible_account": "k:ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"
+   ,"buyer-guard": {"keys": ["ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"], "pred": "keys-all"}
+   ,"buyer-guard-1": {"keys": ["c8493f58aaff5787a15c987cf35b41bbca164a41d8978913860805768ed66fe7"], "pred": "keys-all"}
+   })
+
+  (test-capability (coin.COINBASE))
+  (coin.coinbase "k:ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c" (read-keyset 'buyer-guard) 2.0)
+  (coin.coinbase "k:c8493f58aaff5787a15c987cf35b41bbca164a41d8978913860805768ed66fe7" (read-keyset 'buyer-guard-1) 2.0)
+
+  (expect "coinbase events"
+   [{"name": "coin.TRANSFER","params": ["" "k:ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c" 2.0]}
+    {"name": "coin.TRANSFER","params": ["" "k:c8493f58aaff5787a15c987cf35b41bbca164a41d8978913860805768ed66fe7" 2.0]}]
+   (map (remove "module-hash")  (env-events true)))
+
+(commit-tx)
+
+(begin-tx)
+
+  (env-hash (hash "offer-royalty-0"))
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+
+  (env-data {
+    "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE)
+    ,"account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+    ,"quote":{
+       "fungible": coin
+       ,"sale-price": 2.0
+       ,"seller-fungible-account": {
+           "account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+          ,"guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+         }
+       ,"sale-type": ""
+     }
+    })
+
+  (env-chain-data {"block-time": (time "2023-07-20T11:26:35Z")})
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+     ,'caps: [
+     (marmalade-v2.ledger.OFFER (read-msg 'token-id) "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3" 1.0 (to-timestamp (time "2023-07-22T11:26:35Z")) )]
+     }])
+
+  (expect "start offer by running step 0 of sale"
+    "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM"
+    (sale (read-msg 'token-id) "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3" 1.0 (to-timestamp (time "2023-07-22T11:26:35Z"))))
+
+  (expect "offer events"
+   [ {"name": "marmalade-v2.policy-manager.QUOTE","params": ["0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM" (read-msg 'token-id) (read-msg 'quote) ]}
+     {"name": "marmalade-v2.ledger.OFFER","params": [(read-msg 'token-id) (read-string 'account) 1.0 1690025195]}
+     {"name": "marmalade-v2.ledger.SALE","params": [(read-msg 'token-id) (read-string 'account) 1.0 1690025195 "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM"]}
+     {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-msg 'token-id) "c:0-3xXARaPTprNrOOHGoO8tEh-ADvWDHskO-2sXZ4eRg" (account-guard (read-msg 'token-id) "c:0-3xXARaPTprNrOOHGoO8tEh-ADvWDHskO-2sXZ4eRg")]}
+     {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-msg 'token-id) (read-string 'account) "c:0-3xXARaPTprNrOOHGoO8tEh-ADvWDHskO-2sXZ4eRg" 1.0]}
+     {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-msg 'token-id) 1.0 {"account": (read-string 'account),"current": 0.0,"previous": 1.0} {"account": "c:0-3xXARaPTprNrOOHGoO8tEh-ADvWDHskO-2sXZ4eRg","current": 1.0,"previous": 0.0}]}]
+   (map (remove "module-hash")  (env-events true)))
+
+  (env-data { "recipient-guard": {"keys": ["seller"], "pred": "keys-all"}})
+
+  (env-data {
+    "creator": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+   ,"buyer": "k:ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"
+   ,"buyer_fungible_account": "k:ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"
+   ,"buyer-guard": {"keys": ["ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"], "pred": "keys-all"}
+   ,"token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE)
+   })
+
+  (env-sigs
+   [{'key:'ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c
+    ,'caps: [
+      (marmalade-v2.ledger.BUY (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE) (read-string 'creator) (read-string 'buyer)  1.0 "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM")
+      (coin.TRANSFER (read-string 'buyer) "c:xx_lmWaqaLkqO3RzZnabF_tpKB11EeagaLUJwM0T_6c" 2.0)
+     ]}])
+
+   (expect
+     "Expect k:buyer balance to be correct"
+     2.0 (coin.get-balance (read-string 'buyer)))
+
+   (expect
+     "Expect vault creator balance to be correct"
+     0.0 (coin.get-balance (read-string 'creator)))
+
+  (env-hash (hash "offer-royalty-0"))
+
+  (expect "Buy succeeds"
+    "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM"
+    (continue-pact 1))
+
+  (expect
+    "Expect k:buyer balance to be correct"
+    0.0 (coin.get-balance (read-string 'buyer)))
+
+  (expect
+    "Expect creator balance to be correct"
+    2.0 (coin.get-balance (read-string 'creator)))
+
+(expect "buy events"
+  [{"name": "coin.TRANSFER","params": [(read-string 'buyer) "c:xx_lmWaqaLkqO3RzZnabF_tpKB11EeagaLUJwM0T_6c" 2.0]}
+   {"name": "marmalade-v2.royalty-policy-v1.ROYALTY-PAYOUT","params": ["0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM" (read-msg 'token-id) 0.1 (read-string 'creator)]}
+   {"name": "coin.TRANSFER","params": ["c:xx_lmWaqaLkqO3RzZnabF_tpKB11EeagaLUJwM0T_6c" (read-string 'creator) 0.1]}
+   {"name": "coin.TRANSFER","params": ["c:xx_lmWaqaLkqO3RzZnabF_tpKB11EeagaLUJwM0T_6c" (read-string 'creator) 1.9]}
+   {"name": "marmalade-v2.ledger.BUY","params": [(read-msg 'token-id) (read-string 'creator) (read-string 'buyer) 1.0 "0HZ-zWbio-_Q0whoIO_BU2_tjLVm9rvZbc2ZxkbhWeM"]}
+   {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-msg 'token-id) (read-string 'buyer) (read-keyset 'buyer-guard)]}
+   {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-msg 'token-id) "c:0-3xXARaPTprNrOOHGoO8tEh-ADvWDHskO-2sXZ4eRg" (read-string 'buyer) 1.0]}
+   {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-msg 'token-id) 1.0 {"account": "c:0-3xXARaPTprNrOOHGoO8tEh-ADvWDHskO-2sXZ4eRg","current": 0.0,"previous": 1.0} {"account": (read-string 'buyer),"current": 1.0,"previous": 0.0}]}]
+ (map (remove "module-hash")  (env-events true)))
+
+(commit-tx)
+
+(begin-tx)
+
+  (env-hash (hash "offer-royalty-1"))
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+
+  (env-data {
+    "seller-guard": {"keys": ["ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"], "pred": "keys-all"}
+  })
+
+  (env-data {
+    "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE)
+    ,"buyer": "k:ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"
+    ,"quote":{
+       "fungible": coin
+       ,"sale-price": 2.0
+       ,"seller-fungible-account": {
+           "account": "k:ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"
+          ,"guard": {"keys": ["ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"], "pred": "keys-all"}
+         }
+       ,"sale-type": ""
+     }
+  })
+
+  (env-chain-data {"block-time": (time "2023-07-20T11:26:35Z")})
+  (env-sigs [
+    { 'key: 'ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c
+     ,'caps: [
+     (marmalade-v2.ledger.OFFER (read-msg 'token-id) (read-string 'buyer) 1.0 (to-timestamp (time "2023-07-22T11:26:35Z")) )]
+     }])
+
+  (expect "start offer by running step 0 of sale"
+    "2L8Q_bSe63oTP32EVXFxNoNtR7BWcUMmmtMmOkI1GyU"
+    (sale (read-msg 'token-id) (read-string 'buyer) 1.0 (to-timestamp (time "2023-07-22T11:26:35Z"))))
+
+  (expect "offer events"
+    [ {"name": "marmalade-v2.policy-manager.QUOTE","params": ["2L8Q_bSe63oTP32EVXFxNoNtR7BWcUMmmtMmOkI1GyU" (read-msg 'token-id) (read-msg 'quote)]}
+      {"name": "marmalade-v2.ledger.OFFER","params": [(read-msg 'token-id) (read-string 'buyer) 1.0 1690025195]}
+      {"name": "marmalade-v2.ledger.SALE","params": [(read-msg 'token-id) (read-string 'buyer) 1.0 1690025195 "2L8Q_bSe63oTP32EVXFxNoNtR7BWcUMmmtMmOkI1GyU"]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-msg 'token-id) "c:WkjYGRQKZsGJEvaQovu3B6V1VC9LBTtMRVMXm9l9IiI" (account-guard (read-msg 'token-id) "c:WkjYGRQKZsGJEvaQovu3B6V1VC9LBTtMRVMXm9l9IiI")]}
+      {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-msg 'token-id) (read-string 'buyer) "c:WkjYGRQKZsGJEvaQovu3B6V1VC9LBTtMRVMXm9l9IiI" 1.0]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-msg 'token-id) 1.0 {"account": (read-string 'buyer),"current": 0.0,"previous": 1.0} {"account": "c:WkjYGRQKZsGJEvaQovu3B6V1VC9LBTtMRVMXm9l9IiI","current": 1.0,"previous": 0.0}]}]
+     (map (remove "module-hash")  (env-events true)))
+
+(commit-tx)
+
+(begin-tx "buyer sells token to buyer1")
+  (env-hash (hash "offer-royalty-1-buy"))
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+
+  (env-data {
+    "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} ALWAYS-TRUE)
+   ,"prev-buyer": "k:ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"
+   ,"creator": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+   ,"buyer": "k:c8493f58aaff5787a15c987cf35b41bbca164a41d8978913860805768ed66fe7"
+   ,"buyer_fungible_account": "k:c8493f58aaff5787a15c987cf35b41bbca164a41d8978913860805768ed66fe7"
+   ,"buyer-guard": {"keys": ["c8493f58aaff5787a15c987cf35b41bbca164a41d8978913860805768ed66fe7"], "pred": "keys-all"}
+   })
+
+  (env-sigs
+   [{'key:'c8493f58aaff5787a15c987cf35b41bbca164a41d8978913860805768ed66fe7
+    ,'caps: [
+      (marmalade-v2.ledger.BUY (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE) (read-string "prev-buyer") (read-string "buyer")  1.0 "2L8Q_bSe63oTP32EVXFxNoNtR7BWcUMmmtMmOkI1GyU")
+      (coin.TRANSFER (read-string "buyer") "c:gg1NCZfPFF1e-gLYCyM7sHg5_1PeUD2sN85HqaojHIQ" 2.0)
+     ]}])
+
+  (expect "Buy succeeds"
+    "2L8Q_bSe63oTP32EVXFxNoNtR7BWcUMmmtMmOkI1GyU"
+    (continue-pact 1 false "2L8Q_bSe63oTP32EVXFxNoNtR7BWcUMmmtMmOkI1GyU"))
+
+  (expect
+    "Expect previous buyer balance to be increased with sale amount"
+    1.9 (coin.get-balance (read-string "prev-buyer")))
+
+  (expect
+    "Expect creator balance to be increased with added royalties"
+    2.1 (coin.get-balance (read-string 'creator)))
+
+(expect "buy events"
+  [{"name": "coin.TRANSFER","params": [(read-string 'buyer) "c:gg1NCZfPFF1e-gLYCyM7sHg5_1PeUD2sN85HqaojHIQ" 2.0]}
+   {"name": "marmalade-v2.royalty-policy-v1.ROYALTY-PAYOUT","params": ["2L8Q_bSe63oTP32EVXFxNoNtR7BWcUMmmtMmOkI1GyU" (read-msg 'token-id) 0.100000000000 (read-string 'creator)]}
+   {"name": "coin.TRANSFER","params": ["c:gg1NCZfPFF1e-gLYCyM7sHg5_1PeUD2sN85HqaojHIQ" (read-string 'creator) 0.100000000000]}
+   {"name": "coin.TRANSFER","params": ["c:gg1NCZfPFF1e-gLYCyM7sHg5_1PeUD2sN85HqaojHIQ" (read-string 'prev-buyer) 1.9]}
+   {"name": "marmalade-v2.ledger.BUY","params": [(read-msg 'token-id) (read-string 'prev-buyer) (read-string 'buyer) 1.0 "2L8Q_bSe63oTP32EVXFxNoNtR7BWcUMmmtMmOkI1GyU"]}
+   {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-msg 'token-id) (read-string 'buyer) (read-keyset 'buyer-guard)]}
+   {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-msg 'token-id) "c:WkjYGRQKZsGJEvaQovu3B6V1VC9LBTtMRVMXm9l9IiI" (read-string 'buyer) 1.0]}
+   {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-msg 'token-id) 1.0 {"account": "c:WkjYGRQKZsGJEvaQovu3B6V1VC9LBTtMRVMXm9l9IiI","current": 0.0,"previous": 1.0} {"account": (read-string 'buyer),"current": 1.0,"previous": 0.0}]}]
+ (map (remove "module-hash")  (env-events true))
+ )
+
+(rollback-tx)
+
+(begin-tx "Fund creator fungible account")
+
+  (env-data {
+   "creator": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+   ,"creator-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+   })
+
+  (test-capability (coin.COINBASE))
+  (coin.coinbase (read-string 'creator) (read-keyset 'creator-guard) 2.0)
+
+  (expect "coinbase events"
+   [{"name": "coin.TRANSFER","params": ["" (read-string 'creator) 2.0]}]
+   (map (remove "module-hash")  (env-events true)))
+
+(commit-tx)
+
+(begin-tx "creator re-buys the token from buyer")
+  (env-hash (hash "offer-royalty-1-buy-creator"))
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+
+  (env-data {
+    "token-id": (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} ALWAYS-TRUE)
+   ,"buyer": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+   ,"buyer_fungible_account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+   ,"buyer-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+   ,"prev-buyer": "k:ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"
+   })
+
+  (env-sigs
+   [{'key:'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+    ,'caps: [
+      (marmalade-v2.ledger.BUY (create-token-id { 'uri: "test-royalty-uri", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY) } ALWAYS-TRUE) (read-string 'prev-buyer) (read-string 'buyer)  1.0 "2L8Q_bSe63oTP32EVXFxNoNtR7BWcUMmmtMmOkI1GyU")
+      (coin.TRANSFER (read-string 'buyer) "c:gg1NCZfPFF1e-gLYCyM7sHg5_1PeUD2sN85HqaojHIQ" 2.0)
+     ]}])
+
+  (expect "Buy succeeds"
+    "2L8Q_bSe63oTP32EVXFxNoNtR7BWcUMmmtMmOkI1GyU"
+    (continue-pact 1 false "2L8Q_bSe63oTP32EVXFxNoNtR7BWcUMmmtMmOkI1GyU"))
+
+  (expect
+    "Expect previous buyer balance to be correct"
+    1.9 (coin.get-balance (read-string 'prev-buyer)))
+
+  (expect
+    "Expect creator balance to be correct"
+    2.1 (coin.get-balance (read-string 'buyer)))
+
+(expect "buy events"
+  [{"name": "coin.TRANSFER","params": [(read-string 'buyer) "c:gg1NCZfPFF1e-gLYCyM7sHg5_1PeUD2sN85HqaojHIQ" 2.0]}
+   {"name": "marmalade-v2.royalty-policy-v1.ROYALTY-PAYOUT","params": ["2L8Q_bSe63oTP32EVXFxNoNtR7BWcUMmmtMmOkI1GyU" (read-msg 'token-id) 0.1 (read-string 'buyer)]}
+   {"name": "coin.TRANSFER","params": ["c:gg1NCZfPFF1e-gLYCyM7sHg5_1PeUD2sN85HqaojHIQ" (read-string 'buyer) 0.1]}
+   {"name": "coin.TRANSFER","params": ["c:gg1NCZfPFF1e-gLYCyM7sHg5_1PeUD2sN85HqaojHIQ" (read-string 'prev-buyer) 1.9]}
+   {"name": "marmalade-v2.ledger.BUY","params": [(read-msg 'token-id) (read-string 'prev-buyer) (read-string 'buyer) 1.0 "2L8Q_bSe63oTP32EVXFxNoNtR7BWcUMmmtMmOkI1GyU"]}
+   {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-msg 'token-id) "c:WkjYGRQKZsGJEvaQovu3B6V1VC9LBTtMRVMXm9l9IiI" (read-string 'buyer) 1.0]}
+   {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-msg 'token-id) 1.0 {"account": "c:WkjYGRQKZsGJEvaQovu3B6V1VC9LBTtMRVMXm9l9IiI","current": 0.0,"previous": 1.0} {"account": (read-string 'buyer),"current": 1.0,"previous": 0.0}]}]
+ (map (remove "module-hash")  (env-events true))
+ )
+
+(rollback-tx)

--- a/pact-tests/pact-tests/marmalade/pact/kip/account-protocols-v1.pact
+++ b/pact-tests/pact-tests/marmalade/pact/kip/account-protocols-v1.pact
@@ -1,0 +1,23 @@
+(namespace 'kip)
+(interface account-protocols-v1
+
+  " Define a standard for support of Kadena Account Protocols, \
+  \ which reserve account names starting with 'X:'' where X is a \
+  \ single latin-1 character. It also indicates which protocols are \
+  \ supported."
+
+  (defconst SINGLE_KEY "k:"
+    " Protocol in which the data portion of the name must match the \
+    \ key in a single-key, 'keys-all' guard."
+  )
+
+  (defun enforce-reserved:bool
+    ( account:string
+      guard:guard
+    )
+    @doc " Enforce reserved account name protocols. Implementations \
+         \ must call this function in all account creation modes \
+         \ (transfer-create, create-account, etc)."
+  )
+
+)

--- a/pact-tests/pact-tests/marmalade/pact/kip/manifest.pact
+++ b/pact-tests/pact-tests/marmalade/pact/kip/manifest.pact
@@ -1,0 +1,75 @@
+(namespace 'kip)
+
+(module token-manifest GOVERNANCE
+
+  (defcap GOVERNANCE ()
+    (enforce-guard (keyset-ref-guard 'marmalade-admin )))
+
+  (defschema mf-uri
+    scheme:string
+    data:string
+  )
+
+  (defschema mf-datum
+    uri:object{mf-uri}
+    hash:string
+    datum:object
+  )
+
+  (defschema manifest
+    uri:object{mf-uri}
+    hash:string
+    data:[object{mf-datum}]
+  )
+
+  (defun hash-contents:string
+    ( uri:object{mf-uri}
+      hashes:[string]
+    )
+    (hash {'uri: uri, 'data: hashes})
+  )
+
+  (defun create-manifest:object{manifest}
+    ( uri:object{mf-uri}
+      data:[object{mf-datum}]
+    )
+    { 'uri: uri
+    , 'hash: (hash-contents uri (map (at 'hash ) data))
+    , 'data: data
+    }
+  )
+
+  (defun create-datum:object{mf-datum}
+    ( uri:object{mf-uri}
+      datum:object
+    )
+    { 'uri: uri
+    , 'hash: (hash-contents uri [(hash datum)])
+    , 'datum: datum
+    }
+  )
+
+  (defun verify-manifest:bool
+    ( manifest:object{manifest}
+    )
+    (bind manifest
+      { "uri":= uri
+      , "data":= data
+      }
+      (= (create-manifest uri data) manifest)
+    )
+  )
+
+  (defun enforce-verify-manifest:bool
+    ( manifest:object{manifest}
+    )
+    (enforce
+      (verify-manifest manifest)
+      "Manifest is not valid")
+  )
+
+  (defun uri (scheme:string data:string)
+    {'scheme: scheme, 'data: data }
+  )
+
+)

--- a/pact-tests/pact-tests/marmalade/pact/kip/poly-fungible-v3.pact
+++ b/pact-tests/pact-tests/marmalade/pact/kip/poly-fungible-v3.pact
@@ -1,0 +1,249 @@
+(namespace (read-string 'ns))
+
+(interface poly-fungible-v3
+
+  (defschema account-details
+    @doc
+      " Account details: token ID, account name, balance, and guard."
+    @model
+      [ (invariant (!= id ""))
+        (invariant (!= account ""))
+        (invariant (>= balance 0.0))
+      ]
+    id:string
+    account:string
+    balance:decimal
+    guard:guard)
+
+  (defschema sender-balance-change
+    @doc "For use in RECONCILE events"
+    account:string
+    previous:decimal
+    current:decimal
+  )
+
+  (defschema receiver-balance-change
+    @doc "For use in RECONCILE events"
+    account:string
+    previous:decimal
+    current:decimal
+  )
+
+  (defcap TRANSFER:bool
+    ( id:string
+      sender:string
+      receiver:string
+      amount:decimal
+    )
+    @doc
+      " Manage transferring AMOUNT of ID from SENDER to RECEIVER. \
+      \ As event, also used to notify burn (with \"\" RECEIVER) \
+      \ and create (with \"\" SENDER)."
+    @managed amount TRANSFER-mgr
+  )
+
+  (defcap XTRANSFER:bool
+    ( id:string
+      sender:string
+      receiver:string
+      target-chain:string
+      amount:decimal
+    )
+    " Manage cross-chain transferring AMOUNT of ID from SENDER to RECEIVER \
+    \ on TARGET-CHAIN."
+    @managed amount TRANSFER-mgr
+  )
+
+  (defun TRANSFER-mgr:decimal
+    ( managed:decimal
+      requested:decimal
+    )
+    @doc " Manages TRANSFER cap AMOUNT where MANAGED is the installed quantity \
+         \ and REQUESTED is the quantity attempting to be granted."
+  )
+
+  (defcap SUPPLY:bool (id:string supply:decimal)
+    @doc " Emitted when SUPPLY is updated, if supported."
+    @event
+  )
+
+  (defcap ACCOUNT_GUARD:bool (id:string account:string guard:guard)
+    @doc " Emitted when ACCOUNT guard is updated."
+    @event
+  )
+
+  (defcap RECONCILE:bool
+    ( token-id:string
+      amount:decimal
+      sender:object{sender-balance-change}
+      receiver:object{receiver-balance-change}
+    )
+    @doc " For accounting via events. \
+         \ sender = {account: '', previous: 0.0, current: 0.0} for mint \
+         \ receiver = {account: '', previous: 0.0, current: 0.0} for burn"
+    @event
+  )
+
+  (defun precision:integer (id:string)
+    @doc
+      " Return maximum decimal precision for ID."
+  )
+
+  (defun enforce-unit:bool
+    ( id:string
+      amount:decimal
+    )
+    @doc
+      " Enforce that AMOUNT meets minimum precision allowed for ID."
+  )
+
+  (defun mint:bool
+    ( id:string
+      account:string
+      guard:guard
+      amount:decimal
+    )
+    @doc
+      " Mint AMOUNT of ID to ACCOUNT with GUARD."
+    @model
+      [ (property (!= id ""))
+        (property (!= account ""))
+        (property (>= amount 0.0))
+      ]
+  )
+
+  (defun burn:bool
+    ( id:string
+      account:string
+      amount:decimal
+    )
+    @doc
+      " Burn AMOUNT of ID from ACCOUNT."
+    @model
+      [ (property (!= id ""))
+        (property (!= account ""))
+        (property (>= amount 0.0))
+      ]
+  )
+
+  (defun create-account:bool
+    ( id:string
+      account:string
+      guard:guard
+    )
+    @doc
+      " Create ACCOUNT for ID with 0.0 balance, with GUARD controlling access."
+    @model
+      [ (property (!= id ""))
+        (property (!= account ""))
+      ]
+  )
+
+  (defun get-balance:decimal
+    ( id:string
+      account:string
+    )
+    @doc
+      " Get balance of ID for ACCOUNT. Fails if account does not exist."
+  )
+
+  (defun details:object{account-details}
+    ( id:string
+      account:string
+    )
+    @doc
+      " Get details of ACCOUNT under ID. Fails if account does not exist."
+  )
+
+  (defun transfer:bool
+    ( id:string
+      sender:string
+      receiver:string
+      amount:decimal
+    )
+    @doc
+      " Transfer AMOUNT of ID between accounts SENDER and RECEIVER. \
+      \ Fails if SENDER does not exist. Managed by TRANSFER."
+    @model
+      [ (property (> amount 0.0))
+        (property (!= id ""))
+        (property (!= sender ""))
+        (property (!= receiver ""))
+        (property (!= sender receiver))
+      ]
+  )
+
+  (defun transfer-create:bool
+    ( id:string
+      sender:string
+      receiver:string
+      receiver-guard:guard
+      amount:decimal
+    )
+    @doc
+      " Transfer AMOUNT of ID between accounts SENDER and RECEIVER. \
+      \ If RECEIVER exists, RECEIVER-GUARD must match existing guard; \
+      \ if RECEIVER does not exist, account is created. \
+      \ Managed by TRANSFER."
+    @model
+      [ (property (> amount 0.0))
+        (property (!= id ""))
+        (property (!= sender ""))
+        (property (!= receiver ""))
+        (property (!= sender receiver))
+      ]
+  )
+
+  (defpact transfer-crosschain:bool
+    ( id:string
+      sender:string
+      receiver:string
+      receiver-guard:guard
+      target-chain:string
+      amount:decimal
+    )
+    @doc
+      " Transfer AMOUNT of ID between accounts SENDER on source chain \
+      \ and RECEIVER on TARGET-CHAIN. If RECEIVER exists, RECEIVER-GUARD \
+      \ must match existing guard. If RECEIVER does not exist, account is created."
+    @model
+      [ (property (> amount 0.0))
+        (property (!= id ""))
+        (property (!= sender ""))
+        (property (!= receiver ""))
+        (property (!= target-chain ""))
+      ]
+  )
+
+  (defun total-supply:decimal (id:string)
+    @doc
+      " Give total available quantity of ID. If not supported, return 0."
+  )
+
+  (defun get-uri:string (id:string)
+    @doc
+      " Give uri for ID."
+  )
+
+  ;;
+  ;; Sale API
+  ;;
+
+  (defcap SALE:bool
+    (id:string seller:string amount:decimal timeout:integer sale-id:string)
+    @doc "Wrapper cap/event of SALE of token ID by SELLER of AMOUNT until TIMEOUT block height."
+    @event
+  )
+
+  (defpact sale:string
+    ( id:string
+      seller:string
+      amount:decimal
+      timeout:integer
+    )
+    @doc " Offer->buy escrow pact of AMOUNT of token ID by SELLER with TIMEOUT in blocks. \
+         \ Step 1 is offer with withdraw rollback after timeout. \
+         \ Step 2 is buy, which completes using 'buyer' and 'buyer-guard' payload values."
+  )
+
+)

--- a/pact-tests/pact-tests/marmalade/pact/kip/token-policy-v2.pact
+++ b/pact-tests/pact-tests/marmalade/pact/kip/token-policy-v2.pact
@@ -1,0 +1,80 @@
+(namespace (read-string 'ns))
+
+(interface token-policy-v2
+
+  (defschema token-info
+    id:string
+    supply:decimal
+    precision:integer
+    uri:string
+    policies:[module{token-policy-v2}])
+
+  (defun enforce-mint:bool
+    ( token:object{token-info}
+      account:string
+      guard:guard
+      amount:decimal
+    )
+    @doc "Minting policy for TOKEN to ACCOUNT for AMOUNT."
+    @model [
+      (property (!= account ""))
+      (property (> amount 0.0))
+    ]
+  )
+
+  (defun enforce-burn:bool
+    ( token:object{token-info}
+      account:string
+      amount:decimal
+    )
+    @doc "Burning policy for TOKEN to ACCOUNT for AMOUNT."
+    @model [
+      (property (!= account ""))
+      (property (> amount 0.0))
+    ]
+  )
+
+  (defun enforce-init:bool
+    (token:object{token-info})
+    @doc "Enforce policy on TOKEN initiation."
+  )
+
+  (defun enforce-offer:bool
+    ( token:object{token-info}
+      seller:string
+      amount:decimal
+      timeout:integer
+      sale-id:string )
+    @doc "Offer policy of sale SALE-ID by SELLER of AMOUNT of TOKEN."
+  )
+
+  (defun enforce-buy:bool
+    ( token:object{token-info}
+      seller:string
+      buyer:string
+      buyer-guard:guard
+      amount:decimal
+      sale-id:string )
+    @doc "Buy policy on SALE-ID by SELLER to BUYER AMOUNT of TOKEN."
+  )
+
+  (defun enforce-withdraw:bool
+    ( token:object{token-info}
+      seller:string
+      amount:decimal
+      timeout:integer
+      sale-id:string )
+    @doc "Withdraw policy on SALE-ID by SELLER of AMOUNT of TOKEN"
+  )
+
+  (defun enforce-transfer:bool
+    ( token:object{token-info}
+      sender:string
+      guard:guard
+      receiver:string
+      amount:decimal )
+    @doc " Enforce rules on transfer of TOKEN AMOUNT from SENDER to RECEIVER. \
+         \ Also governs rotate of SENDER (with same RECEIVER and 0.0 AMOUNT). "
+  )
+
+)

--- a/pact-tests/pact-tests/marmalade/pact/kip/updatable-uri-policy-v1.pact
+++ b/pact-tests/pact-tests/marmalade/pact/kip/updatable-uri-policy-v1.pact
@@ -1,0 +1,14 @@
+(namespace (read-string 'ns))
+
+(interface updatable-uri-policy-v1
+
+  (defun enforce-update-uri:bool
+    ( token:object{kip.token-policy-v2.token-info}
+      new-uri:string
+    )
+    @doc "Updating the URI of a token."
+    @model [
+      (property (!= new-uri ""))
+    ]
+  )
+)

--- a/pact-tests/pact-tests/marmalade/pact/ledger/ledger-v2.interface.pact
+++ b/pact-tests/pact-tests/marmalade/pact/ledger/ledger-v2.interface.pact
@@ -1,0 +1,44 @@
+(namespace (read-msg 'ns))
+
+(interface ledger-v2
+
+  (defcap INIT-CALL:bool (id:string precision:integer uri:string)
+    @doc
+      "Capability securing the modref call for enforce-init "
+  )
+
+  (defcap TRANSFER-CALL:bool (id:string sender:string receiver:string amount:decimal)
+    @doc
+    "Capability securing the modref call for enforce-transfer"
+  )
+
+  (defcap MINT-CALL:bool (id:string account:string amount:decimal)
+    @doc
+      "Capability securing the modref call for enforce-mint"
+  )
+
+  (defcap BURN-CALL:bool (id:string account:string amount:decimal)
+    @doc
+      "Capability securing the modref call for enforce-burn"
+  )
+
+  (defcap OFFER-CALL:bool (id:string seller:string amount:decimal timeout:integer sale-id:string)
+    @doc
+      "Capability securing the modref call for enforce-offer"
+  )
+
+  (defcap WITHDRAW-CALL:bool (id:string seller:string amount:decimal timeout:integer sale-id:string)
+    @doc
+      "Capability securing the modref call for enforce-withdraw"
+  )
+
+  (defcap BUY-CALL:bool (id:string seller:string buyer:string amount:decimal sale-id:string)
+    @doc
+      "Capability securing the modref call for enforce-buy"
+  )
+
+  (defcap UPDATE-URI-CALL:bool (id:string new-uri:string)
+    @doc
+      "Capability securing the modref call for enforce-update-uri"
+  )
+)

--- a/pact-tests/pact-tests/marmalade/pact/ledger/ledger.interface.pact
+++ b/pact-tests/pact-tests/marmalade/pact/ledger/ledger.interface.pact
@@ -1,0 +1,39 @@
+(namespace (read-msg 'ns))
+
+(interface ledger-v1
+
+  (defcap INIT-CALL:bool (id:string precision:integer uri:string)
+    @doc
+      "Capability securing the modref call for enforce-init "
+  )
+
+  (defcap TRANSFER-CALL:bool (id:string sender:string receiver:string amount:decimal)
+    @doc
+    "Capability securing the modref call for enforce-transfer"
+  )
+
+  (defcap MINT-CALL:bool (id:string account:string amount:decimal)
+    @doc
+      "Capability securing the modref call for enforce-mint"
+  )
+
+  (defcap BURN-CALL:bool (id:string account:string amount:decimal)
+    @doc
+      "Capability securing the modref call for enforce-burn"
+  )
+
+  (defcap OFFER-CALL:bool (id:string seller:string amount:decimal timeout:integer sale-id:string)
+    @doc
+      "Capability securing the modref call for enforce-offer"
+  )
+
+  (defcap WITHDRAW-CALL:bool (id:string seller:string amount:decimal timeout:integer sale-id:string)
+    @doc
+      "Capability securing the modref call for enforce-withdraw"
+  )
+
+  (defcap BUY-CALL:bool (id:string seller:string buyer:string amount:decimal sale-id:string)
+    @doc
+      "Capability securing the modref call for enforce-buy"
+  )
+)

--- a/pact-tests/pact-tests/marmalade/pact/ledger/ledger.pact
+++ b/pact-tests/pact-tests/marmalade/pact/ledger/ledger.pact
@@ -1,0 +1,758 @@
+(namespace (read-string 'ns))
+
+(module ledger GOVERNANCE
+
+  @model
+    [
+      (defproperty valid-account (account:string)
+          (> (length account) 2))
+    ]
+
+  (implements marmalade-v2.ledger-v2)
+  (implements kip.poly-fungible-v3)
+
+  (use kip.poly-fungible-v3 [account-details sender-balance-change receiver-balance-change])
+  (use kip.token-policy-v2 [token-info])
+  (use util.fungible-util)
+  (use marmalade-v2.policy-manager)
+
+  ;; Version
+
+  (defconst VERSION:integer 1)
+
+  ;;
+  ;; Tables/Schemas
+  ;;
+
+  (deftable ledger:{account-details})
+
+  (defschema token-schema
+    id:string
+    uri:string
+    precision:integer
+    supply:decimal
+    policies:[module{kip.token-policy-v2}]
+  )
+
+  (defschema token-details
+    uri:string
+    precision:integer
+    policies:[module{kip.token-policy-v2}]
+  )
+
+  (defschema version
+    version:integer
+  )
+
+  (deftable tokens:{token-schema})
+  (deftable versions:{version})
+
+  ;;
+  ;; Governance
+  ;;
+
+  (defconst ADMIN-KS:string "marmalade-v2.marmalade-contract-admin")
+
+  (defcap GOVERNANCE ()
+    (enforce-guard ADMIN-KS))
+
+  ;;
+  ;; poly-fungible-v3 caps
+  ;;
+
+  (defcap TRANSFER:bool
+    ( id:string
+      sender:string
+      receiver:string
+      amount:decimal
+    )
+    @managed amount TRANSFER-mgr
+    (enforce-unit id amount)
+    (enforce (> amount 0.0) "Amount must be positive")
+    (compose-capability (DEBIT id sender))
+    (compose-capability (CREDIT id receiver))
+  )
+
+  (defcap XTRANSFER:bool
+    ( id:string
+      sender:string
+      receiver:string
+      target-chain:string
+      amount:decimal
+    )
+    @managed amount TRANSFER-mgr
+    (enforce false "cross chain not supported")
+  )
+
+  (defun TRANSFER-mgr:decimal
+    ( managed:decimal
+      requested:decimal
+    )
+    (let ((newbal (- managed requested)))
+      (enforce (>= newbal 0.0)
+        (format "TRANSFER exceeded for balance {}" [managed]))
+      newbal)
+  )
+
+  (defcap SUPPLY:bool (id:string supply:decimal)
+    @doc " Emitted when supply is updated, if supported."
+    @event true
+  )
+
+  (defcap CREATE-TOKEN:bool (id:string)
+    true
+  )
+
+  (defcap TOKEN:bool (id:string precision:integer policies:[module{kip.token-policy-v2}] uri:string creation-guard:guard)
+    @event
+    true
+  )
+
+  (defcap RECONCILE:bool
+    ( token-id:string
+      amount:decimal
+      sender:object{sender-balance-change}
+      receiver:object{receiver-balance-change}
+    )
+    @doc " For accounting via events. \
+         \ sender = {account: '', previous: 0.0, current: 0.0} for mint \
+         \ receiver = {account: '', previous: 0.0, current: 0.0} for burn"
+    @event
+    true
+  )
+
+  (defcap ACCOUNT_GUARD:bool (id:string account:string guard:guard)
+    @doc " Emitted when ACCOUNT guard is updated."
+    @event
+    true
+  )
+
+  ;;
+  ;; ledger-v2 caps to be able to validate access to policy operations.
+  ;;
+
+  (defcap INIT-CALL:bool (id:string precision:integer uri:string)
+    true
+  )
+
+  (defcap TRANSFER-CALL:bool (id:string sender:string receiver:string amount:decimal)
+    true
+  )
+
+  (defcap MINT-CALL:bool (id:string account:string amount:decimal)
+    true
+  )
+
+  (defcap BURN-CALL:bool (id:string account:string amount:decimal)
+    true
+  )
+
+  (defcap UPDATE-URI-CALL:bool (id:string new-uri:string)
+    true
+  )
+
+  (defcap OFFER-CALL:bool (id:string seller:string amount:decimal timeout:integer sale-id:string)
+    true
+  )
+
+  (defcap WITHDRAW-CALL:bool (id:string seller:string amount:decimal timeout:integer sale-id:string)
+    true
+  )
+
+  (defcap BUY-CALL:bool (id:string seller:string buyer:string amount:decimal sale-id:string)
+    true
+  )
+
+  ;;
+  ;; Implementation caps
+  ;;
+
+  (defcap DEBIT (id:string sender:string)
+    (enforce-guard (account-guard id sender))
+  )
+
+  (defcap CREDIT (id:string receiver:string) true)
+
+  (defcap UPDATE_SUPPLY ()
+    "private cap for update-supply"
+    true)
+
+  (defcap MINT:bool (id:string account:string amount:decimal)
+    @managed ;; one-shot for a given amount
+    (enforce (< 0.0 amount) "Amount must be positive")
+    (compose-capability (CREDIT id account))
+    (compose-capability (UPDATE_SUPPLY))
+  )
+
+  (defcap BURN (id:string account:string amount:decimal)
+    @managed ;; one-shot for a given amount
+    (enforce (< 0.0 amount) "Amount must be positive")
+    (compose-capability (DEBIT id account))
+    (compose-capability (UPDATE_SUPPLY))
+  )
+
+  (defcap UPDATE-URI:bool
+    ( token-id:string
+      new-uri:string
+    )
+    @managed
+    true
+  )
+
+  ;; Marmalade Functions
+
+  (defun create-token:bool
+    ( id:string
+      precision:integer
+      uri:string
+      policies:[module{kip.token-policy-v2}]
+      creation-guard:guard
+    )
+    @doc "Initializes a TOKEN with given policies and parameters, \
+    \ and executes the enforce-init function for each listed policy."
+    ;; enforces token and uri protocols
+    (enforce-uri-reserved uri)
+    (let ((token-details { 'uri: uri, 'precision: precision, 'policies: (sort policies) }))
+      (enforce-token-reserved id token-details creation-guard)
+    )
+    (with-capability (INIT-CALL id precision uri)
+      ;; maps policy list and calls policy::enforce-init
+      (marmalade-v2.policy-manager.enforce-init
+        { 'id: id, 'supply: 0.0, 'precision: precision, 'uri: uri,  'policies: policies})
+    )
+    (with-capability (CREATE-TOKEN id)
+      (enforce-guard creation-guard)
+      (insert tokens id {
+        "id": id,
+        "uri": uri,
+        "precision": precision,
+        "supply": 0.0,
+        "policies": policies
+      })
+      (insert versions id {
+        "version": VERSION
+      })
+      (emit-event (TOKEN id precision policies uri creation-guard))
+    )
+  )
+
+  (defun mint:bool
+    ( id:string
+      account:string
+      guard:guard
+      amount:decimal
+    )
+    @doc "Mints an AMOUNT of TOKEN to the provided ACCOUNT and its guard,\
+    \ and executes the enforce-mint policy functions."
+    (with-capability (MINT-CALL id account amount)
+      (marmalade-v2.policy-manager.enforce-mint (get-token-info id) account guard amount)
+    )
+    (with-capability (MINT id account amount)
+      (let
+        (
+          (receiver (credit id account guard amount))
+          (sender:object{sender-balance-change}
+            {'account: "", 'previous: 0.0, 'current: 0.0})
+        )
+        (emit-event (RECONCILE id amount sender receiver))
+        (update-supply id amount)
+      ))
+  )
+
+  (defun burn:bool
+    ( id:string
+      account:string
+      amount:decimal
+    )
+    @doc "Burns an AMOUNT of TOKEN from the specified ACCOUNT,\
+    \ and executes the enforce-burn policy functions"
+    (with-capability (BURN-CALL id account amount)
+      (marmalade-v2.policy-manager.enforce-burn (get-token-info id) account amount)
+    )
+    (with-capability (BURN id account amount)
+      (let
+        (
+          (sender (debit id account amount))
+          (receiver:object{receiver-balance-change}
+            {'account: "", 'previous: 0.0, 'current: 0.0})
+        )
+        (emit-event (RECONCILE id amount sender receiver))
+        (update-supply id (- amount))
+      ))
+  )
+
+  (defun transfer:bool
+    ( id:string
+      sender:string
+      receiver:string
+      amount:decimal
+    )
+    @doc "Transfers an AMOUNT of TOKEN from the sender ACCOUNT \
+    \ to an existing receiver ACCOUNT, and executes the enforce-transfer \
+    \ policy functions."
+
+    (enforce (!= sender receiver)
+      "sender cannot be the receiver of a transfer")
+    (enforce-valid-transfer sender receiver (precision id) amount)
+    (with-capability (TRANSFER-CALL id sender receiver amount)
+      (marmalade-v2.policy-manager.enforce-transfer (get-token-info id) sender (account-guard id sender) receiver amount)
+    )
+    (with-capability (TRANSFER id sender receiver amount)
+      (with-read ledger (key id receiver)
+        { "guard" := g }
+        (let
+          ( (sender (debit id sender amount))
+            (receiver (credit id receiver g amount))
+          )
+          (emit-event (RECONCILE id amount sender receiver))
+        )
+      ))
+  )
+
+  (defun transfer-create:bool
+    ( id:string
+      sender:string
+      receiver:string
+      receiver-guard:guard
+      amount:decimal
+    )
+    @doc "Transfers an AMOUNT of TOKEN from the sender ACCOUNT \
+    \ to the receiver ACCOUNT, creates an account if non-existent \
+    \ , and executes the enforce-transfer policy functions."
+
+    (enforce (!= sender receiver)
+      "sender cannot be the receiver of a transfer")
+    (enforce-valid-transfer sender receiver (precision id) amount)
+    (with-capability (TRANSFER-CALL id sender receiver amount)
+      (marmalade-v2.policy-manager.enforce-transfer (get-token-info id) sender (account-guard id sender) receiver amount)
+    )
+    (with-capability (TRANSFER id sender receiver amount)
+      (let
+        (
+          (sender (debit id sender amount))
+          (receiver (credit id receiver receiver-guard amount))
+        )
+        (emit-event (RECONCILE id amount sender receiver))
+      ))
+  )
+
+  (defun update-uri:bool
+    ( id:string
+      new-uri:string
+    )
+    @doc "Updates the URI of the token, and executes enforce-update-uri \
+    \ policy functions."
+
+    (let ((version:integer (get-version id)))
+      (enforce (> version 0) "updatable-uri not supported"))
+    (with-capability (UPDATE-URI-CALL id new-uri)
+      (marmalade-v2.policy-manager.enforce-update-uri (get-token-info id) new-uri)
+    )
+    (with-capability (UPDATE-URI id new-uri)
+      (update tokens id { 'uri: new-uri })
+    )
+    true
+  )
+
+  ;; Implementation Functions
+
+  (defun debit:object{sender-balance-change}
+    ( id:string
+      account:string
+      amount:decimal
+    )
+
+    (require-capability (DEBIT id account))
+
+    (enforce-unit id amount)
+
+    (with-read ledger (key id account)
+      { "balance" := old-bal }
+
+      (enforce (<= amount old-bal) "Insufficient funds")
+
+      (let ((new-bal (- old-bal amount)))
+        (update ledger (key id account)
+          { "balance" : new-bal }
+          )
+        {'account: account, 'previous: old-bal, 'current: new-bal}
+      ))
+  )
+
+  (defun credit:object{receiver-balance-change}
+    ( id:string
+      account:string
+      guard:guard
+      amount:decimal
+    )
+    @doc "Credit AMOUNT to ACCOUNT balance"
+
+    @model [ (property (> amount 0.0))
+             (property (valid-account account))
+           ]
+    (enforce-reserved account guard)
+    (enforce-unit id amount)
+
+    (require-capability (CREDIT id account))
+
+    (with-default-read ledger (key id account)
+      { "balance" : -1.0 }
+      { "balance" := old-bal }
+
+      (let* ((is-new:bool
+               (= old-bal -1.0))
+             (old-bal:decimal (if is-new 0.0 old-bal))
+             (new-bal:decimal  (+ old-bal amount)))
+        (write ledger (key id account)
+           { "balance" : new-bal
+           , "guard"   : guard
+           , "id" : id
+           , "account" : account
+           })
+        (if is-new (emit-event (ACCOUNT_GUARD id account guard)) true)
+        {'account: account, 'previous: old-bal, 'current: new-bal}
+      ))
+    )
+
+  (defun credit-account:object{receiver-balance-change}
+    ( id:string
+      account:string
+      amount:decimal
+    )
+    @doc "Credit AMOUNT to ACCOUNT"
+    (credit id account (account-guard id account) amount)
+  )
+
+  (defun update-supply:bool (id:string amount:decimal)
+    (require-capability (UPDATE_SUPPLY))
+    (with-default-read tokens id
+      { 'supply: 0.0 }
+      { 'supply := s }
+      (let ((new-supply (+ s amount)))
+        (update tokens id {'supply: new-supply })
+        (emit-event (SUPPLY id new-supply))))
+  )
+
+  (defun enforce-unit:bool (id:string amount:decimal)
+    (let ((p (precision id)))
+    (enforce
+      (= (floor amount p)
+         amount)
+      "precision violation"))
+  )
+
+  (defpact transfer-crosschain:bool
+    ( id:string
+      sender:string
+      receiver:string
+      receiver-guard:guard
+      target-chain:string
+      amount:decimal )
+    (step
+      (enforce false "cross chain not supported"))
+  )
+
+  (defun account-guard:guard (id:string account:string)
+    (with-read ledger (key id account) { 'guard := g } g)
+  )
+
+  (defun get-token-info:object{kip.token-policy-v2.token-info} (id:string)
+    (with-read tokens id
+     { 'policies := policies:[module{kip.token-policy-v2}]
+     , 'supply := supply:decimal
+     , 'precision := precision:integer
+     , 'uri := uri:string
+     }
+     {
+       'id: id
+       , 'supply: supply
+       , 'precision: precision
+       , 'uri: uri
+       , 'policies: policies
+     } )
+  )
+
+  (defun create-account:bool
+    ( id:string
+      account:string
+      guard:guard
+    )
+    (enforce-reserved account guard)
+    (insert ledger (key id account)
+      { "balance" : 0.0
+      , "guard"   : guard
+      , "id" : id
+      , "account" : account
+      })
+    (emit-event (ACCOUNT_GUARD id account guard))
+  )
+
+  (defun create-token-id:string (token-details:object{token-details}
+                                 creation-guard:guard)
+    (format "t:{}"
+      [(hash [(format "{}" [token-details]) (at 'chain-id (chain-data)) creation-guard])])
+  )
+
+  (defun check-reserved:string (token-id:string)
+    " Checks token-id for reserved name and returns type if \
+    \ found or empty string. Reserved names start with a \
+    \ single char and colon, e.g. 't:foo', which would return 't' as type."
+    (let ((pfx (take 2 token-id)))
+      (if (= ":" (take -1 pfx)) (take 1 pfx) "")))
+
+  (defun enforce-token-reserved:bool (token-id:string token-details:object{token-details}
+                                      creation-guard:guard)
+    @doc "Enforce reserved token-id name protocols."
+    (let ((r (check-reserved token-id)))
+      (if (= "t" r)
+        (enforce
+          (= token-id
+             (create-token-id token-details creation-guard))
+          "Token protocol violation")
+        (enforce false
+          (format "Unrecognized reserved protocol: {}" [r]) ))))
+
+  (defun enforce-uri-reserved:bool (uri:string)
+    " Enforce reserved uri name protocols "
+    (if (= "marmalade:" (take 10 uri))
+        (enforce false "Reserved protocol: marmalade:")
+        true
+    )
+  )
+
+  (defun truncate:decimal (id:string amount:decimal)
+    (floor amount (precision id))
+  )
+
+  ;;
+  ;; ACCESSORS
+  ;;
+
+  (defun key:string ( id:string account:string )
+    @doc "DB key for ledger account"
+    (format "{}:{}" [id account])
+  )
+
+  (defun get-balance:decimal (id:string account:string)
+    @doc "Returns the ACCOUNT balance of the TOKEN"
+    (at 'balance (read ledger (key id account)))
+  )
+
+  (defun details:object{account-details}
+    ( id:string account:string )
+    @doc "Returns ACCOUNT information of the TOKEN"
+    (read ledger (key id account))
+  )
+
+  (defun total-supply:decimal (id:string)
+    @doc "Returns total SUPPLY of the TOKEN"
+    (with-default-read tokens id
+      { 'supply : 0.0 }
+      { 'supply := s }
+      s)
+  )
+
+  (defun precision:integer (id:string)
+    @doc "Returns PRECISION of the TOKEN"
+    (with-read tokens id
+      { 'precision := precision }
+      precision
+    )
+  )
+
+  (defun get-uri:string (id:string)
+    @doc "Returns URI of the TOKEN"
+    (with-read tokens id
+      { 'uri := uri }
+      uri
+    )
+  )
+
+  (defun get-version:integer (id:string)
+    @doc "Returns Marmalade VERSION of the TOKEN at creation"
+    (with-default-read versions id
+      {'version: 0 }
+      {'version:= version }
+      (if (< version 1)
+        (with-read tokens id
+          {'id:= id}
+          version
+        )
+        version
+      )
+    )
+  )
+
+  ;;
+  ;; sale
+  ;;
+
+  (defcap SALE:bool
+    (id:string seller:string amount:decimal timeout:integer sale-id:string)
+    @doc "Wrapper cap/event of SALE of token ID by SELLER of AMOUNT until TIMEOUT block height."
+    @event
+    (enforce (> amount 0.0) "Amount must be positive")
+    (compose-capability (OFFER id seller amount timeout))
+    (compose-capability (SALE_PRIVATE sale-id))
+  )
+
+  (defcap OFFER:bool
+    (id:string seller:string amount:decimal timeout:integer)
+    @doc "Managed cap for SELLER offering AMOUNT of token ID until TIMEOUT."
+    @managed
+    (enforce (sale-active timeout) "SALE: invalid timeout")
+    (compose-capability (DEBIT id seller))
+    (compose-capability (CREDIT id (sale-account)))
+  )
+
+  (defcap WITHDRAW:bool
+    (id:string seller:string amount:decimal timeout:integer sale-id:string)
+    @doc "Withdraws offer SALE from SELLER of AMOUNT of token ID after timeout."
+    @managed
+    (compose-capability (SALE_PRIVATE sale-id))
+    (if (= 0 timeout)
+      (enforce-guard (at 'guard (details id seller)))
+      (enforce (not (sale-active timeout)) "WITHDRAW: still active")
+    )
+    (compose-capability (DEBIT id (sale-account)))
+    (compose-capability (CREDIT id seller))
+  )
+
+  (defcap BUY:bool
+    (id:string seller:string buyer:string amount:decimal sale-id:string)
+    @doc "Completes sale OFFER to BUYER."
+    @managed
+    (compose-capability (SALE_PRIVATE sale-id))
+    (compose-capability (DEBIT id (sale-account)))
+    (compose-capability (CREDIT id buyer))
+  )
+
+  (defcap SALE_PRIVATE:bool (sale-id:string) true)
+
+  (defpact sale:string
+    ( id:string
+      seller:string
+      amount:decimal
+      timeout:integer
+    )
+    (step-with-rollback
+      ;; Step 0: offer
+      (let ((token-info (get-token-info id)))
+        (with-capability (OFFER-CALL id seller amount timeout (pact-id))
+          (marmalade-v2.policy-manager.enforce-offer token-info seller amount timeout (pact-id)))
+        (with-capability (SALE id seller amount timeout (pact-id))
+          (offer id seller amount))
+        (pact-id)
+      )
+      ;;Step 0, rollback: withdraw
+      (let ((token-info (get-token-info id)))
+        (with-capability (WITHDRAW-CALL id seller amount timeout (pact-id))
+          (marmalade-v2.policy-manager.enforce-withdraw token-info seller amount timeout (pact-id)))
+        (with-capability (WITHDRAW id seller amount timeout (pact-id))
+          (withdraw id seller amount))
+        (pact-id)
+      )
+    )
+    (step
+      ;; Step 1: buy
+      (let ( (buyer:string (read-msg "buyer"))
+              (buyer-guard:guard (read-msg "buyer-guard")) )
+          (with-capability (BUY-CALL id seller buyer amount (pact-id))
+            (marmalade-v2.policy-manager.enforce-buy (get-token-info id) seller buyer buyer-guard amount (pact-id))
+          )
+          (with-capability (BUY id seller buyer amount (pact-id))
+            (buy id seller buyer buyer-guard amount)
+          )
+          (pact-id)
+    ))
+  )
+
+  (defun offer:bool
+    ( id:string
+      seller:string
+      amount:decimal
+    )
+    @doc "Initiate sale with by SELLER by escrowing AMOUNT of TOKEN until TIMEOUT."
+    @model
+      [ (property (!= id ""))
+        (property (!= seller ""))
+        (property (>= amount 0.0))
+      ]
+    (require-capability (SALE_PRIVATE (pact-id)))
+    (let
+      (
+        (sender (debit id seller amount))
+        (receiver (credit id (sale-account) (create-capability-pact-guard (SALE_PRIVATE (pact-id))) amount))
+      )
+      (emit-event (TRANSFER id seller (sale-account) amount))
+      (emit-event (RECONCILE id amount sender receiver)))
+  )
+
+  (defun withdraw:bool
+    ( id:string
+      seller:string
+      amount:decimal
+    )
+    @doc "Withdraw offer by SELLER of AMOUNT of TOKEN"
+    @model
+      [ (property (!= id ""))
+        (property (!= seller ""))
+        (property (>= amount 0.0))
+      ]
+    (require-capability (SALE_PRIVATE (pact-id)))
+    (let
+      (
+        (sender (debit id (sale-account) amount))
+        (receiver (credit-account id seller amount))
+      )
+      (emit-event (TRANSFER id (sale-account) seller amount))
+      (emit-event (RECONCILE id amount sender receiver)))
+  )
+
+  (defun buy:bool
+    ( id:string
+      seller:string
+      buyer:string
+      buyer-guard:guard
+      amount:decimal
+    )
+    @doc "Complete sale with transfer."
+    @model
+      [ (property (!= id ""))
+        (property (!= seller ""))
+        (property (!= buyer ""))
+        (property (>= amount 0.0))
+      ]
+    (require-capability (SALE_PRIVATE (pact-id)))
+    (let
+      (
+        (sender (debit id (sale-account) amount))
+        (receiver (credit id buyer buyer-guard amount))
+      )
+      (emit-event (TRANSFER id (sale-account) buyer amount))
+      (emit-event (RECONCILE id amount sender receiver))
+      true
+  ))
+
+  (defun sale-active:bool (timeout:integer)
+    @doc "Sale is active until TIMEOUT time."
+    (if (= 0 timeout)
+      true
+      (< (at 'block-time (chain-data)) (add-time (time "1970-01-01T00:00:00Z") timeout))
+    )
+  )
+
+  (defun sale-account:string ()
+    (create-principal (create-capability-pact-guard (SALE_PRIVATE (pact-id))))
+  )
+)
+
+(if (read-msg 'upgrade )
+  (if (read-msg 'upgrade_version_1 )
+    [ (create-table versions) ]
+    ["upgrade complete"]
+  )
+  [ (create-table ledger)
+    (create-table tokens) ])
+
+(enforce-guard ADMIN-KS)

--- a/pact-tests/pact-tests/marmalade/pact/ledger/ledger.repl
+++ b/pact-tests/pact-tests/marmalade/pact/ledger/ledger.repl
@@ -1,0 +1,316 @@
+(load "../marmalade.repl")
+
+(typecheck "marmalade-v2.ledger")
+(begin-tx "create-token")
+
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use mini-guard-utils)
+  (env-chain-data {"chain-id": "0"})
+
+  (expect-failure "create a token with token-id with a protocol other than t:"
+    "Unrecognized reserved protocol"
+    (create-token "a:bc" 0 "test-uri" [] ALWAYS-TRUE))
+
+  (expect-failure "create a token with token-id not using a protocol"
+    "Unrecognized reserved protocol"
+    (create-token "abc" 0 "test-uri" [] ALWAYS-TRUE))
+
+  (expect-failure "create a token with token-id that doesn't satisfy t: protocol"
+    "Token protocol violation"
+    (create-token
+      (create-token-id { 'uri: "test-uri-wrong", 'precision: 0, 'policies: [] } ALWAYS-TRUE)
+      0 "test-uri" [] ALWAYS-TRUE))
+
+  (expect-failure "create a token with uri starting with marmalade fails"
+    "Reserved protocol: marmalade:"
+    (create-token
+      (create-token-id { 'uri: "marmalade:uri", 'precision: 0, 'policies: [] } ALWAYS-TRUE)
+       0 "marmalade:uri" [] ALWAYS-TRUE))
+
+  (expect "create a token with token-id that satisfies t: protocol"
+    true
+    (create-token
+      (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: [] } ALWAYS-TRUE)
+       0 "test-uri" [] ALWAYS-TRUE))
+
+  (expect "Token info is inserted into table"
+    { "id": "t:YV6-cQBhE_EoIXAuNV08aGXLfcucBEGy0Gb1Pj6w_Oo"
+     ,"supply": 0.0
+     ,"precision": 0
+     ,"uri": "test-uri"
+     ,"policies": []
+    }
+    (get-token-info "t:YV6-cQBhE_EoIXAuNV08aGXLfcucBEGy0Gb1Pj6w_Oo")
+  )
+
+  (expect "create-token events"
+     (format "{}" [[
+     {"name": "marmalade-v2.ledger.TOKEN","params": ["t:YV6-cQBhE_EoIXAuNV08aGXLfcucBEGy0Gb1Pj6w_Oo" 0 [] "test-uri" ALWAYS-TRUE]}]])
+     (format "{}" [(map (remove "module-hash")  (env-events true))])
+  )
+
+(commit-tx)
+
+(begin-tx "mint")
+  (use marmalade-v2.ledger)
+
+  (env-data {
+     "token-id": "t:YV6-cQBhE_EoIXAuNV08aGXLfcucBEGy0Gb1Pj6w_Oo"
+    ,"account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+    ,"account-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+    })
+
+  (expect-failure "mint fails without MINT capability in scope"
+    "Managed capability not installed: (marmalade-v2.ledger.MINT"
+    (mint (read-msg 'token-id) (read-msg 'account) (read-keyset 'account-guard) 1.0))
+
+  (env-sigs [
+    { 'key: 'any
+     ,'caps: [(MINT (read-msg "token-id") (read-string 'account) 1.0)]}
+   ])
+
+  (expect "mint succeeds"
+    true
+    (mint (read-msg 'token-id) (read-msg 'account) (read-keyset 'account-guard) 1.0))
+
+  (expect "Token supply is updated"
+    { "id": (read-string "token-id")
+     ,"supply": 1.0
+     ,"precision": 0
+     ,"uri": "test-uri"
+     ,"policies": []
+    }
+    (get-token-info (read-string "token-id"))
+  )
+
+  (expect "Account is credited"
+    1.0
+    (get-balance (read-string "token-id") (read-string "account"))
+  )
+
+  (expect "mint events"
+    [
+      {"name": "marmalade-v2.ledger.MINT","params": [(read-string "token-id") (read-string "account") 1.0]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string "token-id") (read-string "account") (read-keyset "account-guard")]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-string "token-id") 1.0 {"account": "","current": 0.0,"previous": 0.0} {"account": (read-string "account"),"current": 1.0,"previous": 0.0}]}
+      {"name": "marmalade-v2.ledger.SUPPLY","params": [(read-string "token-id") 1.0]}
+    ]
+    (map (remove "module-hash")  (env-events true))
+  )
+
+(commit-tx)
+
+(begin-tx "offer, withdraw with timeout")
+  (env-hash (hash "offer-0"))
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.util-v1)
+  (env-chain-data {"block-time": (time "2023-07-20T11:26:35Z")})
+
+  (env-data {
+     "token-id": "t:YV6-cQBhE_EoIXAuNV08aGXLfcucBEGy0Gb1Pj6w_Oo"
+     ,"account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+     ,"account-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+    })
+
+  (expect-failure "offer fails when called directly"
+    "pact-id: not in pact execution"
+    (offer (read-string "token-id") (read-string "account") 1.0)
+  )
+
+  (expect-failure "offer fails without OFFER capability in scope"
+    "Managed capability not installed: (marmalade-v2.ledger.OFFER"
+    (sale (read-string "token-id") (read-string "account") 1.0 (to-timestamp (time "2023-07-22T11:26:35Z")))
+  )
+
+  (env-sigs [
+    { 'key: 'any
+     ,'caps: [(marmalade-v2.ledger.OFFER (read-string "token-id") (read-string "account") 1.0 (to-timestamp (time "2023-07-22T11:26:35Z")))]}
+  ])
+
+  (expect-failure "offer fails if OFFER capability is not signed by seller"
+    "Keyset failure (keys-all): [e4c6807d...]"
+    (sale (read-string "token-id") (read-string "account") 1.0 (to-timestamp (time "2023-07-22T11:26:35Z")))
+  )
+
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+     ,'caps: [(marmalade-v2.ledger.OFFER (read-string "token-id") (read-string "account") 1.0 (to-timestamp (time "2023-07-22T11:26:35Z")))]}
+  ])
+
+  (expect "offer succeeds"
+    (pact-id)
+    (sale (read-string "token-id") (read-string "account") 1.0 (to-timestamp (time "2023-07-22T11:26:35Z")))
+  )
+
+  (expect "Seller account is debited"
+    0.0
+    (get-balance (read-string "token-id") (read-string "account"))
+  )
+
+  (expect "Escrow account is credited"
+    1.0
+    (get-balance (read-string "token-id") "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc")
+  )
+
+  (expect "offer events"
+    [ {"name": "marmalade-v2.ledger.OFFER","params": [(read-string "token-id") (read-string "account") 1.0 1690025195]}
+      {"name": "marmalade-v2.ledger.SALE","params": [(read-string "token-id") (read-string "account") 1.0 1690025195 "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string "token-id") "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc" (create-capability-pact-guard (SALE_PRIVATE "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"))]}
+      {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-string "token-id") (read-string "account") "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc" 1.0]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-string "token-id") 1.0 {"account": (read-string "account"),"current": 0.0,"previous": 1.0} {"account": "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc","current": 1.0,"previous": 0.0}]}]
+    (map (remove "module-hash")  (env-events true))
+  )
+
+  (env-sigs [
+    { 'key: 'any
+     ,'caps: [(marmalade-v2.ledger.WITHDRAW (read-string "token-id") (read-string "account") 1.0 (to-timestamp (time "2023-07-22T11:26:35Z")) (pact-id))]}
+  ])
+
+  (env-chain-data {"block-time": (time "2023-07-21T11:26:35Z")})
+
+  (expect-failure "withdraw fails before timeout has passed"
+    "WITHDRAW: still active"
+    (continue-pact 0 true)
+  )
+
+  (env-chain-data {"block-time": (time "2023-07-23T11:26:35Z")})
+
+  (env-sigs [])
+
+  (expect-failure "withdraw fails when called directly"
+    "require-capability: not granted: (marmalade-v2.ledger.SALE_PRIVATE"
+    (withdraw (read-string "token-id") (read-string "account") 1.0)
+  )
+
+  (expect-failure "withdraw fails without WITHDRAW capability in scope"
+    "Managed capability not installed: (marmalade-v2.ledger.WITHDRAW"
+    (continue-pact 0 true)
+  )
+
+  (env-sigs [
+    { 'key: 'any
+     ,'caps: [(marmalade-v2.ledger.WITHDRAW (read-string "token-id") (read-string "account") 1.0 (to-timestamp (time "2023-07-22T11:26:35Z")) (pact-id))]}
+  ])
+
+  (expect "withdraw succeeds when WITHDRAW capability in scope, regardless of signer"
+    (pact-id)
+    (continue-pact 0 true)
+  )
+
+  (expect "withdraw events"
+    [ {"name": "marmalade-v2.ledger.WITHDRAW","params": ["t:YV6-cQBhE_EoIXAuNV08aGXLfcucBEGy0Gb1Pj6w_Oo" "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3" 1.0 1690025195 "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"]}
+      {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:YV6-cQBhE_EoIXAuNV08aGXLfcucBEGy0Gb1Pj6w_Oo" "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc" "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3" 1.0]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:YV6-cQBhE_EoIXAuNV08aGXLfcucBEGy0Gb1Pj6w_Oo" 1.0 {"account": "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc","current": 0.0,"previous": 1.0} {"account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3","current": 1.0,"previous": 0.0}]}]
+    (map (remove "module-hash")  (env-events true))
+  )
+
+(rollback-tx)
+
+(begin-tx "offer, withdraw without timeout")
+
+(env-hash (hash "offer-1"))
+(use marmalade-v2.ledger)
+(env-chain-data {"block-time": (time "2023-07-20T11:26:35Z")})
+
+(env-sigs [
+  { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+   ,'caps: [(marmalade-v2.ledger.OFFER (read-string "token-id") (read-string "account") 1.0 0)]}
+])
+
+(expect "offer succeeds"
+  (pact-id)
+  (sale (read-string "token-id") (read-string "account") 1.0 0)
+)
+
+(expect "Seller account is debited"
+  0.0
+  (get-balance (read-string "token-id") (read-string "account"))
+)
+
+(expect "Escrow account is credited"
+  1.0
+  (get-balance (read-string "token-id") "c:TCxrhvg6e_NUVqelF7bnXTT7aabA5qtKdKUXCUXo2_Q")
+)
+
+(expect "offer events"
+  [ {"name": "marmalade-v2.ledger.OFFER","params": [(read-string "token-id") (read-string "account") 1.0 0]}
+    {"name": "marmalade-v2.ledger.SALE","params": [(read-string "token-id") (read-string "account") 1.0 0 (pact-id)]}
+    {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string "token-id") "c:TCxrhvg6e_NUVqelF7bnXTT7aabA5qtKdKUXCUXo2_Q" (create-capability-pact-guard (SALE_PRIVATE (pact-id)))]}
+    {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-string "token-id") (read-string "account") "c:TCxrhvg6e_NUVqelF7bnXTT7aabA5qtKdKUXCUXo2_Q" 1.0]}
+    {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-string "token-id") 1.0 {"account": (read-string "account"),"current": 0.0,"previous": 1.0} {"account": "c:TCxrhvg6e_NUVqelF7bnXTT7aabA5qtKdKUXCUXo2_Q","current": 1.0,"previous": 0.0}]}]
+  (map (remove "module-hash")  (env-events true))
+)
+
+(env-chain-data {"block-time": (time "2023-07-25T11:26:35Z")})
+
+(expect-failure "withdraw fails when called directly"
+  "require-capability: not granted: (marmalade-v2.ledger.SALE_PRIVATE"
+  (withdraw (read-string "token-id") (read-string "account") 1.0)
+)
+
+(expect-failure "withdraw fails without WITHDRAW capability in scope"
+  "Managed capability not installed: (marmalade-v2.ledger.WITHDRAW"
+  (continue-pact 0 true)
+)
+
+(env-sigs [
+  { 'key: 'any
+   ,'caps: [(marmalade-v2.ledger.WITHDRAW (read-string "token-id") (read-string "account") 1.0 0 (pact-id))]}
+])
+
+(expect-failure "withdraw fails when sig is not signed"
+  "Keyset failure (keys-all): "
+  (continue-pact 0 true)
+)
+
+(env-sigs [
+  { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+   ,'caps: [(marmalade-v2.ledger.WITHDRAW (read-string "token-id") (read-string "account") 1.0 0 (pact-id))]}
+])
+
+(expect "withdraw succeeds"
+  (pact-id)
+  (continue-pact 0 true)
+)
+
+(expect "withdraw events"
+  [
+    {"name": "marmalade-v2.ledger.WITHDRAW","params": ["t:YV6-cQBhE_EoIXAuNV08aGXLfcucBEGy0Gb1Pj6w_Oo" (read-string "account") 1.0 0 "DKc5HEWcmP8iPWue2WvMcnjn_WnowmuHz5Ogukm2SWk"]}
+    {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:YV6-cQBhE_EoIXAuNV08aGXLfcucBEGy0Gb1Pj6w_Oo" "c:TCxrhvg6e_NUVqelF7bnXTT7aabA5qtKdKUXCUXo2_Q" "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3" 1.0]}
+    {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:YV6-cQBhE_EoIXAuNV08aGXLfcucBEGy0Gb1Pj6w_Oo" 1.0 {"account": "c:TCxrhvg6e_NUVqelF7bnXTT7aabA5qtKdKUXCUXo2_Q","current": 0.0,"previous": 1.0} {"account": (read-string "account"),"current": 1.0,"previous": 0.0}
+  ]}]
+  (map (remove "module-hash")  (env-events true))
+)
+
+(rollback-tx)
+
+(begin-tx "transfer-crosschain fails")
+  (use mini-guard-utils)
+
+  (expect-failure "transfer-crosschain is prohibited"
+    "cross chain not supported"
+    (marmalade-v2.ledger.transfer-crosschain "" "" "" ALWAYS-TRUE "" 0.0)
+  )
+
+(commit-tx)
+
+
+(begin-tx "update uri of a token")
+
+(env-sigs [
+  { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+   ,'caps: [(marmalade-v2.ledger.UPDATE-URI (read-string "token-id") "updated-uri")]}
+])
+
+(expect "update uri succeeds when created without guards policy"
+  true
+  (marmalade-v2.ledger.update-uri "t:YV6-cQBhE_EoIXAuNV08aGXLfcucBEGy0Gb1Pj6w_Oo" "updated-uri")
+)
+
+(expect "uri events"
+  [{"name": "marmalade-v2.ledger.UPDATE-URI","params": ["t:YV6-cQBhE_EoIXAuNV08aGXLfcucBEGy0Gb1Pj6w_Oo" "updated-uri"]}]
+  (map (remove "module-hash")  (env-events true))
+)
+
+(commit-tx)

--- a/pact-tests/pact-tests/marmalade/pact/marmalade-ns/ns-contract-admin.pact
+++ b/pact-tests/pact-tests/marmalade/pact/marmalade-ns/ns-contract-admin.pact
@@ -1,0 +1,3 @@
+(namespace (read-msg 'ns))
+(define-keyset  (+ (read-msg 'ns) ".marmalade-contract-admin"))
+(enforce-guard (+ (read-msg 'ns) ".marmalade-contract-admin"))

--- a/pact-tests/pact-tests/marmalade/pact/marmalade-ns/ns-marmalade.pact
+++ b/pact-tests/pact-tests/marmalade/pact/marmalade-ns/ns-marmalade.pact
@@ -1,0 +1,5 @@
+(ns.write-registry (read-msg 'ns) (read-keyset 'marmalade-admin) true)
+(define-namespace
+  (read-msg 'ns)
+  (read-keyset 'marmalade-user) (read-keyset 'marmalade-admin)
+)

--- a/pact-tests/pact-tests/marmalade/pact/marmalade-util/util-v1.md
+++ b/pact-tests/pact-tests/marmalade/pact/marmalade-util/util-v1.md
@@ -1,0 +1,45 @@
+
+# Util V1
+
+This contract, `util-v1`, is designed to locate utility functions that marmalade functions can leverage, including easy creation or minting of the marmalade tokens, or concrete-policy formation.
+
+## Specifications and Tables:
+
+**Capabilities**:
+ - `GOVERNANCE`: enforces access control of contract upgrade.
+ - `UTIL_SIGN`: provides a capability to scope user's signature. NOTE that the capability will scope the user's signature to all the policies that the token is created with. Users are encouraged to only sign the capability when using a basic NFT with only `non-fungible-policy-v1`, and scope the signatures to only the code that enforces the signature.
+
+## Functions:
+
+### mint-NFT
+
+This function merges the `marmalade-v2.ledger.create-token` and `marmalade-v2.ledger.mint` functions to provide users a easier minting experience. The function limits its usage to tokens that implement the concrete-policy,`NON-FUNGIBLE-POLICY`, which programs the token to limit the supply to 1 and precision to 0, making the token one and only.
+The function takes in 3 parameters, `uri` , `policies`, `guard`, and crafts the `account` name using `create-principal` pact native function by inputting the guard, and must be signed with `guard`.
+
+
+### mint-basic-NFT
+
+This function wraps the `mint-NFT` token, and provides an easy tool to create token without any configuration. The token will be available to participate in Marmalade sales, but will not have any additional features such as royalties or collections.
+
+### create-token-with-mint-guard
+
+This function is a wrapper function around `marmalade-v2.ledger.create-token`. DApps can leverage the function
+to enforce that `mint_guard` is always registered with `guard-token-policy-v1`.
+
+#### create-policies
+
+The function takes in a `{concrete-policy-bool}` schema and generates a list, `[module{kip.token-policy-v2}]`, filtering only the modules selected to `true`.
+
+### create-concrete-policy
+
+This function is opposite of `create-policies`, and takes in the list of token-policies and returns a `{concrete-policy-bool}`, providing an easy way to learn which concrete features are active to token.
+
+### to-timestamp
+
+This function takes in `time` argument and returns a UTC timestamp as `integer`. This function can be used in
+Marmalade sales, which requires an UTC timestamp in `integer` type.
+
+### curr-time
+
+This function returns the block time in UTC timestamp as `integer`. This function can be used in
+policies or sale contracts to check against various logics. 

--- a/pact-tests/pact-tests/marmalade/pact/marmalade-util/util-v1.pact
+++ b/pact-tests/pact-tests/marmalade/pact/marmalade-util/util-v1.pact
@@ -1,0 +1,132 @@
+(namespace (read-string 'ns))
+
+(module util-v1 GOVERNANCE
+  (use kip.token-policy-v2)
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-v2.policy-manager [CONCRETE_POLICY_LIST NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY GUARD_POLICY])
+
+  (defconst ADMIN-KS:string "marmalade-v2.marmalade-contract-admin")
+
+  (defcap GOVERNANCE ()
+    (enforce-guard ADMIN-KS))
+
+  (defcap UTIL-SIGN ()
+    @doc "Capabiltiy to easily scope signatures"
+    true
+  )
+
+  (defschema concrete-policy-bool
+    non-fungible-policy:bool
+    royalty-policy:bool
+    collection-policy:bool
+    guard-policy:bool
+  )
+
+  (defconst DEFAULT:object{concrete-policy-bool}
+    { 'non-fungible-policy: true
+     ,'royalty-policy: false
+     ,'collection-policy:false
+     ,'guard-policy: true
+     })
+
+  (defconst DEFAULT_ROYALTY:object{concrete-policy-bool}
+    { 'non-fungible-policy: true
+     ,'royalty-policy: true
+     ,'collection-policy:false
+     ,'guard-policy: true
+    }
+  )
+
+  (defconst DEFAULT_COLLECTION:object{concrete-policy-bool}
+    { 'non-fungible-policy: true
+     ,'royalty-policy: false
+     ,'collection-policy: true
+     ,'guard-policy: true
+    }
+  )
+
+  (defconst DEFAULT_COLLECTION_ROYALTY:object{concrete-policy-bool}
+    { 'non-fungible-policy: true
+     ,'royalty-policy: true
+     ,'collection-policy: true
+     ,'guard-policy: true
+    }
+  )
+
+  (defconst EMPTY:object{concrete-policy-bool}
+    { 'non-fungible-policy: false
+     ,'royalty-policy: false
+     ,'collection-policy:false
+     ,'guard-policy: false
+    }
+  )
+
+  (defun create-policies (concrete-policy:object{concrete-policy-bool})
+    (let* ( (is-used-policy (lambda (policy-field:string) (at policy-field concrete-policy)))
+            (used-policies:[string] (filter (is-used-policy) CONCRETE_POLICY_LIST)))
+          (map (get-concrete-policy) used-policies))
+  )
+
+  (defun create-concrete-policy:object{concrete-policy-bool} (policies:[module{kip.token-policy-v2}])
+    { 'non-fungible-policy: (contains (get-concrete-policy NON_FUNGIBLE_POLICY) policies)
+     ,'royalty-policy: (contains (get-concrete-policy ROYALTY_POLICY) policies)
+     ,'collection-policy: (contains (get-concrete-policy COLLECTION_POLICY) policies)
+     ,'guard-policy: (contains (get-concrete-policy GUARD_POLICY) policies)
+    }
+  )
+
+  (defun contains-concrete-policy:bool (concrete-policy:string policies:[module{kip.token-policy-v2}])
+    (let* ( (policy-modref:module{kip.token-policy-v2} (get-concrete-policy concrete-policy) )
+            (policy-str:string (format "{}" [policy-modref]) )
+            (policies-str:[string] (map (lambda (policy:module{kip.token-policy-v2})
+                                      (format "{}" [policy])) policies)) )
+    (enforce (contains policy-str policies-str) (format "{} is required" [concrete-policy])))
+    true
+  )
+
+  (defun to-timestamp:integer (input:time)
+    "Computes an Unix timestamp of the input date"
+    (floor (diff-time input (time "1970-01-01T00:00:00Z")))
+  )
+
+  (defun curr-time:integer ()
+    "Computes an Unix timestamp of the block time"
+    (to-timestamp (at 'block-time (chain-data)))
+  )
+
+  (defun mint-NFT (uri:string policies:[module{kip.token-policy-v2}] guard:guard)
+    @doc "Mints a NON-FUNGIBLE-TOKEN with policies and creation-guard"
+    (let* ( (nfp-precision:integer 0)
+            (account:string (create-principal guard))
+            (nfp-amount:decimal 1.0)
+            (token-id:string (create-token-id {'uri: uri, 'precision: nfp-precision, 'policies: policies} guard)) )
+      (contains-concrete-policy NON_FUNGIBLE_POLICY policies)
+      (with-capability (UTIL-SIGN)
+        (create-token token-id nfp-precision uri policies guard)
+      )
+      (install-capability (MINT token-id account nfp-amount))
+      (mint token-id account guard nfp-amount)
+    )
+  )
+
+  (defun mint-basic-NFT (uri:string guard:guard)
+    @doc "Mints a NON-FUNGIBLE-TOKEN without any configuration"
+    (mint-NFT uri [(get-concrete-policy NON_FUNGIBLE_POLICY)] guard)
+  )
+
+  (defun create-token-with-mint-guard (uri:string precision:integer policies:[module{kip.token-policy-v2}])
+    @doc "Creates a token, enforce that MINT-GUARD is registered"
+    (let* ( (mint-guard:guard (read-keyset "mint_guard"))
+            (token-id:string (create-token-id {'uri: uri, 'precision: precision, 'policies: policies} mint-guard))
+            )
+      (contains-concrete-policy GUARD_POLICY policies)
+      (with-capability (UTIL-SIGN)
+        (create-token token-id precision uri policies mint-guard)
+      )
+    )
+  )
+
+)
+
+(enforce-guard ADMIN-KS)

--- a/pact-tests/pact-tests/marmalade/pact/marmalade-util/util-v1.repl
+++ b/pact-tests/pact-tests/marmalade/pact/marmalade-util/util-v1.repl
@@ -1,0 +1,127 @@
+(load "../marmalade.repl")
+
+(typecheck "marmalade-v2.util-v1")
+
+(begin-tx "mint a featureless NFT")
+
+  (use marmalade-v2.util-v1)
+  (env-data {
+    "account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3",
+    "account-guard": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"]
+  })
+
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+     ,'caps: [(marmalade-v2.util-v1.UTIL-SIGN) ]
+    }
+   ])
+
+  (mint-basic-NFT "uri" (read-keyset 'account-guard ))
+
+  (expect "create-token, mint events"
+     [ {"name": "marmalade-v2.ledger.TOKEN","params": ["t:Ov0cEBLMvSo2E1ys7dWLgqGTT9OYOLyILf1ow9Gopek" 0 [marmalade-v2.non-fungible-policy-v1] "uri" (read-keyset 'account-guard)]}
+       {"name": "marmalade-v2.ledger.MINT","params": ["t:Ov0cEBLMvSo2E1ys7dWLgqGTT9OYOLyILf1ow9Gopek" (read-string 'account) 1.0]}
+       {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:Ov0cEBLMvSo2E1ys7dWLgqGTT9OYOLyILf1ow9Gopek" (read-string 'account) (read-keyset 'account-guard)]}
+       {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:Ov0cEBLMvSo2E1ys7dWLgqGTT9OYOLyILf1ow9Gopek" 1.0 {"account": "","current": 0.0,"previous": 0.0} {"account": (read-string 'account),"current": 1.0,"previous": 0.0}]}
+       {"name": "marmalade-v2.ledger.SUPPLY","params": ["t:Ov0cEBLMvSo2E1ys7dWLgqGTT9OYOLyILf1ow9Gopek" 1.0]}]
+     (map (remove "module-hash")  (env-events true))
+  )
+
+(commit-tx)
+
+(begin-tx "mint a NFT with policies")
+
+  (use marmalade-v2.util-v1)
+  (env-data {
+    "account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3",
+    "account-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"},
+    "sale_guard": {"keys": ["6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"], "pred": "keys-all"}
+  })
+
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+     ,'caps: [(marmalade-v2.ledger.CREATE-TOKEN "t:KCqmjoC9QK86p3YF5MmVJMfC7Ngq5PRZHCiHf73-hss") ]
+    }
+   ])
+
+  (expect "mint default NFT using mint-NFT "
+    true
+    (mint-NFT "uri-1" (create-policies DEFAULT) (read-keyset 'account-guard )))
+
+  (expect "create-token, mint events"
+     [ {"name": "marmalade-v2.guard-policy-v1.GUARDS","params": ["t:KCqmjoC9QK86p3YF5MmVJMfC7Ngq5PRZHCiHf73-hss" {"burn-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"mint-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"sale-guard": (read-keyset 'sale_guard),"transfer-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS, "uri-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS}]}
+       {"name": "marmalade-v2.ledger.TOKEN","params": ["t:KCqmjoC9QK86p3YF5MmVJMfC7Ngq5PRZHCiHf73-hss" 0 [marmalade-v2.non-fungible-policy-v1 marmalade-v2.guard-policy-v1] "uri-1" (read-keyset 'account-guard)]}
+       {"name": "marmalade-v2.ledger.MINT","params": ["t:KCqmjoC9QK86p3YF5MmVJMfC7Ngq5PRZHCiHf73-hss" (read-string 'account) 1.0]}
+       {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:KCqmjoC9QK86p3YF5MmVJMfC7Ngq5PRZHCiHf73-hss" (read-string 'account) (read-keyset 'account-guard)]}
+       {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:KCqmjoC9QK86p3YF5MmVJMfC7Ngq5PRZHCiHf73-hss" 1.0 {"account": "","current": 0.0,"previous": 0.0} {"account": (read-string 'account),"current": 1.0,"previous": 0.0}]}
+       {"name": "marmalade-v2.ledger.SUPPLY","params": ["t:KCqmjoC9QK86p3YF5MmVJMfC7Ngq5PRZHCiHf73-hss" 1.0]}]
+     (map (remove "module-hash")  (env-events true))
+  )
+
+(commit-tx)
+
+(begin-tx)
+  (use marmalade-v2.util-v1)
+  (env-data {"mint_guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}})
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+     ,'caps: [(marmalade-v2.ledger.CREATE-TOKEN "t:L3Eh5k3RUJDiD2AWahQwaQPJJ6S3_L9tK2svspfpRPQ")]
+    }
+   ])
+  (expect "create-tokne with a mint guard"
+    true
+    (create-token-with-mint-guard "ur1i" 0 (create-policies DEFAULT)))
+
+  (expect "create-token, events"
+    [ {"name": "marmalade-v2.guard-policy-v1.GUARDS","params": ["t:L3Eh5k3RUJDiD2AWahQwaQPJJ6S3_L9tK2svspfpRPQ" {"burn-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"mint-guard": (read-keyset 'mint_guard),"sale-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS,"transfer-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS, "uri-guard": marmalade-v2.guard-policy-v1.GUARD_SUCCESS}]}
+      {"name": "marmalade-v2.ledger.TOKEN","params": ["t:L3Eh5k3RUJDiD2AWahQwaQPJJ6S3_L9tK2svspfpRPQ" 0 [marmalade-v2.non-fungible-policy-v1 marmalade-v2.guard-policy-v1] "ur1i" (read-keyset 'mint_guard)]}]
+     (map (remove "module-hash")  (env-events true))
+  )
+(commit-tx)
+
+(begin-tx)
+  (use marmalade-v2.util-v1)
+
+  (env-data {
+    "account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3",
+    "account-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}}
+  )
+
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+     ,'caps: [
+       (marmalade-v2.ledger.MINT "t:L3Eh5k3RUJDiD2AWahQwaQPJJ6S3_L9tK2svspfpRPQ" (read-string 'account) 1.0)
+       (marmalade-v2.guard-policy-v1.MINT "t:L3Eh5k3RUJDiD2AWahQwaQPJJ6S3_L9tK2svspfpRPQ" (read-string 'account) 1.0)
+     ]
+    }
+   ])
+
+
+  (marmalade-v2.ledger.mint "t:L3Eh5k3RUJDiD2AWahQwaQPJJ6S3_L9tK2svspfpRPQ" (read-string 'account) (read-keyset 'account-guard ) 1.0)
+  (expect "mint, events"
+    [ {"name": "marmalade-v2.ledger.MINT","params": ["t:L3Eh5k3RUJDiD2AWahQwaQPJJ6S3_L9tK2svspfpRPQ" (read-string 'account) 1.0]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:L3Eh5k3RUJDiD2AWahQwaQPJJ6S3_L9tK2svspfpRPQ" (read-string 'account) (read-keyset 'account-guard)]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:L3Eh5k3RUJDiD2AWahQwaQPJJ6S3_L9tK2svspfpRPQ" 1.0 {"account": "","current": 0.0,"previous": 0.0} {"account": (read-string 'account),"current": 1.0,"previous": 0.0}]}
+      {"name": "marmalade-v2.ledger.SUPPLY","params": ["t:L3Eh5k3RUJDiD2AWahQwaQPJJ6S3_L9tK2svspfpRPQ" 1.0]}]
+     (map (remove "module-hash")  (env-events true))
+  )
+(commit-tx)
+
+(begin-tx)
+
+  (env-chain-data {"block-time": (time "2023-10-01T00:00:00Z")})
+
+  (use marmalade-v2.util-v1)
+
+  (expect "to-timestamp takes in time arguement and returns timestamp"
+    1696118400 (to-timestamp (time "2023-10-01T00:00:00Z") ))
+
+  (expect "curr-time returns current time in timestamp"
+    1696118400 (curr-time))
+
+  (env-chain-data {"block-time": (time "2023-10-02T00:00:00Z")})
+
+  (expect "curr-time returns current time in timestamp"
+    1696204800 (curr-time))
+
+(commit-tx)

--- a/pact-tests/pact-tests/marmalade/pact/marmalade.repl
+++ b/pact-tests/pact-tests/marmalade/pact/marmalade.repl
@@ -1,0 +1,437 @@
+(begin-tx)
+  (env-data
+    { 'ns-admin-keyset: []
+    , 'ns-genesis-keyset:[]
+    , 'ns-operate-keyset:[] })
+  (load "./root/fungible-v2.pact")
+  (load "./root/fungible-xchain-v1.pact")
+  (load "./root/coin.pact")
+  (load "./root/gas-payer-v1.pact")
+  (env-exec-config ["DisablePact44"])
+  (load "./root/ns.pact")
+  (env-exec-config [])
+
+ (define-namespace 'kip (sig-keyset) (sig-keyset))
+
+  (load "./kip/account-protocols-v1.pact")
+  (env-data
+  { 'ns: "kip"
+  , 'upgrade: false })
+
+  (load "./kip/manifest.pact")
+  (load "./kip/token-policy-v2.pact")
+  (load "./kip/updatable-uri-policy-v1.pact")
+  (load "./kip/poly-fungible-v3.pact")
+  (define-namespace 'util (sig-keyset) (sig-keyset))
+  (load "./util/fungible-util.pact")
+  (load "./util/guards1.pact")
+(commit-tx)
+
+(begin-tx "deploy marmalade-v2 namespace and admin keyset")
+  (env-data
+   { 'marmalade-admin: ["marmalade-admin"]
+   , 'marmalade-user: ["marmalade-user"]
+   , 'ns: "marmalade-v2"
+   , 'upgrade: false })
+   (env-sigs [
+     { 'key: 'marmalade-admin
+      ,'caps: []
+      }])
+  (load "./marmalade-ns/ns-marmalade.pact")
+  (env-data
+   { "marmalade-v2.marmalade-contract-admin": ["marmalade-contract-admin"]
+   , 'ns: "marmalade-v2"
+   , 'upgrade: false })
+   (env-sigs [
+     { 'key: 'marmalade-user
+      ,'caps: []
+     }, {
+       'key: 'marmalade-contract-admin
+      ,'caps: []
+      }])
+  (load "./marmalade-ns/ns-contract-admin.pact")
+(commit-tx)
+
+(begin-tx "deploy marmalade-sale namespace and admin keyset")
+  (env-data
+   { 'marmalade-admin: ["marmalade-admin"]
+   , 'marmalade-user: ["marmalade-user"]
+   , 'ns: "marmalade-sale"
+   , 'upgrade: false })
+   (env-sigs [
+     { 'key: 'marmalade-admin
+      ,'caps: []
+      }])
+  (load "./marmalade-ns/ns-marmalade.pact")
+  (env-data
+   { "marmalade-sale.marmalade-contract-admin": ["marmalade-contract-admin"]
+   , 'ns: "marmalade-sale"
+   , 'upgrade: false })
+   (env-sigs [
+     { 'key: 'marmalade-user
+      ,'caps: []
+     }, {
+       'key: 'marmalade-contract-admin
+      ,'caps: []
+      }])
+  (load "./marmalade-ns/ns-contract-admin.pact")
+
+(commit-tx)
+
+(env-data
+ { 'marmalade-admin: ["marmalade-admin"]
+ , 'marmalade-user: ["marmalade-user"]
+ , 'ns: "marmalade-v2"
+ , 'upgrade: false })
+
+(begin-tx)
+
+  (load "./ledger/ledger.interface.pact")
+  (load "./ledger/ledger-v2.interface.pact")
+  (load "./policy-manager/sale.interface.pact")
+  (load "./policy-manager/policy-manager.pact")
+  (load "./ledger/ledger.pact")
+  (load "./marmalade-util/util-v1.pact")
+  (load "./test/abc.pact")
+  (load "./test/def.pact")
+(commit-tx)
+
+(begin-tx "load concrete-polices")
+  (load "./concrete-policies/non-fungible-policy/non-fungible-policy-v1.pact")
+  (load "./concrete-policies/royalty-policy/royalty-policy-v1.pact")
+  (load "./concrete-policies/collection-policy/collection-policy-v1.pact")
+  (load "./concrete-policies/guard-policy/guard-policy-v1.pact")
+  (load "./policy-manager/manager-init.pact")
+(commit-tx)
+
+(begin-tx)
+  (module mini-guard-utils G
+    (defcap G() true)
+    (defun always-true:bool () true)
+    (defconst ALWAYS-TRUE:guard (create-user-guard (always-true)))
+  )
+(commit-tx)
+
+
+(begin-tx "upgrade marmalade")
+  (env-sigs [
+    { 'key: 'marmalade-user
+     ,'caps: []
+    }, {
+      'key: 'marmalade-contract-admin
+     ,'caps: []
+     }])
+  (env-data
+   { 'marmalade-admin: ["marmalade-admin"]
+   , 'marmalade-user: ["marmalade-user"]
+   , 'ns: "marmalade-v2"
+   , 'upgrade: true
+   , 'upgrade_version_1: true })
+  (load "./ledger/ledger.pact")
+  (load "./concrete-policies/guard-policy/guard-policy-v1.pact")
+(commit-tx)
+
+(begin-tx "create-token")
+
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+
+  (env-data {'c-ks: {"keys": ["creation-guard"], "pred": "keys-all"},
+             'bad-c-ks: {"keys": ["bad-creation-guard"], "pred": "keys-all"}
+            })
+
+  (env-chain-data {"chain-id": "0"})
+
+  (expect-failure "create a token without creation-guard signature"
+    "Keyset failure"
+    (create-token
+      (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: [] } (read-keyset 'c-ks))
+      0 "test-uri" [] (read-keyset 'c-ks)))
+
+  (env-sigs [{"key":"creation-guard", "caps":[]}])
+
+  (expect-failure "create a token with a bad creation-guard signature"
+    "Keyset failure"
+    (create-token
+      (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: [] } (read-keyset 'bad-c-ks))
+      0 "test-uri" [] (read-keyset 'bad-c-ks)))
+
+  (expect-failure "create a token with token-id with a protocol other than t:"
+    "Unrecognized reserved protocol"
+    (create-token "a:bc" 0 "test-uri" [] (read-keyset 'c-ks)))
+
+  (expect-failure "create a token with token-id not using a protocol"
+    "Unrecognized reserved protocol"
+    (create-token "abc" 0 "test-uri" [] (read-keyset 'c-ks)))
+
+  (expect-failure "create a token with token-id that doesn't satisfy t: protocol"
+    "Token protocol violation"
+    (create-token
+      (create-token-id { 'uri: "test-uri-wrong", 'precision: 0, 'policies: [] } (read-keyset 'c-ks))
+      0 "test-uri" [] (read-keyset 'c-ks)))
+
+  (expect-failure "create a token with uri starting with marmalade fails"
+    "Reserved protocol: marmalade:"
+    (create-token
+      (create-token-id { 'uri: "marmalade:uri", 'precision: 0, 'policies: [] } (read-keyset 'c-ks))
+       0 "marmalade:uri" [] (read-keyset 'c-ks)))
+
+  (expect "create a token with token-id that satisfies t: protocol"
+    true
+    (create-token
+      (create-token-id { 'uri: "test-uri", 'precision: 0, 'policies: [] } (read-keyset 'c-ks))
+       0 "test-uri" [] (read-keyset 'c-ks)))
+
+  (expect "Token info is inserted into table"
+    { "id": "t:_xAMunHwoHC8xdv5R9BfaJd-d3aUyOP8j6eDdHrBvTU"
+     ,"supply": 0.0
+     ,"precision": 0
+     ,"uri": "test-uri"
+     ,"policies": []
+    }
+    (get-token-info "t:_xAMunHwoHC8xdv5R9BfaJd-d3aUyOP8j6eDdHrBvTU")
+  )
+
+  (expect "create-token events"
+     (format "{}" [[
+     {"name": "marmalade-v2.ledger.TOKEN","params": ["t:_xAMunHwoHC8xdv5R9BfaJd-d3aUyOP8j6eDdHrBvTU" 0 [] "test-uri" (read-keyset 'c-ks)]}]])
+     (format "{}" [(map (remove "module-hash")  (env-events true))])
+  )
+
+(commit-tx)
+
+(begin-tx "mint")
+  (use marmalade-v2.ledger)
+
+  (env-data {
+     "token-id": "t:_xAMunHwoHC8xdv5R9BfaJd-d3aUyOP8j6eDdHrBvTU"
+    ,"account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+    ,"account-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+    })
+
+  (expect-failure "mint fails without MINT capability in scope"
+    "Managed capability not installed: (marmalade-v2.ledger.MINT"
+    (mint (read-msg 'token-id) (read-msg 'account) (read-keyset 'account-guard) 1.0))
+
+  (env-sigs [
+    { 'key: 'any
+     ,'caps: [(MINT (read-msg "token-id") (read-string 'account) 1.0)]}
+   ])
+
+  (expect "mint succeeds"
+    true
+    (mint (read-msg 'token-id) (read-msg 'account) (read-keyset 'account-guard) 1.0))
+
+  (expect "Token supply is updated"
+    { "id": (read-string "token-id")
+     ,"supply": 1.0
+     ,"precision": 0
+     ,"uri": "test-uri"
+     ,"policies": []
+    }
+    (get-token-info (read-string "token-id"))
+  )
+
+  (expect "Account is credited"
+    1.0
+    (get-balance (read-string "token-id") (read-string "account"))
+  )
+
+  (expect "mint events"
+    [
+      {"name": "marmalade-v2.ledger.MINT","params": [(read-string "token-id") (read-string "account") 1.0]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string "token-id") (read-string "account") (read-keyset "account-guard")]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-string "token-id") 1.0 {"account": "","current": 0.0,"previous": 0.0} {"account": (read-string "account"),"current": 1.0,"previous": 0.0}]}
+      {"name": "marmalade-v2.ledger.SUPPLY","params": [(read-string "token-id") 1.0]}
+    ]
+    (map (remove "module-hash")  (env-events true))
+  )
+
+(commit-tx)
+
+(begin-tx "offer, withdraw with timeout")
+  (env-hash (hash "offer-0"))
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.util-v1)
+  (env-chain-data {"block-time": (time "2023-07-20T11:26:35Z")})
+
+  (env-data {
+     "token-id": "t:_xAMunHwoHC8xdv5R9BfaJd-d3aUyOP8j6eDdHrBvTU"
+    ,"account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+    ,"account-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+    })
+
+  (expect-failure "offer fails when called directly"
+    "pact-id: not in pact execution"
+    (offer (read-string "token-id") (read-string "account") 1.0)
+  )
+
+  (expect-failure "offer fails without OFFER capability in scope"
+    "Managed capability not installed: (marmalade-v2.ledger.OFFER"
+    (sale (read-string "token-id") (read-string "account") 1.0 (to-timestamp (time "2023-07-22T11:26:35Z")))
+  )
+
+  (env-sigs [
+    { 'key: 'any
+     ,'caps: [(marmalade-v2.ledger.OFFER (read-string "token-id") (read-string "account") 1.0 (to-timestamp (time "2023-07-22T11:26:35Z")))]}
+  ])
+
+  (expect-failure "offer fails if OFFER capability is not signed by seller"
+    "Keyset failure (keys-all): [e4c6807d...]"
+    (sale (read-string "token-id") (read-string "account") 1.0 (to-timestamp (time "2023-07-22T11:26:35Z")))
+  )
+
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+     ,'caps: [(marmalade-v2.ledger.OFFER (read-string "token-id") (read-string "account") 1.0 (to-timestamp (time "2023-07-22T11:26:35Z")))]}
+  ])
+
+  (expect "offer succeeds"
+    (pact-id)
+    (sale (read-string "token-id") (read-string "account") 1.0 (to-timestamp (time "2023-07-22T11:26:35Z")))
+  )
+
+  (expect "Seller account is debited"
+    0.0
+    (get-balance (read-string "token-id") (read-string "account"))
+  )
+
+  (expect "Escrow account is credited"
+    1.0
+    (get-balance (read-string "token-id") "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc")
+  )
+
+  (expect "offer events"
+    [ {"name": "marmalade-v2.ledger.OFFER","params": [(read-string "token-id") (read-string "account") 1.0 1690025195]}
+      {"name": "marmalade-v2.ledger.SALE","params": [(read-string "token-id") (read-string "account") 1.0 1690025195 "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string "token-id") "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc" (create-capability-pact-guard (SALE_PRIVATE "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"))]}
+      {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-string "token-id") (read-string "account") "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc" 1.0]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-string "token-id") 1.0 {"account": (read-string "account"),"current": 0.0,"previous": 1.0} {"account": "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc","current": 1.0,"previous": 0.0}]}]
+    (map (remove "module-hash")  (env-events true))
+  )
+
+  (env-sigs [
+    { 'key: 'any
+     ,'caps: [(marmalade-v2.ledger.WITHDRAW (read-string "token-id") (read-string "account") 1.0 (to-timestamp (time "2023-07-22T11:26:35Z")) (pact-id))]}
+  ])
+
+  (env-chain-data {"block-time": (time "2023-07-21T11:26:35Z")})
+
+  (expect-failure "withdraw fails before timeout has passed"
+    "WITHDRAW: still active"
+    (continue-pact 0 true)
+  )
+
+  (env-chain-data {"block-time": (time "2023-07-23T11:26:35Z")})
+
+  (env-sigs [])
+
+  (expect-failure "withdraw fails when called directly"
+    "require-capability: not granted: (marmalade-v2.ledger.SALE_PRIVATE"
+    (withdraw (read-string "token-id") (read-string "account") 1.0)
+  )
+
+  (expect-failure "withdraw fails without WITHDRAW capability in scope"
+    "Managed capability not installed: (marmalade-v2.ledger.WITHDRAW"
+    (continue-pact 0 true)
+  )
+
+  (env-sigs [
+    { 'key: 'any
+     ,'caps: [(marmalade-v2.ledger.WITHDRAW (read-string "token-id") (read-string "account") 1.0 (to-timestamp (time "2023-07-22T11:26:35Z")) (pact-id))]}
+  ])
+
+  (expect "withdraw succeeds when WITHDRAW capability in scope, regardless of signer"
+    (pact-id)
+    (continue-pact 0 true)
+  )
+
+  (expect "withdraw events"
+    [ {"name": "marmalade-v2.ledger.WITHDRAW","params": ["t:_xAMunHwoHC8xdv5R9BfaJd-d3aUyOP8j6eDdHrBvTU" (read-string "account") 1.0 1690025195 "C1vw1eMf_DZV3oZjyinRIKrQV2rPMBMh3lydeduo8yg"]}
+      {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:_xAMunHwoHC8xdv5R9BfaJd-d3aUyOP8j6eDdHrBvTU" "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc" (read-string "account") 1.0]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:_xAMunHwoHC8xdv5R9BfaJd-d3aUyOP8j6eDdHrBvTU" 1.0 {"account": "c:WT_MPlkws_-GywvQmomGZwGsCJAcIWqrMSA9ie82FRc","current": 0.0,"previous": 1.0} {"account": (read-string "account"),"current": 1.0,"previous": 0.0}]}]
+    (map (remove "module-hash")  (env-events true))
+  )
+
+(rollback-tx)
+
+(begin-tx "offer, withdraw without timeout")
+
+(env-hash (hash "offer-1"))
+(use marmalade-v2.ledger)
+(env-chain-data {"block-time": (time "2023-07-20T11:26:35Z")})
+
+(env-sigs [
+  { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+   ,'caps: [(marmalade-v2.ledger.OFFER (read-string "token-id") (read-string "account") 1.0 0)]}
+])
+
+(expect "offer succeeds"
+  (pact-id)
+  (sale (read-string "token-id") (read-string "account") 1.0 0)
+)
+
+(expect "Seller account is debited"
+  0.0
+  (get-balance (read-string "token-id") (read-string "account"))
+)
+
+(expect "Escrow account is credited"
+  1.0
+  (get-balance (read-string "token-id") "c:TCxrhvg6e_NUVqelF7bnXTT7aabA5qtKdKUXCUXo2_Q")
+)
+
+(expect "offer events"
+  [ {"name": "marmalade-v2.ledger.OFFER","params": [(read-string "token-id") (read-string "account") 1.0 0]}
+    {"name": "marmalade-v2.ledger.SALE","params": [(read-string "token-id") (read-string "account") 1.0 0 (pact-id)]}
+    {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string "token-id") "c:TCxrhvg6e_NUVqelF7bnXTT7aabA5qtKdKUXCUXo2_Q" (create-capability-pact-guard (SALE_PRIVATE (pact-id)))]}
+    {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-string "token-id") (read-string "account") "c:TCxrhvg6e_NUVqelF7bnXTT7aabA5qtKdKUXCUXo2_Q" 1.0]}
+    {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-string "token-id") 1.0 {"account": (read-string "account"),"current": 0.0,"previous": 1.0} {"account": "c:TCxrhvg6e_NUVqelF7bnXTT7aabA5qtKdKUXCUXo2_Q","current": 1.0,"previous": 0.0}]}]
+  (map (remove "module-hash")  (env-events true))
+)
+
+(env-chain-data {"block-time": (time "2023-07-25T11:26:35Z")})
+
+(expect-failure "withdraw fails when called directly"
+  "require-capability: not granted: (marmalade-v2.ledger.SALE_PRIVATE"
+  (withdraw (read-string "token-id") (read-string "account") 1.0)
+)
+
+(expect-failure "withdraw fails without WITHDRAW capability in scope"
+  "Managed capability not installed: (marmalade-v2.ledger.WITHDRAW"
+  (continue-pact 0 true)
+)
+
+(env-sigs [
+  { 'key: 'any
+   ,'caps: [(marmalade-v2.ledger.WITHDRAW (read-string "token-id") (read-string "account") 1.0 0 (pact-id))]}
+])
+
+(expect-failure "withdraw fails when sig is not signed"
+  "Keyset failure (keys-all): "
+  (continue-pact 0 true)
+)
+
+(env-sigs [
+  { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+   ,'caps: [(marmalade-v2.ledger.WITHDRAW (read-string "token-id") (read-string "account") 1.0 0 (pact-id))]}
+])
+
+(expect "withdraw succeeds"
+  (pact-id)
+  (continue-pact 0 true)
+)
+
+(expect "withdraw events"
+  [
+    {"name": "marmalade-v2.ledger.WITHDRAW","params": ["t:_xAMunHwoHC8xdv5R9BfaJd-d3aUyOP8j6eDdHrBvTU" (read-string "account") 1.0 0 "DKc5HEWcmP8iPWue2WvMcnjn_WnowmuHz5Ogukm2SWk"]}
+    {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:_xAMunHwoHC8xdv5R9BfaJd-d3aUyOP8j6eDdHrBvTU" "c:TCxrhvg6e_NUVqelF7bnXTT7aabA5qtKdKUXCUXo2_Q" (read-string "account") 1.0]}
+    {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:_xAMunHwoHC8xdv5R9BfaJd-d3aUyOP8j6eDdHrBvTU" 1.0 {"account": "c:TCxrhvg6e_NUVqelF7bnXTT7aabA5qtKdKUXCUXo2_Q","current": 0.0,"previous": 1.0} {"account": (read-string "account") ,"current": 1.0,"previous": 0.0}
+  ]}]
+  (map (remove "module-hash")  (env-events true))
+)
+
+(rollback-tx)
+
+(begin-tx "test utility functions")
+(commit-tx)

--- a/pact-tests/pact-tests/marmalade/pact/policy-manager/manager-init.pact
+++ b/pact-tests/pact-tests/marmalade/pact/policy-manager/manager-init.pact
@@ -1,0 +1,8 @@
+(namespace (read-string 'ns))
+(use policy-manager [NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY GUARD_POLICY])
+
+(policy-manager.init ledger)
+(policy-manager.write-concrete-policy NON_FUNGIBLE_POLICY non-fungible-policy-v1)
+(policy-manager.write-concrete-policy ROYALTY_POLICY royalty-policy-v1)
+(policy-manager.write-concrete-policy COLLECTION_POLICY collection-policy-v1)
+(policy-manager.write-concrete-policy GUARD_POLICY guard-policy-v1)

--- a/pact-tests/pact-tests/marmalade/pact/policy-manager/policy-manager.pact
+++ b/pact-tests/pact-tests/marmalade/pact/policy-manager/policy-manager.pact
@@ -1,0 +1,560 @@
+(namespace (read-string 'ns))
+
+(module policy-manager GOVERNANCE
+
+  (bless "mQ_oo2I6T85QydnylhVmoHM9elDsmVD1wV9iXrAuT0I")
+  (bless "WC7obfshJ_VsH2PmcTL2iy4TKjbhHvA1WU_aMWIRwKc")
+  (bless "SpJiV_6CfE3gA5QUlTEKhFgXvZrhg2dORfFqk2GBgjI")
+
+  (defconst ADMIN-KS:string "marmalade-v2.marmalade-contract-admin")
+
+  (defcap GOVERNANCE ()
+    (enforce-guard ADMIN-KS))
+
+  (use kip.token-policy-v2 [token-info])
+  (use util.fungible-util)
+
+  ; Saves reference to ledger
+  (defschema ledger
+    ledger-impl:module{marmalade-v2.ledger-v2}
+  )
+
+  (deftable ledgers:{ledger}
+    @doc "Singleton table for ledger reference storage")
+
+  (defun init:bool(ledger:module{marmalade-v2.ledger-v2})
+    @doc "Must be initiated with ledger implementation"
+    (with-capability (GOVERNANCE)
+      (write ledgers "" {
+        "ledger-impl": ledger
+      })
+    )
+    true
+  )
+
+  (defschema quote-schema
+    @doc "Quote spec of the sale"
+    token-id:string
+    amount:decimal
+    seller:string
+    timeout:integer
+    fungible:module{fungible-v2}
+    seller-fungible-account:object{fungible-account}
+    sale-price:decimal
+    sale-type:string
+  )
+
+  (defschema quote-spec
+    fungible:module{fungible-v2}
+    seller-fungible-account:object{fungible-account}
+    sale-price:decimal
+    sale-type:string
+  )
+
+  (defschema fungible-account
+    @doc "account and guard information of a fungible"
+    account:string
+    guard:guard
+  )
+
+  (defschema marketplace-fee-spec
+    @doc "Marketplace fee data to include in payload"
+    mk-account:string
+    mk-fee-percentage:decimal
+  )
+
+  ;; Saves Sale Logic
+  (defschema sale-contract
+    sale-contract:module{sale-v2}
+  )
+
+  (deftable sale-whitelist:{sale-contract})
+
+  (deftable quotes:{quote-schema})
+
+  (defcap QUOTE:bool
+    ( sale-id:string
+      token-id:string
+      spec:object{quote-spec}
+    )
+    @event
+    true
+  )
+
+  (defconst QUOTE-MSG-KEY:string "quote"
+    @doc "Payload field for quote spec")
+
+  (defconst BUYER-FUNGIBLE-ACCOUNT-MSG-KEY:string "buyer_fungible_account"
+    @doc "Payload field for buyer's fungible account")
+
+  (defconst UPDATED-PRICE-KEY:string "updated_price"
+    @doc "Payload field for updated price")
+
+  (defconst MARKETPLACE-FEE-KEY "marketplace_fee"
+    @doc "Payload field for marketplace fee spec")
+
+  (defcap ESCROW (sale-id:string)
+    @doc "Capability to be used as escrow's capability guard"
+    true
+  )
+
+  ;;
+  ;; policy-manager-v1 caps to be able to validate access to quote-manager & policy operations.
+  ;;
+  (defcap INIT-CALL:bool (id:string precision:integer uri:string policy:string)
+    true
+  )
+
+  (defcap TRANSFER-CALL:bool (id:string sender:string receiver:string amount:decimal policy:string)
+    true
+  )
+
+  (defcap MINT-CALL:bool (id:string account:string amount:decimal policy:string)
+    true
+  )
+
+  (defcap BURN-CALL:bool (id:string account:string amount:decimal policy:string)
+    true
+  )
+
+  (defcap OFFER-CALL:bool (id:string seller:string amount:decimal sale-id:string timeout:integer policy:string)
+    true
+  )
+
+  (defcap WITHDRAW-CALL:bool (id:string seller:string amount:decimal sale-id:string timeout:integer policy:string)
+    true
+  )
+
+  (defcap BUY-CALL:bool (id:string seller:string buyer:string amount:decimal sale-id:string policy:string)
+    true
+  )
+
+  (defcap UPDATE-URI-CALL:bool (id:string new-uri:string policy:string)
+    true
+  )
+
+  (defcap SALE-GUARD-CALL:bool (sale-id:string price:decimal)
+    true
+  )
+
+  (defcap FUNGIBLE-TRANSFER-CALL:bool (id:string)
+    true
+  )
+
+  (defcap UPDATE-QUOTE-PRICE:bool (token-id:string sale-id:string sale-type:string updated-price:decimal)
+    @doc "Enforces sale-guard on update-quote-price"
+    (enforce (> updated-price 0.0) "QUOTE price must be positive")
+    (compose-capability (SALE-GUARD-CALL sale-id updated-price))
+    (let ((sale-contract:module{sale-v2} (retrieve-sale sale-type)))
+      (sale-contract::enforce-quote-update sale-id updated-price))
+  )
+
+  (defcap SALE-WHITELIST:bool(sale-contract-key:string)
+    @event
+    (enforce-guard ADMIN-KS)
+  )
+
+  (defun get-escrow-account:object{fungible-account} (sale-id:string)
+    @doc "Returns fungible escrow ACCOUNT and GUARD of the SALE"
+    { 'account: (create-principal (create-capability-guard (ESCROW sale-id)))
+    , 'guard: (create-capability-guard (ESCROW sale-id))
+    })
+
+  (defun add-sale-whitelist:bool (sale-contract:module{sale-v2})
+    @doc "Adds quote-guard to quote-guard-whitelist list"
+    (let ((sale-key (format "{}" [sale-contract])))
+      (with-capability (SALE-WHITELIST sale-key)
+        (insert sale-whitelist sale-key
+          { 'sale-contract: sale-contract }
+    )))
+    true
+  )
+
+  ; Saves Concrete policy information
+  (defschema concrete-policy
+    policy:module{kip.token-policy-v2}
+  )
+
+  (deftable concrete-policies:{concrete-policy})
+
+  (defcap CONCRETE-POLICY:bool (policy-field:string policy:module{kip.token-policy-v2})
+    @event
+    (enforce-guard ADMIN-KS))
+
+  (defconst NON_FUNGIBLE_POLICY:string 'non-fungible-policy )
+  (defconst ROYALTY_POLICY:string 'royalty-policy )
+  (defconst COLLECTION_POLICY:string 'collection-policy )
+  (defconst GUARD_POLICY:string 'guard-policy )
+  (defconst CONCRETE_POLICY_LIST:[string]
+    [NON_FUNGIBLE_POLICY ROYALTY_POLICY COLLECTION_POLICY GUARD_POLICY] )
+
+  (defun write-concrete-policy:bool (policy-field:string policy:module{kip.token-policy-v2})
+    (enforce (contains policy-field CONCRETE_POLICY_LIST) "Not registered as concrete policy")
+    (with-capability (CONCRETE-POLICY policy-field policy)
+      (write concrete-policies policy-field {
+        "policy": policy
+        }
+      )
+    true)
+  )
+
+  ; Capbilities to guard internal functions
+
+  (defcap OFFER:bool (sale-id:string)
+    @doc "Capability to grant internal transaction inside OFFER"
+    true
+  )
+
+  (defcap BUY:bool (sale-id:string)
+    @doc "Capability to grant internal transaction inside BUY"
+    true
+  )
+
+  (defcap WITHDRAW:bool (sale-id:string)
+    @doc "Capability to grant internal transaction inside WITHDRAW"
+    true
+  )
+
+  ; Map list of policy functions
+
+  (defun enforce-init:[bool]
+    (token:object{token-info})
+    (let ((ledger:module{marmalade-v2.ledger-v2} (retrieve-ledger)))
+      (require-capability (ledger::INIT-CALL (at "id" token) (at "precision" token) (at "uri" token)))
+    )
+
+    (map (lambda (policy:module{kip.token-policy-v2})
+      (with-capability (INIT-CALL (at "id" token) (at "precision" token) (at "uri" token) (format "{}" [policy]))
+        (policy::enforce-init token)
+      )
+    ) (at 'policies token))
+  )
+
+  (defun enforce-mint:[bool]
+    ( token:object{token-info}
+      account:string
+      guard:guard
+      amount:decimal
+    )
+    (let ((ledger:module{marmalade-v2.ledger-v2} (retrieve-ledger)))
+      (require-capability (ledger::MINT-CALL (at "id" token) account amount))
+    )
+    (map (lambda (policy:module{kip.token-policy-v2})
+      (with-capability (MINT-CALL (at "id" token) account amount (format "{}" [policy]))
+        (policy::enforce-mint token account guard amount)
+      )
+    ) (at 'policies token))
+  )
+
+  (defun enforce-burn:[bool]
+    ( token:object{token-info}
+      account:string
+      amount:decimal
+    )
+    (let ((ledger:module{marmalade-v2.ledger-v2} (retrieve-ledger)))
+      (require-capability (ledger::BURN-CALL (at "id" token) account amount))
+    )
+    (map (lambda (policy:module{kip.token-policy-v2})
+      (with-capability (BURN-CALL (at "id" token) account amount (format "{}" [policy]))
+        (policy::enforce-burn token account amount)
+      )
+    ) (at 'policies token))
+  )
+
+  (defun enforce-offer:[bool]
+    ( token:object{token-info}
+      seller:string
+      amount:decimal
+      timeout:integer
+      sale-id:string )
+    @doc " Executed at `offer` step of marmalade.ledger.                             \
+    \ Required msg-data keys:                                                        \
+    \ * (optional) quote:object{quote-spec} - sale is registered as a quoted fungible \
+    \ sale if present. If absent, sale proceeds without quotes."
+
+    (let ((ledger:module{marmalade-v2.ledger-v2} (retrieve-ledger)))
+      (require-capability (ledger::OFFER-CALL (at "id" token) seller amount timeout sale-id))
+    )
+
+    (enforce-sale-pact sale-id)
+    (enforce (= (pact-id) (tx-hash)) "cannot be triggered as nested defpacts")
+
+    ; Check if quote-msg exists
+    (if (exists-msg-quote QUOTE-MSG-KEY)
+      ; true - insert quote message and create escrow account in fungible
+    (let* (
+        (quote-spec:object{quote-spec} (read-msg QUOTE-MSG-KEY))
+        (fungible:module{fungible-v2} (at 'fungible quote-spec))
+        (escrow-account:object{fungible-account} (get-escrow-account sale-id))
+        (token-id:string (at 'id token))
+        (quote:object{quote-schema} (+
+            { "token-id": token-id
+            , 'seller: seller
+            , 'amount: amount
+            , 'timeout: timeout
+            }
+            quote-spec))
+      )
+      (validate-quote quote)
+      (insert quotes sale-id quote) ;; void sale type
+      (fungible::create-account (at 'account escrow-account) (at 'guard escrow-account))
+      (emit-event (QUOTE sale-id token-id quote-spec))
+    )
+      ; false - skip
+      true
+    )
+     ; run policy::enforce-offer
+    (map
+      (lambda (policy:module{kip.token-policy-v2})
+        (with-capability (OFFER-CALL (at "id" token) seller amount sale-id timeout (format "{}" [policy]))
+          (policy::enforce-offer token seller amount timeout sale-id)
+        )
+      )
+      (at 'policies token))
+  )
+
+  (defun enforce-withdraw:[bool]
+    ( token:object{token-info}
+      seller:string
+      amount:decimal
+      timeout:integer
+      sale-id:string )
+    @doc " Executed at `withdraw` step of marmalade.ledger."
+    (let ((ledger:module{marmalade-v2.ledger-v2} (retrieve-ledger)))
+      (require-capability (ledger::WITHDRAW-CALL (at "id" token) seller amount timeout sale-id))
+    )
+    (enforce-sale-pact sale-id)
+
+    (if (exists-quote sale-id)
+      (let* (
+        (quote-spec:object{quote-schema} (get-quote-info sale-id))
+        (sale-type:string (at 'sale-type quote-spec)))
+
+        (if (!= sale-type "")
+          (let ((sale-contract:module{sale-v2} (retrieve-sale sale-type)))
+            (sale-contract::enforce-withdrawal sale-id))
+          true
+        ))
+      true
+    )
+
+    (map (lambda (policy:module{kip.token-policy-v2})
+      (with-capability (WITHDRAW-CALL (at "id" token) seller amount sale-id timeout (format "{}" [policy]))
+        (policy::enforce-withdraw token seller amount timeout sale-id)
+      )
+    ) (at 'policies token))
+  )
+
+  (defun enforce-buy:[bool]
+    ( token:object{token-info}
+      seller:string
+      buyer:string
+      buyer-guard:guard
+      amount:decimal
+      sale-id:string )
+      @doc " Executed at `buy` step of marmalade.ledger.                                 \
+      \ Required msg-data keys:                                                          \
+      \ * (optional) buyer_fungible_account:string - The fungible account of the buyer   \
+      \ which transfers the fungible to the escrow account. Only required if the sale is \
+      \ a quoted sale. "
+
+    (enforce-sale-pact sale-id)
+
+    ;; enforce function is called from ledger
+    (let ((ledger:module{marmalade-v2.ledger-v2} (retrieve-ledger)))
+      (require-capability (ledger::BUY-CALL (at "id" token) seller buyer amount sale-id))
+    )
+
+    ; Checks if quote is saved at offer
+    (if (exists-quote sale-id)
+
+      ; true - quote is used
+      (let* (
+             (escrow-account:object{fungible-account} (get-escrow-account sale-id))
+             (quote-spec:object{quote-schema} (get-quote-info sale-id))
+             (fungible:module{fungible-v2} (at 'fungible quote-spec))
+             (seller-fungible-account:object{fungible-account} (at 'seller-fungible-account quote-spec))
+             (sale-type:string (at 'sale-type quote-spec))
+             (sale-price:decimal (at 'sale-price quote-spec))
+           )
+
+        ; If a sale contract is being used, update the price accordingly
+        (if (!= sale-type "")
+          (if (exists-msg-decimal UPDATED-PRICE-KEY)
+            (let ((updated-price:decimal (read-msg UPDATED-PRICE-KEY)))
+              (fungible::enforce-unit updated-price)
+              (with-capability (UPDATE-QUOTE-PRICE (at 'id token) sale-id sale-type updated-price)
+                (update quotes sale-id { "sale-price": updated-price })
+              )
+              true
+            )
+          true
+          )
+          true
+        )
+
+        (let* (
+            (final-sale-price:decimal  (at 'sale-price (get-quote-info sale-id)))
+            (mk-fee-spec:object{marketplace-fee-spec} (try { "mk-account": "", "mk-fee-percentage": 0.0 } (read-msg MARKETPLACE-FEE-KEY)))
+            (mk-fee-percentage:decimal (at 'mk-fee-percentage mk-fee-spec))
+            (mk-fee:decimal (floor (* mk-fee-percentage final-sale-price) (fungible::precision)))
+          )
+          (enforce (> final-sale-price 0.0) "Price is not finalized for this quote")
+
+          ; Handle the marketplace fee if applicable
+          (if (= 0.0 mk-fee-percentage)
+            true
+            (with-capability (FUNGIBLE-TRANSFER-CALL sale-id)
+              (enforce (and (>= mk-fee-percentage 0.0) (<= mk-fee-percentage 1.0)) "Invalid market-fee percentage")
+
+              (install-capability (fungible::TRANSFER (read-msg BUYER-FUNGIBLE-ACCOUNT-MSG-KEY) (at "mk-account" mk-fee-spec) mk-fee))
+              (fungible::transfer (read-msg BUYER-FUNGIBLE-ACCOUNT-MSG-KEY) (at "mk-account" mk-fee-spec) mk-fee)
+            )
+          )
+
+          (with-capability (FUNGIBLE-TRANSFER-CALL sale-id)
+            ; Transfer sale amount from buyer to policy manager's escrow account
+            (install-capability (fungible::TRANSFER (read-msg BUYER-FUNGIBLE-ACCOUNT-MSG-KEY) (at 'account escrow-account) final-sale-price))
+            (fungible::transfer-create (read-msg BUYER-FUNGIBLE-ACCOUNT-MSG-KEY) (at 'account escrow-account) (at 'guard escrow-account) final-sale-price)
+          )
+          (with-capability (ESCROW sale-id)
+            ; Run policies::enforce-buy
+            (let ((result:[bool]
+              (map (lambda (policy:module{kip.token-policy-v2})
+                  (with-capability (BUY-CALL (at "id" token) seller buyer amount sale-id (format "{}" [policy]))
+                    (policy::enforce-buy token seller buyer buyer-guard amount sale-id)
+                  )
+                ) (at 'policies token))
+                ))
+
+              (let (
+                    (balance:decimal (fungible::get-balance (at 'account escrow-account)))
+                  )
+                (install-capability (fungible::TRANSFER (at 'account escrow-account) (at 'account seller-fungible-account) balance))
+                (fungible::transfer (at 'account escrow-account) (at 'account seller-fungible-account) balance)
+              )
+            result
+          ))
+        )
+      )
+
+      ; false: quote is not used
+      (map (lambda (policy:module{kip.token-policy-v2})
+        (with-capability (BUY-CALL (at "id" token) seller buyer amount sale-id (format "{}" [policy]))
+          (policy::enforce-buy token seller buyer buyer-guard amount sale-id)
+        )
+      ) (at 'policies token))
+    )
+  )
+
+  (defun enforce-transfer:[bool]
+    ( token:object{token-info}
+      sender:string
+      guard:guard
+      receiver:string
+      amount:decimal )
+    (let ((ledger:module{marmalade-v2.ledger-v2} (retrieve-ledger)))
+      (require-capability (ledger::TRANSFER-CALL (at "id" token) sender receiver amount))
+    )
+    (map (lambda (policy:module{kip.token-policy-v2})
+      (with-capability (TRANSFER-CALL (at "id" token) sender receiver amount (format "{}" [policy]))
+        (policy::enforce-transfer token sender guard receiver amount)
+      )
+    ) (at 'policies token))
+  )
+
+  (defun enforce-update-uri:[bool]
+     ( token:object{token-info}
+       new-uri:string )
+     (let ((ledger:module{marmalade-v2.ledger-v2} (retrieve-ledger)))
+       (require-capability (ledger::UPDATE-URI-CALL (at "id" token) new-uri))
+     )
+     (map (lambda (policy:module{kip.token-policy-v2,kip.updatable-uri-policy-v1})
+       (with-capability (UPDATE-URI-CALL (at "id" token)  new-uri (format "{}" [policy]))
+         (policy::enforce-update-uri token new-uri)
+       )
+     ) (at 'policies token))
+   )
+
+  (defun enforce-sale-pact:bool (sale:string)
+    "Enforces that SALE is id for currently executing pact"
+    (enforce (= sale (pact-id)) "Invalid pact/sale id")
+  )
+
+  ; Utility functions
+
+  (defun exists-quote:bool (sale-id:string)
+    @doc "Looks up quote table for quote"
+    (try false (let ((q (get-quote-info sale-id))) true))
+  )
+
+  (defun exists-msg-decimal:bool (msg:string)
+    @doc "Checks env-data field and see if the msg is a decimal"
+    (let  ((d:decimal (try -1.0 (read-msg msg))))
+      (!= d -1.0))
+  )
+
+  (defun exists-msg-quote:bool (msg:string)
+    @doc "Checks env-data field and see if the msg is a object"
+    (let ((o:object (try {} (read-msg msg))))
+      (!= o {}))
+  )
+
+  (defun retrieve-ledger:module{marmalade-v2.ledger-v2} ()
+    @doc "Retrieves the ledger implementation"
+    (with-read ledgers "" {
+        "ledger-impl":= ledger
+      }
+    ledger)
+  )
+
+  (defun retrieve-sale:module{sale-v2} (sale-type:string)
+    @doc "Retrieves the sale-contract"
+    (with-read sale-whitelist sale-type {"sale-contract":= sale} sale)
+  )
+
+  (defun get-concrete-policy:module{kip.token-policy-v2} (policy-field:string)
+    (with-read concrete-policies policy-field {
+      "policy":= policy
+      }
+      policy)
+  )
+
+  (defun get-quote-info:object{quote-schema} (sale-id:string)
+    @doc "Get Quote information"
+    (read quotes sale-id)
+  )
+
+  ;; Validate functions
+  (defun validate-fungible-account (fungible:module{fungible-v2} account:object{fungible-account})
+    (let ((seller-details (fungible::details (at 'account account))))
+      (enforce (=
+        (at 'guard seller-details) (at 'guard account))
+            "Account guard does not match"))
+  )
+
+  (defun validate-quote:bool (quote-spec:object{quote-schema})
+    (let* ( (fungible:module{fungible-v2} (at 'fungible quote-spec) )
+            (seller-fungible-account:object{fungible-account} (at 'seller-fungible-account quote-spec))
+            (sale-type:string (at 'sale-type quote-spec))
+            (sale-price:decimal (at 'sale-price quote-spec)) )
+      (validate-fungible-account fungible seller-fungible-account)
+      (fungible::enforce-unit sale-price)
+      (if (= sale-type "")
+        (enforce (> sale-price 0.0) "Offer price must be positive" )
+        [ (retrieve-sale sale-type)
+          (enforce (>= sale-price 0.0) "Offer price must be positive or zero")
+        ]
+      )
+      true)
+  )
+)
+
+(if (read-msg 'upgrade )
+  ["upgrade complete"]
+  [ (create-table ledgers)
+    (create-table concrete-policies)
+    (create-table quotes)
+    (create-table sale-whitelist)
+  ])
+(enforce-guard ADMIN-KS)

--- a/pact-tests/pact-tests/marmalade/pact/policy-manager/policy-manager.repl
+++ b/pact-tests/pact-tests/marmalade/pact/policy-manager/policy-manager.repl
@@ -1,0 +1,959 @@
+(load "../marmalade.repl")
+
+(typecheck "marmalade-v2.policy-manager")
+
+(begin-tx "upgrade policy and check if stored policy matches with saved concrete policy")
+  (env-sigs [
+    { 'key: 'marmalade-contract-admin
+     ,'caps: []
+   }])
+   (use marmalade-v2.ledger)
+   (use marmalade-v2.util-v1)
+   (use mini-guard-utils)
+
+   (env-data {
+     'ns: "marmalade-v2"
+    ,'token-id: (create-token-id { 'uri: "test-uri-3", 'precision: 0, 'policies: (create-policies DEFAULT)} ALWAYS-TRUE )
+    })
+
+    (expect  "create a token "
+      true
+      (create-token (read-msg 'token-id ) 0 "test-uri-3"  (create-policies DEFAULT) ALWAYS-TRUE))
+
+    (module non-fungible-policy-v1 GOVERNANCE
+
+      @doc "Concrete policy for issuing an nft with a fixed supply of 1"
+
+      (defconst ADMIN-KS:string "marmalade-v2.marmalade-contract-admin")
+
+      (defcap GOVERNANCE ()
+        (enforce-guard ADMIN-KS))
+
+      (implements kip.token-policy-v2)
+      (use kip.token-policy-v2 [token-info])
+      (use marmalade-v2.policy-manager)
+
+      (defun enforce-init:bool
+        ( token:object{token-info}
+        )
+        (require-capability (INIT-CALL (at "id" token) (at "precision" token) (at "uri" token)))
+        true
+      )
+
+      (defun enforce-mint:bool
+        ( token:object{token-info}
+          account:string
+          guard:guard
+          amount:decimal
+        )
+        (require-capability (MINT-CALL (at "id" token) account amount))
+      )
+
+      (defun enforce-burn:bool
+        ( token:object{token-info}
+          account:string
+          amount:decimal
+        )
+        (require-capability (BURN-CALL (at "id" token) account amount))
+      )
+
+      (defun enforce-offer:bool
+        ( token:object{token-info}
+          seller:string
+          amount:decimal
+          timeout:integer
+          sale-id:string
+        )
+        @doc "Capture quote spec for SALE of TOKEN from message"
+        (require-capability (OFFER-CALL (at "id" token) seller amount sale-id))
+      )
+
+      (defun enforce-buy:bool
+        ( token:object{token-info}
+          seller:string
+          buyer:string
+          buyer-guard:guard
+          amount:decimal
+          sale-id:string )
+        (require-capability (BUY-CALL (at "id" token) seller buyer amount sale-id))
+      )
+
+      (defun enforce-transfer:bool
+        ( token:object{token-info}
+          sender:string
+          guard:guard
+          receiver:string
+          amount:decimal )
+        (require-capability (TRANSFER-CALL (at "id" token) sender receiver amount))
+      )
+
+      (defun enforce-withdraw:bool
+        ( token:object{token-info}
+          seller:string
+          amount:decimal
+          timeout:integer
+          sale-id:string )
+        (require-capability (WITHDRAW-CALL (at "id" token) seller amount sale-id))
+      )
+    )
+
+  (use marmalade-v2.policy-manager)
+  (use marmalade-v2.policy-manager [NON_FUNGIBLE_POLICY])
+
+  (expect-failure "write-concrete-policy fails if concrete policy field is not registered"
+    "Not registered as concrete policy"
+    (write-concrete-policy "not-registered-policy" marmalade-v2.non-fungible-policy-v1))
+
+  (expect "upgrade non-fungible-policy"
+    true
+    (write-concrete-policy NON_FUNGIBLE_POLICY marmalade-v2.non-fungible-policy-v1))
+
+  (expect "check if stored policy matches with saved concrete-policy"
+    true
+    (contains
+      (get-concrete-policy NON_FUNGIBLE_POLICY)
+      (at 'policies (get-token-info (read-msg 'token-id )))) )
+
+(rollback-tx)
+
+(begin-tx "Test enforce-init")
+
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+
+  (env-hash (hash "offer-1"))
+  (env-chain-data {"chain-id": "0"})
+  (env-data {
+    "mint-guard": {"keys": ["mint"], "pred": "keys-all"}
+    })
+
+  (expect-failure "enforce-init cannot be called directly"
+    "(require-capability (ledger::I...: Failure: Tx Failed: require-capability: not granted: (marmalade-v2.ledger.INIT-CALL \"t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU\" 0 \"default-test-uri\")"
+    (enforce-init {
+      "id": (create-token-id { 'uri: "default-test-uri", 'precision: 0, 'policies: [] } ALWAYS-TRUE)
+     ,"supply": 0.0
+     ,"precision": 0
+     ,"uri": "default-test-uri"
+     ,"policies": [] })
+  )
+
+  (expect "create a token"
+    true
+    (create-token
+      (create-token-id { 'uri: "default-test-uri", 'precision: 0, 'policies: [] } ALWAYS-TRUE)
+       0 "default-test-uri" [] ALWAYS-TRUE))
+
+  (expect "create-token events"
+     [ {"name": "marmalade-v2.ledger.TOKEN","params": ["t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" 0 [] "default-test-uri" ALWAYS-TRUE]}]
+     (map (remove "module-hash")  (env-events true))
+  )
+
+(commit-tx)
+
+(begin-tx "Test enforce-mint")
+  (env-chain-data {"chain-id": "0"})
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-v2.util-v1)
+
+  (env-data {
+     "token-id": "t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU"
+    , "account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+    , "account-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+    })
+
+  (env-sigs [
+    { 'key: 'mint
+     ,'caps: [(marmalade-v2.ledger.MINT (read-string "token-id") (read-string 'account)  1.0)
+    ]}])
+
+   (expect-failure "enforce-mint cannot be called directly"
+     "(require-capability (ledger::M...: Failure: Tx Failed: require-capability: not granted: (marmalade-v2.ledger.MINT-CALL \"t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU\" \"k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3\" 1.0)"
+     (enforce-mint (get-token-info "t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU") (read-string 'account) (read-keyset 'account-guard ) 1.0)
+   )
+
+  (expect "mint a default token through ledger.mint"
+    true
+    (mint (read-string 'token-id )  (read-string 'account ) (read-keyset 'account-guard ) 1.0))
+
+  (expect "mint events"
+    [ {"name": "marmalade-v2.ledger.MINT","params": ["t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" (read-string 'account) 1.0]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" (read-string 'account) (read-keyset 'account-guard)]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" 1.0 {"account": "","current": 0.0,"previous": 0.0} {"account": (read-string 'account), "current": 1.0,"previous": 0.0}]} {"name": "marmalade-v2.ledger.SUPPLY","params": ["t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" 1.0]}
+    ]
+   (map (remove "module-hash")  (env-events true))
+  )
+
+(commit-tx)
+
+(begin-tx "Test enforce-burn")
+(use marmalade-v2.ledger)
+(use marmalade-v2.policy-manager)
+(use marmalade-v2.util-v1)
+
+(env-sigs [
+  { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+  ,'caps: [(marmalade-v2.ledger.BURN (read-msg "token-id") (read-string 'account) 1.0)]
+  }])
+
+(expect-failure "enforce-burn cannot be called directly"
+ "require-capability (ledger::B...: Failure: Tx Failed: require-capability: not granted: (marmalade-v2.ledger.BURN-CALL \"t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU\" \"k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3\" 1.0)"
+ (enforce-burn (get-token-info "t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU") (read-string 'account) 1.0)
+)
+
+(expect "enforce-burn cannot be called directly"
+  true
+  (burn "t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" (read-string 'account) 1.0)
+)
+
+(rollback-tx)
+
+(begin-tx "Test enforce-offer, enforce-withdraw(fail), enforce-buy(succeed) without quote")
+  (env-chain-data {"chain-id": "0"})
+  (env-hash (hash "enforce-offer-0"))
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-v2.util-v1)
+
+  (env-data {
+      "token-id": "t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU"
+     ,"seller": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+  })
+
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+    ,'caps: [
+      (marmalade-v2.ledger.OFFER (read-string 'token-id) (read-string 'seller) 1.0 0)]
+    }])
+
+  (expect-failure "enforce-offer cannot be called directly"
+    "(marmalade-v2.ledger.OFFER-CALL \"t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU\" \"k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3\" 1.0 0 \"void-sale-id\")"
+    (enforce-offer (get-token-info (read-string "token-id")) (read-string 'seller) 1.0 0 "void-sale-id")
+  )
+
+  (expect "start offer by running step 0 of sale"
+    (pact-id)
+    (sale (read-msg 'token-id) (read-string 'seller) 1.0 0))
+
+(expect "offer events"
+    [ {"name": "marmalade-v2.ledger.OFFER","params": [(read-string "token-id") (read-string 'seller) 1.0 0]}
+      {"name": "marmalade-v2.ledger.SALE","params": [(read-string "token-id") (read-string 'seller) 1.0 0 "y9iTTBsSq56yIgmJexCyOX3DSFVe0CwQs4K0jISRAdM"]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string "token-id") "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs" (account-guard (read-string "token-id") "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs")]}
+      {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-string "token-id") (read-string 'seller) "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs" 1.0]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-string "token-id") 1.0 {"account": (read-string 'seller),"current": 0.0,"previous": 1.0} {"account": "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs","current": 1.0,"previous": 0.0}]}]
+    (map (remove "module-hash")  (env-events true))
+  )
+
+  (env-data {
+    "token-id": "t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU"
+   ,"seller": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+   ,"buyer": "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+   ,"buyer-guard": {"keys": ["6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"], "pred": "keys-all"}
+  })
+
+  (env-sigs
+    [ {'key:'buyer
+      ,'caps: [
+        (marmalade-v2.ledger.BUY "t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" (read-string 'seller ) (read-string 'buyer ) 1.0 (pact-id))
+      ]}
+  ])
+
+  (expect-failure "enforce-buy cannot be called directly"
+   "(marmalade-v2.ledger.BUY-CALL \"t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU\" \"k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3\" \"k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3\" 1.0 \"y9iTTBsSq56yIgmJexCyOX3DSFVe0CwQs4K0jISRAdM\")"
+   (enforce-buy (get-token-info (read-string 'token-id )) (read-string 'seller ) (read-string 'buyer ) (read-keyset 'buyer-guard ) 1.0 (pact-id)))
+
+  (expect "Buy succeeds"
+    (pact-id)
+    (continue-pact 1))
+
+  (expect "buy events"
+   [ {"name": "marmalade-v2.ledger.BUY","params": ["t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" (read-string 'seller ) (read-string 'buyer ) 1.0 "y9iTTBsSq56yIgmJexCyOX3DSFVe0CwQs4K0jISRAdM"]}
+     {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" (read-string 'buyer ) (read-keyset 'buyer-guard)]}
+     {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs" (read-string 'buyer ) 1.0]}
+     {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" 1.0 {"account": "c:cNEu9OPDCB7tmnj-Z2cMxrRNbJAeGl_r3aO-L367oSs","current": 0.0,"previous": 1.0} {"account": (read-string 'buyer ),"current": 1.0,"previous": 0.0}]}]
+    (map (remove "module-hash")  (env-events true))
+  )
+
+  (env-sigs [
+    { 'key: 'account
+    ,'caps: [
+      (marmalade-v2.ledger.WITHDRAW (read-string 'token-id) (read-string 'seller ) 1.0 0 (pact-id))]
+    }])
+
+  (expect-failure "Withdraw fails after buy is completed"
+    "resumePact: pact completed: y9iTTBsSq56yIgmJexCyOX3DSFVe0CwQs4K0jISRAdM"
+    (continue-pact 0 true))
+
+(rollback-tx)
+
+
+(begin-tx "Test enforce-offer, enforce-withdraw (succeed), enforce-buy (fail) without quote")
+  (env-chain-data {"chain-id": "0"})
+  (env-hash (hash "enforce-offer-1"))
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-v2.util-v1)
+
+  (env-data {
+      "token-id": "t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU"
+     ,"seller": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+  })
+
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+    ,'caps: [
+      (marmalade-v2.ledger.OFFER (read-string 'token-id) (read-string 'seller ) 1.0 0)]
+    }])
+
+  (expect "start offer by running step 0 of sale"
+    (pact-id)
+    (sale (read-msg 'token-id) (read-string 'seller ) 1.0 0))
+
+(expect "offer events"
+    [ {"name": "marmalade-v2.ledger.OFFER","params": [(read-string "token-id") (read-string 'seller ) 1.0 0]}
+      {"name": "marmalade-v2.ledger.SALE","params": [(read-string "token-id") (read-string 'seller ) 1.0 0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string "token-id") "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" (account-guard (read-string "token-id") "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q")]}
+      {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-string "token-id") (read-string 'seller ) "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" 1.0]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-string "token-id") 1.0 {"account": (read-string 'seller ),"current": 0.0,"previous": 1.0} {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 1.0,"previous": 0.0}]}]
+    (map (remove "module-hash")  (env-events true))
+  )
+
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+    ,'caps: [
+      (marmalade-v2.ledger.WITHDRAW (read-string 'token-id) (read-string 'seller) 1.0 0 (pact-id))]
+    }])
+
+  (expect-failure "enforce-withdraw cannot be called directly"
+    "(marmalade-v2.ledger.WITHDRAW-CALL \"t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU\" \"k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3\" 1.0 0 \"i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY\")"
+    (enforce-withdraw (get-token-info (read-string 'token-id )) (read-string 'seller ) 1.0 0 (pact-id) ))
+
+  (expect "Withdraw succeeds"
+    (pact-id)
+    (continue-pact 0 true))
+
+  (expect "withdraw events"
+   [ {"name": "marmalade-v2.ledger.WITHDRAW","params": ["t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" (read-string 'seller ) 1.0 0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
+     {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" (read-string 'seller ) 1.0]}
+     {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": (read-string 'seller ),"current": 1.0,"previous": 0.0}]}]
+    (map (remove "module-hash")  (env-events true))
+  )
+
+  (env-data {
+    "buyer": "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+   ,"buyer-guard": {"keys": ["6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"], "pred": "keys-all"}
+   ,"buyer_fungible_account": "k:ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"
+   })
+
+  (env-sigs
+    [{'key:'ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c
+      ,'caps: [
+        (marmalade-v2.abc.TRANSFER (read-string 'buyer_fungible_account) "c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" 2.0)
+      ]}
+    {'key: "6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+      ,'caps: [
+        (marmalade-v2.ledger.BUY "t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" "k:account" "k:buyer" 1.0 (pact-id))
+      ]}
+  ])
+
+  (expect-failure "Buy fails when called after withdraw"
+    "resumePact: pact completed: i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"
+    (continue-pact 1))
+
+(rollback-tx)
+
+(begin-tx "Create buyer and market fungible account, fund buyer account")
+  (env-chain-data {"chain-id": "0"})
+  (env-data {
+    "buyer-fungible": "k:ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c",
+    "market-fungible": "k:64b06a45036484b484f521f7c21f439b9b7ea0f22687d3673bfea22073b23277",
+    "buyer-fungible-guard": {"keys": ["ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"], "pred": "keys-all"},
+    "market-fungible-guard": {"keys": ["64b06a45036484b484f521f7c21f439b9b7ea0f22687d3673bfea22073b23277"], "pred": "keys-all"}
+   })
+
+  (marmalade-v2.abc.create-account (read-string 'buyer-fungible) (read-keyset 'buyer-fungible-guard))
+  (marmalade-v2.abc.create-account (read-string 'market-fungible) (read-keyset 'market-fungible-guard))
+  (marmalade-v2.abc.fund (read-string 'buyer-fungible) 2.0)
+  (marmalade-v2.abc.fund (read-string 'market-fungible) 2.0)
+(commit-tx)
+
+(begin-tx "Test enforce-offer, enforce-withdraw(succeeds), enforce-buy(fails) with quote and without sale contract")
+  (env-chain-data {"chain-id": "0"})
+  (env-hash (hash "enforce-offer-1"))
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-v2.util-v1)
+
+  (env-data {
+      "seller-account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3",
+      "seller-fungible-account": "k:c8493f58aaff5787a15c987cf35b41bbca164a41d8978913860805768ed66fe7",
+      "seller-fungible-guard": {"keys": ["c8493f58aaff5787a15c987cf35b41bbca164a41d8978913860805768ed66fe7"], "pred": "keys-all"}
+    })
+
+  (marmalade-v2.abc.create-account (read-string "seller-fungible-account") (read-keyset 'seller-fungible-guard))
+
+  (env-data {
+      "token-id": "t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU"
+     ,"seller": (read-string 'seller-account)
+     ,"quote":{
+        "fungible": marmalade-v2.abc
+        ,"sale-price": 2.0
+        ,"seller-fungible-account": {
+            "account": "k:c8493f58aaff5787a15c987cf35b41bbca164a41d8978913860805768ed66fe7"
+           ,"guard": {"keys": ["c8493f58aaff5787a15c987cf35b41bbca164a41d8978913860805768ed66fe7"], "pred": "keys-all"}
+          }
+        ,"sale-type": ""
+      }
+    }
+  )
+
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+    ,'caps: [
+      (marmalade-v2.ledger.OFFER (read-string 'token-id) (read-string 'seller) 1.0 0)]
+    }])
+
+  (expect "start offer with quote spec"
+    (pact-id)
+    (sale (read-msg 'token-id) (read-string 'seller) 1.0 0))
+
+  (expect "offer events"
+      [
+      {"name": "marmalade-v2.policy-manager.QUOTE","params": [(pact-id) (read-string 'token-id) (read-msg 'quote ) ]}
+        {"name": "marmalade-v2.ledger.OFFER","params": [(read-string 'token-id) (read-string 'seller) 1.0 0]}
+        {"name": "marmalade-v2.ledger.SALE","params": [(read-string 'token-id) (read-string 'seller) 1.0 0 (pact-id)]}
+        {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string 'token-id) "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" (account-guard (read-string "token-id") "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q")]}
+        {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-string 'token-id) (read-string 'seller) "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" 1.0]}
+        {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-string 'token-id) 1.0 {"account": (read-string 'seller),"current": 0.0,"previous": 1.0} {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 1.0,"previous": 0.0}]}
+      ]
+      (map (remove "module-hash")  (env-events true))
+    )
+
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+    ,'caps: [
+      (marmalade-v2.ledger.WITHDRAW "t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" (read-string 'seller) 1.0 0 (pact-id))]
+    }])
+
+  (expect "Withdraw succeeds"
+    (pact-id)
+    (continue-pact 0 true))
+
+    (expect "withdraw events"
+      [ {"name": "marmalade-v2.ledger.WITHDRAW","params": ["t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" (read-string 'seller) 1.0 0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
+        {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" (read-string 'seller) 1.0]}
+        {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": (read-string 'seller),"current": 1.0,"previous": 0.0}]}]
+      (map (remove "module-hash")  (env-events true))
+    )
+
+  (env-sigs
+    [{'key:'ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c
+      ,'caps: [
+        (marmalade-v2.abc.TRANSFER "k:ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c" "c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" 2.0)
+      ]}
+    {'key: "6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+      ,'caps: [
+        (marmalade-v2.ledger.BUY "t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" "k:account" "k:buyer" 1.0 (pact-id))
+      ]}
+  ])
+
+  (env-data {
+    "buyer": "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+   ,"buyer-guard": {"keys": ["6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"], "pred": "keys-all"}
+   ,"buyer_fungible_account": "k:ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"
+   })
+
+  (expect-failure "Buy fails when called after withdraw"
+    "resumePact: pact completed: i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"
+    (continue-pact 1))
+
+(rollback-tx)
+
+(begin-tx "Test enforce-offer, enforce-withdraw(fails), enforce-buy(succeeds) with quote and without sale contract")
+  (env-chain-data {"chain-id": "0"})
+  (env-hash (hash "enforce-offer-1"))
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-v2.util-v1)
+
+  (env-data {
+      "seller": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3",
+      "seller-fungible-account": "k:c8493f58aaff5787a15c987cf35b41bbca164a41d8978913860805768ed66fe7",
+      "seller-fungible-guard": {"keys": ["c8493f58aaff5787a15c987cf35b41bbca164a41d8978913860805768ed66fe7"], "pred": "keys-all"}
+    })
+
+  (marmalade-v2.abc.create-account (read-string "seller-fungible-account") (read-keyset 'seller-fungible-guard))
+
+  (env-data {
+      "token-id": "t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU"
+     ,"seller": (read-string 'seller)
+     ,"quote":{
+        "fungible": marmalade-v2.abc
+        ,"sale-price": 2.0
+        ,"seller-fungible-account": {
+            "account": "k:c8493f58aaff5787a15c987cf35b41bbca164a41d8978913860805768ed66fe7"
+           ,"guard": {"keys": ["c8493f58aaff5787a15c987cf35b41bbca164a41d8978913860805768ed66fe7"], "pred": "keys-all"}
+          }
+        ,"sale-type": ""
+      }
+    }
+  )
+
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+    ,'caps: [
+      (marmalade-v2.ledger.OFFER (read-string 'token-id) (read-string 'seller) 1.0 0)]
+    }])
+
+  (expect "start offer with quote spec"
+    (pact-id)
+    (sale (read-msg 'token-id) (read-string 'seller) 1.0 0))
+
+  (expect "offer events"
+      [ {"name": "marmalade-v2.policy-manager.QUOTE","params": [(pact-id) (read-string 'token-id) (read-msg 'quote ) ]}
+        {"name": "marmalade-v2.ledger.OFFER","params": [(read-string 'token-id) (read-string 'seller) 1.0 0]}
+        {"name": "marmalade-v2.ledger.SALE","params": [(read-string 'token-id) (read-string 'seller) 1.0 0 (pact-id)]}
+        {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string 'token-id) "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" (account-guard (read-string "token-id") "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q")]}
+        {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-string 'token-id) (read-string 'seller) "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" 1.0]}
+        {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-string 'token-id) 1.0 {"account": (read-string 'seller),"current": 0.0,"previous": 1.0} {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 1.0,"previous": 0.0}]}
+      ]
+      (map (remove "module-hash")  (env-events true))
+    )
+
+  (env-data {
+    "seller": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+   ,"buyer": "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+   ,"buyer-guard": {"keys": ["6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"], "pred": "keys-all"}
+   ,"buyer_fungible_account": "k:ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"
+   ,"seller-fungible-account": "k:c8493f58aaff5787a15c987cf35b41bbca164a41d8978913860805768ed66fe7"
+   ,"updated_price":4.0
+   })
+
+   (env-sigs
+     [{'key:'ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c
+       ,'caps: [
+         (marmalade-v2.abc.TRANSFER "k:ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c" "c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" 2.0)
+       ]}
+     {'key:'buyer
+       ,'caps: [
+         (marmalade-v2.ledger.BUY "t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" (read-string 'seller) (read-string 'buyer) 1.0 (pact-id))
+       ]}
+   ])
+
+  (expect "Buy succeeds"
+    (pact-id)
+    (continue-pact 1))
+
+  (expect "buy events"
+    [ {"name": "marmalade-v2.abc.TRANSFER","params": [(read-string "buyer_fungible_account") "c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" 2.0]}
+      {"name": "marmalade-v2.abc.TRANSFER","params": ["c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" (read-string "seller-fungible-account") 2.0]}
+      {"name": "marmalade-v2.ledger.BUY","params": ["t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" (read-string 'seller) (read-string 'buyer) 1.0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" (read-string 'buyer) (read-keyset 'buyer-guard)]}
+      {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" (read-string 'buyer) 1.0]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": (read-string 'buyer),"current": 1.0,"previous": 0.0}]}]
+    (map (remove "module-hash")  (env-events true))
+  )
+
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+    ,'caps: [
+      (marmalade-v2.ledger.WITHDRAW "t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" (read-string 'seller) 1.0 0 (pact-id))]
+    }])
+
+  (expect-failure "Withdraw fails after buy has completed"
+    "resumePact: pact completed: i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"
+    (continue-pact 0 true))
+
+(rollback-tx)
+
+(begin-tx "Test enforce-offer, enforce-buy(succeeds) with quote and marketplace fees")
+  (env-chain-data {"chain-id": "0"})
+  (env-hash (hash "enforce-offer-1"))
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-v2.util-v1)
+
+  (env-data {
+      "seller-fungible-account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+    , "seller-fungible-guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+    , "marketplace-fungible-account": "k:4c5ba7f5bbb730602ebf7d4bc63fecd11f6d0288368797ee07d89977c71fc7e1"
+    , "marketplace-fungible-guard": {"keys": ["4c5ba7f5bbb730602ebf7d4bc63fecd11f6d0288368797ee07d89977c71fc7e1"], "pred": "keys-all"}
+    , "buyer-fungible-account": "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+    , "buyer-fungible-guard": {"keys": ["6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"], "pred": "keys-all"}
+    })
+
+  (marmalade-v2.abc.create-account (read-string "seller-fungible-account") (read-keyset 'seller-fungible-guard))
+  (marmalade-v2.abc.create-account (read-string "marketplace-fungible-account") (read-keyset 'marketplace-fungible-guard))
+  (marmalade-v2.abc.create-account (read-string "buyer-fungible-account") (read-keyset 'buyer-fungible-guard))
+  (marmalade-v2.abc.fund (read-string 'buyer-fungible-account) 2.0)
+
+  (env-data {
+      "token-id": "t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU"
+     ,"seller": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+     ,"quote":{
+        "fungible": marmalade-v2.abc
+        ,"sale-price": 1.5
+        ,"seller-fungible-account": {
+            "account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+           ,"guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+          }
+        ,"sale-type": ""
+      }
+    }
+  )
+
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+    ,'caps: [
+      (marmalade-v2.ledger.OFFER (read-string 'token-id) (read-string 'seller) 1.0 0)]
+    }])
+
+  (expect "start offer with quote spec"
+    (pact-id)
+    (sale (read-msg 'token-id) (read-string 'seller) 1.0 0))
+
+  (expect "offer events"
+      [ {"name": "marmalade-v2.policy-manager.QUOTE","params": [(pact-id) (read-string 'token-id) (read-msg 'quote ) ]}
+        {"name": "marmalade-v2.ledger.OFFER","params": [(read-string 'token-id) (read-string 'seller) 1.0 0]}
+        {"name": "marmalade-v2.ledger.SALE","params": [(read-string 'token-id) (read-string 'seller) 1.0 0 (pact-id)]}
+        {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string 'token-id) "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" (account-guard (read-string "token-id") "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q")]}
+        {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-string 'token-id) (read-string 'seller) "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" 1.0]}
+        {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-string 'token-id) 1.0 {"account": (read-string 'seller),"current": 0.0,"previous": 1.0} {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 1.0,"previous": 0.0}]}
+      ]
+      (map (remove "module-hash")  (env-events true))
+    )
+
+  (env-data {
+    "seller": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+   ,"buyer": "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+   ,"buyer-guard": {"keys": ["6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"], "pred": "keys-all"}
+   ,"buyer_fungible_account": "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+   ,"marketplace-fungible-account": "k:4c5ba7f5bbb730602ebf7d4bc63fecd11f6d0288368797ee07d89977c71fc7e1"
+   ,"marketplace_fee": {
+     "mk-account": "k:4c5ba7f5bbb730602ebf7d4bc63fecd11f6d0288368797ee07d89977c71fc7e1",
+     "mk-fee-percentage": 1.1
+    }
+   })
+
+   (env-sigs
+     [{'key: "6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+       ,'caps: [
+         (marmalade-v2.abc.TRANSFER (read-string 'buyer_fungible_account) "c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" 1.5)
+         (marmalade-v2.abc.TRANSFER (read-string 'buyer_fungible_account) (read-string 'marketplace-fungible-account) 0.15)
+         (marmalade-v2.ledger.BUY "t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" (read-string 'seller) (read-string 'buyer) 1.0 (pact-id))
+       ]}
+   ])
+
+   (expect-failure "Buy fails when marketplace fee configuration is incorrect"
+     "Invalid market-fee percentage"
+     (continue-pact 1))
+
+   (env-data {
+     "seller": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+    ,"buyer": "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+    ,"buyer-guard": {"keys": ["6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"], "pred": "keys-all"}
+    ,"buyer_fungible_account": "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+    ,"marketplace-fungible-account": "k:4c5ba7f5bbb730602ebf7d4bc63fecd11f6d0288368797ee07d89977c71fc7e1"
+    ,"marketplace_fee": {
+      "mk-account": "k:4c5ba7f5bbb730602ebf7d4bc63fecd11f6d0288368797ee07d89977c71fc7e1",
+      "mk-fee-percentage": 0.1
+     }
+    })
+
+  (expect "Buy succeeds"
+    (pact-id)
+    (continue-pact 1))
+
+  (expect "buy events"
+    [
+      {"name": "marmalade-v2.abc.TRANSFER","params": [(read-string 'buyer_fungible_account) (read-string 'marketplace-fungible-account) 0.15000000000000]}
+      {"name": "marmalade-v2.abc.TRANSFER","params": [(read-string 'buyer_fungible_account) "c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" 1.5]}
+      {"name": "marmalade-v2.abc.TRANSFER","params": ["c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" (read-string 'seller) 1.5]}
+      {"name": "marmalade-v2.ledger.BUY","params": ["t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" (read-string 'seller) (read-string 'buyer) 1.0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" (read-string 'buyer) (read-keyset 'buyer-guard)]}
+      {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" (read-string 'buyer) 1.0]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": (read-string 'buyer),"current": 1.0,"previous": 0.0}]}]
+    (map (remove "module-hash")  (env-events true))
+  )
+
+  (expect "Buyer balance has been deducted"
+    0.35
+    (marmalade-v2.abc.get-balance (read-string 'buyer_fungible_account))
+  )
+
+  (expect "Seller balance has increased"
+    1.5
+    (marmalade-v2.abc.get-balance (read-string 'seller))
+  )
+
+  (expect "Marketplace balance has increased with marketplace fees"
+    0.15
+    (marmalade-v2.abc.get-balance (read-string 'marketplace-fungible-account))
+  )
+
+(rollback-tx)
+
+(begin-tx "Test enforce-offer, enforce-withdraw")
+  (env-chain-data {"chain-id": "0",  "block-time": (time "2023-07-01T00:00:00Z")})
+  (env-hash (hash "enforce-offer-1"))
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-v2.util-v1)
+
+  (env-data {
+      "seller-fungible-account": "k:c8493f58aaff5787a15c987cf35b41bbca164a41d8978913860805768ed66fe7"
+    , "seller-fungible-guard": {"keys": ["c8493f58aaff5787a15c987cf35b41bbca164a41d8978913860805768ed66fe7"], "pred": "keys-all"}
+    })
+
+  (marmalade-v2.abc.create-account (read-string "seller-fungible-account") (read-keyset 'seller-fungible-guard))
+
+  (env-data {
+      "token-id": "t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU"
+     ,"seller": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+     ,"quote":{
+        "fungible": marmalade-v2.abc
+        ,"sale-price": 2.0
+        ,"seller-fungible-account": {
+            "account": "k:c8493f58aaff5787a15c987cf35b41bbca164a41d8978913860805768ed66fe7"
+           ,"guard": {"keys": ["c8493f58aaff5787a15c987cf35b41bbca164a41d8978913860805768ed66fe7"], "pred": "keys-all"}
+          }
+        ,"sale-type": "wrong"
+      }
+    }
+  )
+
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+    ,'caps: [
+      (marmalade-v2.ledger.OFFER (read-string 'token-id) (read-string 'seller) 1.0 (to-timestamp (time "2023-07-10T00:00:00Z")))]
+    }])
+
+  (expect-failure "sale with non-whitelisted sale-type fails"
+    "with-read: row not found: wrong"
+    (sale (read-msg 'token-id) "k:account" 1.0 (to-timestamp (time "2023-07-10T00:00:00Z"))))
+
+  (env-data {
+      "token-id": "t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU"
+     ,"seller": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+     ,"quote":{
+        "fungible": marmalade-v2.abc
+        ,"sale-price": 2.0
+        ,"seller-fungible-account": {
+            "account": "k:c8493f58aaff5787a15c987cf35b41bbca164a41d8978913860805768ed66fe7"
+           ,"guard": {"keys": ["c8493f58aaff5787a15c987cf35b41bbca164a41d8978913860805768ed66fe7"], "pred": "keys-all"}
+          }
+        ,"sale-type": ""
+      }
+    }
+  )
+
+  (expect "start offer with quote spec"
+    (pact-id)
+    (sale (read-msg 'token-id) (read-string "seller") 1.0 (to-timestamp (time "2023-07-10T00:00:00Z"))))
+
+ (expect "offer events"
+    [ {"name": "marmalade-v2.policy-manager.QUOTE","params": [(pact-id) (read-string 'token-id) (read-msg 'quote ) ]}
+      {"name": "marmalade-v2.ledger.OFFER","params": [(read-string 'token-id) (read-string "seller") 1.0 (to-timestamp (time "2023-07-10T00:00:00Z"))]}
+      {"name": "marmalade-v2.ledger.SALE","params": [(read-string 'token-id) (read-string "seller") 1.0 (to-timestamp (time "2023-07-10T00:00:00Z")) (pact-id)]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string 'token-id) "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" (account-guard (read-string "token-id") "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q")]}
+      {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-string 'token-id) (read-string "seller") "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" 1.0]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-string 'token-id) 1.0 {"account": (read-string "seller"),"current": 0.0,"previous": 1.0} {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 1.0,"previous": 0.0}]}
+    ]
+    (map (remove "module-hash")  (env-events true))
+  )
+
+  (env-data {
+    "buyer": "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+   ,"buyer-guard": {"keys": ["6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"], "pred": "keys-all"}
+   ,"seller": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+   })
+
+  (env-chain-data {"chain-id": "0",  "block-time": (time "2023-08-01T00:00:00Z")})
+
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+    ,'caps: [
+      (marmalade-v2.ledger.WITHDRAW "t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" (read-string 'seller) 1.0 (to-timestamp (time "2023-07-10T00:00:00Z")) (pact-id))]
+    }])
+
+  (expect "Withdraw succeeds"
+    "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"
+    (continue-pact 0 true))
+
+  (expect "withdraw events"
+   [ {"name": "marmalade-v2.ledger.WITHDRAW","params": ["t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" (read-string 'seller) 1.0 1688947200 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
+     {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" (read-string 'seller) 1.0]}
+     {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": (read-string 'seller),"current": 1.0,"previous": 0.0}]}]
+    (map (remove "module-hash")  (env-events true))
+  )
+
+(rollback-tx)
+
+
+(begin-tx )
+  (env-sigs [{"key": "marmalade-user", "caps": []}])
+  (env-data {"ns": "marmalade-v2"})
+  (namespace (read-string 'ns))
+
+  (module sale-example-v1 GOV
+    (implements marmalade-v2.sale-v2)
+
+    (defcap GOV () true)
+
+    (defun enforce-quote-update:bool (sale-id:string price:decimal)
+      (require-capability (marmalade-v2.policy-manager.SALE-GUARD-CALL sale-id price))
+    )
+
+    (defun enforce-withdrawal:bool (sale-id:string)
+      true
+    )
+  )
+
+(commit-tx)
+
+
+(begin-tx "Test enforce-offer, enforce-withdraw")
+  (env-chain-data {"chain-id": "0",  "block-time": (time "2023-07-01T00:00:00Z")})
+  (env-hash (hash "enforce-offer-1"))
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-v2.util-v1)
+
+  (env-data {
+      "seller-fungible-account": "k:c8493f58aaff5787a15c987cf35b41bbca164a41d8978913860805768ed66fe7"
+    , "seller-fungible-guard": {"keys": ["c8493f58aaff5787a15c987cf35b41bbca164a41d8978913860805768ed66fe7"], "pred": "keys-all"}
+    })
+
+  (env-sigs [
+    {"key": "marmalade-contract-admin",
+     "caps": [ (marmalade-v2.policy-manager.SALE-WHITELIST "marmalade-v2.sale-example-v1") ]
+   }]
+  )
+
+  (marmalade-v2.abc.create-account (read-string "seller-fungible-account") (read-keyset 'seller-fungible-guard))
+  (add-sale-whitelist marmalade-v2.sale-example-v1)
+  (env-data {
+      "token-id": "t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU"
+     ,"seller": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+     ,"quote":{
+        "fungible": marmalade-v2.abc
+        ,"sale-price": 2.0000000000000001
+        ,"seller-fungible-account": {
+            "account": "k:c8493f58aaff5787a15c987cf35b41bbca164a41d8978913860805768ed66fe7"
+           ,"guard": {"keys": ["c8493f58aaff5787a15c987cf35b41bbca164a41d8978913860805768ed66fe7"], "pred": "keys-all"}
+          }
+        ,"sale-type": "marmalade-v2.sale-example-v1"
+      }
+    }
+  )
+
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+    ,'caps: [
+      (marmalade-v2.ledger.OFFER (read-string 'token-id) (read-string 'seller) 1.0 (to-timestamp (time "2023-07-10T00:00:00Z")))]
+    }])
+
+  (expect-failure "sale fails when sale-price precision is incorrect"
+    "precision violation"
+    (sale (read-msg 'token-id) (read-string 'seller) 1.0 (to-timestamp (time "2023-07-10T00:00:00Z"))))
+
+  (env-data {
+      "token-id": "t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU"
+     ,"seller": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+     ,"quote":{
+        "fungible": marmalade-v2.abc
+        ,"sale-price": 0.0
+        ,"seller-fungible-account": {
+            "account": "k:c8493f58aaff5787a15c987cf35b41bbca164a41d8978913860805768ed66fe7"
+           ,"guard": {"keys": ["c8493f58aaff5787a15c987cf35b41bbca164a41d8978913860805768ed66fe7"], "pred": "keys-all"}
+          }
+        ,"sale-type": "marmalade-v2.sale-example-v1"
+      }
+    }
+  )
+
+  (expect "start offer with quote spec"
+    (pact-id)
+    (sale (read-msg 'token-id) (read-string 'seller) 1.0 (to-timestamp (time "2023-07-10T00:00:00Z"))))
+
+ (expect "offer events"
+    [ {"name": "marmalade-v2.policy-manager.SALE-WHITELIST","params": ["marmalade-v2.sale-example-v1"]}
+      {"name": "marmalade-v2.policy-manager.QUOTE","params": [(pact-id) (read-string 'token-id) (read-msg 'quote ) ]}
+      {"name": "marmalade-v2.ledger.OFFER","params": [(read-string 'token-id) (read-string 'seller) 1.0 (to-timestamp (time "2023-07-10T00:00:00Z"))]}
+      {"name": "marmalade-v2.ledger.SALE","params": [(read-string 'token-id) (read-string 'seller) 1.0 (to-timestamp (time "2023-07-10T00:00:00Z")) (pact-id)]}
+      {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": [(read-string 'token-id) "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" (account-guard (read-string "token-id") "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q")]}
+      {"name": "marmalade-v2.ledger.TRANSFER","params": [(read-string 'token-id) (read-string 'seller) "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" 1.0]}
+      {"name": "marmalade-v2.ledger.RECONCILE","params": [(read-string 'token-id) 1.0 {"account": (read-string 'seller),"current": 0.0,"previous": 1.0} {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 1.0,"previous": 0.0}]}
+    ]
+    (map (remove "module-hash")  (env-events true))
+  )
+
+  (env-data {
+    "buyer": "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+   ,"buyer-guard": {"keys": ["6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"], "pred": "keys-all"}
+   ,"buyer_fungible_account": "k:ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"
+   ,"seller": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+   })
+
+  (marmalade-v2.abc.fund (read-string "buyer_fungible_account") 50.0)
+  (env-sigs
+    [ {'key: "6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+      ,'caps: [
+        (marmalade-v2.ledger.BUY "t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" (read-string 'seller) (read-string 'buyer) 1.0 (pact-id))
+      ]}
+      ,{'key: 'ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c
+       ,'caps: [(marmalade-v2.abc.TRANSFER (read-string 'buyer_fungible_account) "c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" 50.0) ]
+      }
+  ])
+
+  (expect-failure "Buy fails without quote price update"
+    "Price is not finalized for this quote"
+    (continue-pact 1))
+
+  (env-data {
+    "buyer": "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+   ,"buyer-guard": {"keys": ["6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"], "pred": "keys-all"}
+   ,"buyer_fungible_account": "k:ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"
+   ,"updated_price":  49.0000000000000001
+   })
+
+  (expect-failure "Buy fails with incorrect precision"
+    "precision violation"
+    (continue-pact 1))
+
+  (env-data {
+    "buyer": "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+   ,"buyer-guard": {"keys": ["6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"], "pred": "keys-all"}
+   ,"buyer_fungible_account": "k:ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"
+   ,"updated_price": ""
+  })
+
+  (expect-failure "Buy fails when updated_price is not decimal"
+    "Type error: expected decimal, found string"
+    (continue-pact 1))
+
+  (env-data {
+    "seller": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+   ,"buyer": "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+   ,"buyer-guard": {"keys": ["6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"], "pred": "keys-all"}
+   ,"buyer_fungible_account": "k:ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"
+   ,"seller-fungible-account": "k:c8493f58aaff5787a15c987cf35b41bbca164a41d8978913860805768ed66fe7"
+   ,"updated_price": 50.0
+  })
+
+  (expect "Buy succeeds"
+    (pact-id)
+    (continue-pact 1))
+
+(expect "buy events"
+  [ {"name": "marmalade-v2.abc.TRANSFER","params": [(read-string "buyer_fungible_account") "c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" 50.0]}
+    {"name": "marmalade-v2.abc.TRANSFER","params": ["c:OgWllLAYtF0-YHB7by8ZdFfYg_DvDLoQNfFD4gXdzdw" (read-string "seller-fungible-account") 50.0]}
+    {"name": "marmalade-v2.ledger.BUY","params": ["t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" (read-string 'seller) (read-string 'buyer) 1.0 "i35txr8Kcr43a3gQm7Zbd98mqQwfqpd2DkdsbKeA0qY"]}
+    {"name": "marmalade-v2.ledger.ACCOUNT_GUARD","params": ["t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" (read-string 'buyer) (read-keyset 'buyer-guard)]}
+    {"name": "marmalade-v2.ledger.TRANSFER","params": ["t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q" (read-string 'buyer) 1.0]}
+    {"name": "marmalade-v2.ledger.RECONCILE","params": ["t:E3StsDuFkw7kPU8_CGha59AaONqN1C39cB37D4hswmU" 1.0 {"account": "c:JKwZqh1BLwRitGKgaousFt5ZgWOSyY0tyPh_xh25a2Q","current": 0.0,"previous": 1.0} {"account": (read-string 'buyer),"current": 1.0,"previous": 0.0}]}]
+    (map (remove "module-hash")  (env-events true)))
+
+(rollback-tx)

--- a/pact-tests/pact-tests/marmalade/pact/policy-manager/sale.interface.pact
+++ b/pact-tests/pact-tests/marmalade/pact/policy-manager/sale.interface.pact
@@ -1,0 +1,14 @@
+(namespace (read-msg 'ns))
+
+(interface sale-v2
+
+  " Standard for marmalade-v2 sale contracts to be implemented in quoted sales."
+
+  (defun enforce-quote-update:bool (sale-id:string price:decimal)
+    @doc "Read-only Function that is enforced to update quote price at enforce-buy"
+  )
+
+  (defun enforce-withdrawal:bool (sale-id:string)
+    @doc "Read-only Function that is enforced to allow withdrawal from sale"
+  )
+)

--- a/pact-tests/pact-tests/marmalade/pact/root/coin.pact
+++ b/pact-tests/pact-tests/marmalade/pact/root/coin.pact
@@ -1,0 +1,685 @@
+
+(module coin GOVERNANCE
+
+  @doc "'coin' represents the Kadena Coin Contract. This contract provides both the \
+  \buy/redeem gas support in the form of 'fund-tx', as well as transfer,       \
+  \credit, debit, coinbase, account creation and query, as well as SPV burn    \
+  \create. To access the coin contract, you may use its fully-qualified name,  \
+  \or issue the '(use coin)' command in the body of a module declaration."
+
+  @model
+    [ (defproperty conserves-mass
+        (= (column-delta coin-table 'balance) 0.0))
+
+      (defproperty valid-account (account:string)
+        (and
+          (>= (length account) 3)
+          (<= (length account) 256)))
+    ]
+
+  (implements fungible-v2)
+  (implements fungible-xchain-v1)
+
+  ;; coin-v2
+  (bless "ut_J_ZNkoyaPUEJhiwVeWnkSQn9JT9sQCWKdjjVVrWo")
+
+  ;; coin v3
+  (bless "1os_sLAUYvBzspn5jjawtRpJWiH1WPfhyNraeVvSIwU")
+
+  ;; coin v4
+  (bless "BjZW0T2ac6qE_I5X8GE4fal6tTqjhLTC7my0ytQSxLU")
+
+  ; --------------------------------------------------------------------------
+  ; Schemas and Tables
+
+  (defschema coin-schema
+    @doc "The coin contract token schema"
+    @model [ (invariant (>= balance 0.0)) ]
+
+    balance:decimal
+    guard:guard)
+
+  (deftable coin-table:{coin-schema})
+
+  ; --------------------------------------------------------------------------
+  ; Capabilities
+
+  (defcap GOVERNANCE ()
+    (enforce false "Enforce non-upgradeability"))
+
+  (defcap GAS ()
+    "Magic capability to protect gas buy and redeem"
+    true)
+
+  (defcap COINBASE ()
+    "Magic capability to protect miner reward"
+    true)
+
+  (defcap GENESIS ()
+    "Magic capability constraining genesis transactions"
+    true)
+
+  (defcap REMEDIATE ()
+    "Magic capability for remediation transactions"
+    true)
+
+  (defcap DEBIT (sender:string)
+    "Capability for managing debiting operations"
+    (enforce-guard (at 'guard (read coin-table sender)))
+    (enforce (!= sender "") "valid sender"))
+
+  (defcap CREDIT (receiver:string)
+    "Capability for managing crediting operations"
+    (enforce (!= receiver "") "valid receiver"))
+
+  (defcap ROTATE (account:string)
+    @doc "Autonomously managed capability for guard rotation"
+    @managed
+    true)
+
+  (defcap TRANSFER:bool
+    ( sender:string
+      receiver:string
+      amount:decimal
+    )
+    @managed amount TRANSFER-mgr
+    (enforce (!= sender receiver) "same sender and receiver")
+    (enforce-unit amount)
+    (enforce (> amount 0.0) "Positive amount")
+    (compose-capability (DEBIT sender))
+    (compose-capability (CREDIT receiver))
+  )
+
+  (defun TRANSFER-mgr:decimal
+    ( managed:decimal
+      requested:decimal
+    )
+
+    (let ((newbal (- managed requested)))
+      (enforce (>= newbal 0.0)
+        (format "TRANSFER exceeded for balance {}" [managed]))
+      newbal)
+  )
+
+  (defcap TRANSFER_XCHAIN:bool
+    ( sender:string
+      receiver:string
+      amount:decimal
+      target-chain:string
+    )
+
+    @managed amount TRANSFER_XCHAIN-mgr
+    (enforce-unit amount)
+    (enforce (> amount 0.0) "Cross-chain transfers require a positive amount")
+    (compose-capability (DEBIT sender))
+  )
+
+  (defun TRANSFER_XCHAIN-mgr:decimal
+    ( managed:decimal
+      requested:decimal
+    )
+
+    (enforce (>= managed requested)
+      (format "TRANSFER_XCHAIN exceeded for balance {}" [managed]))
+    0.0
+  )
+
+  (defcap TRANSFER_XCHAIN_RECD:bool
+    ( sender:string
+      receiver:string
+      amount:decimal
+      source-chain:string
+    )
+    @event true
+  )
+
+  ; v3 capabilities
+  (defcap RELEASE_ALLOCATION
+    ( account:string
+      amount:decimal
+    )
+    @doc "Event for allocation release, can be used for sig scoping."
+    @event true
+  )
+
+  ; --------------------------------------------------------------------------
+  ; Constants
+
+  (defconst COIN_CHARSET CHARSET_LATIN1
+    "The default coin contract character set")
+
+  (defconst MINIMUM_PRECISION 12
+    "Minimum allowed precision for coin transactions")
+
+  (defconst MINIMUM_ACCOUNT_LENGTH 3
+    "Minimum account length admissible for coin accounts")
+
+  (defconst MAXIMUM_ACCOUNT_LENGTH 256
+    "Maximum account name length admissible for coin accounts")
+
+  (defconst VALID_CHAIN_IDS (map (int-to-str 10) (enumerate 0 19))
+    "List of all valid Chainweb chain ids")
+
+  ; --------------------------------------------------------------------------
+  ; Utilities
+
+  (defun enforce-unit:bool (amount:decimal)
+    @doc "Enforce minimum precision allowed for coin transactions"
+
+    (enforce
+      (= (floor amount MINIMUM_PRECISION)
+         amount)
+      (format "Amount violates minimum precision: {}" [amount]))
+    )
+
+  (defun validate-account (account:string)
+    @doc "Enforce that an account name conforms to the coin contract \
+         \minimum and maximum length requirements, as well as the    \
+         \latin-1 character set."
+
+    (enforce
+      (is-charset COIN_CHARSET account)
+      (format
+        "Account does not conform to the coin contract charset: {}"
+        [account]))
+
+    (let ((account-length (length account)))
+
+      (enforce
+        (>= account-length MINIMUM_ACCOUNT_LENGTH)
+        (format
+          "Account name does not conform to the min length requirement: {}"
+          [account]))
+
+      (enforce
+        (<= account-length MAXIMUM_ACCOUNT_LENGTH)
+        (format
+          "Account name does not conform to the max length requirement: {}"
+          [account]))
+      )
+  )
+
+  ; --------------------------------------------------------------------------
+  ; Coin Contract
+
+  (defun gas-only ()
+    "Predicate for gas-only user guards."
+    (require-capability (GAS)))
+
+  (defun gas-guard (guard:guard)
+    "Predicate for gas + single key user guards"
+    (enforce-one
+      "Enforce either the presence of a GAS cap or keyset"
+      [ (gas-only)
+        (enforce-guard guard)
+      ]))
+
+  (defun buy-gas:string (sender:string total:decimal)
+    @doc "This function describes the main 'gas buy' operation. At this point \
+    \MINER has been chosen from the pool, and will be validated. The SENDER   \
+    \of this transaction has specified a gas limit LIMIT (maximum gas) for    \
+    \the transaction, and the price is the spot price of gas at that time.    \
+    \The gas buy will be executed prior to executing SENDER's code."
+
+    @model [ (property (> total 0.0))
+             (property (valid-account sender))
+           ]
+
+    (validate-account sender)
+
+    (enforce-unit total)
+    (enforce (> total 0.0) "gas supply must be a positive quantity")
+
+    (require-capability (GAS))
+    (with-capability (DEBIT sender)
+      (debit sender total))
+    )
+
+  (defun redeem-gas:string (miner:string miner-guard:guard sender:string total:decimal)
+    @doc "This function describes the main 'redeem gas' operation. At this    \
+    \point, the SENDER's transaction has been executed, and the gas that      \
+    \was charged has been calculated. MINER will be credited the gas cost,    \
+    \and SENDER will receive the remainder up to the limit"
+
+    @model [ (property (> total 0.0))
+             (property (valid-account sender))
+             (property (valid-account miner))
+           ]
+
+    (validate-account sender)
+    (validate-account miner)
+    (enforce-unit total)
+
+    (require-capability (GAS))
+    (let*
+      ((fee (read-decimal "fee"))
+       (refund (- total fee)))
+
+      (enforce-unit fee)
+      (enforce (>= fee 0.0)
+        "fee must be a non-negative quantity")
+
+      (enforce (>= refund 0.0)
+        "refund must be a non-negative quantity")
+
+      (emit-event (TRANSFER sender miner fee)) ;v3
+
+        ; directly update instead of credit
+      (with-capability (CREDIT sender)
+        (if (> refund 0.0)
+          (with-read coin-table sender
+            { "balance" := balance }
+            (update coin-table sender
+              { "balance": (+ balance refund) }))
+
+          "noop"))
+
+      (with-capability (CREDIT miner)
+        (if (> fee 0.0)
+          (credit miner miner-guard fee)
+          "noop"))
+      )
+
+    )
+
+  (defun create-account:string (account:string guard:guard)
+    @model [ (property (valid-account account)) ]
+
+    (validate-account account)
+    (enforce-reserved account guard)
+
+    (insert coin-table account
+      { "balance" : 0.0
+      , "guard"   : guard
+      })
+    )
+
+  (defun get-balance:decimal (account:string)
+    (with-read coin-table account
+      { "balance" := balance }
+      balance
+      )
+    )
+
+  (defun details:object{fungible-v2.account-details}
+    ( account:string )
+    (with-read coin-table account
+      { "balance" := bal
+      , "guard" := g }
+      { "account" : account
+      , "balance" : bal
+      , "guard": g })
+    )
+
+  (defun rotate:string (account:string new-guard:guard)
+    (with-capability (ROTATE account)
+      (with-read coin-table account
+        { "guard" := old-guard }
+
+        (enforce-guard old-guard)
+
+        (update coin-table account
+          { "guard" : new-guard }
+          )))
+    )
+
+
+  (defun precision:integer
+    ()
+    MINIMUM_PRECISION)
+
+  (defun transfer:string (sender:string receiver:string amount:decimal)
+    @model [ (property conserves-mass)
+             (property (> amount 0.0))
+             (property (valid-account sender))
+             (property (valid-account receiver))
+             (property (!= sender receiver)) ]
+
+    (enforce (!= sender receiver)
+      "sender cannot be the receiver of a transfer")
+
+    (validate-account sender)
+    (validate-account receiver)
+
+    (enforce (> amount 0.0)
+      "transfer amount must be positive")
+
+    (enforce-unit amount)
+
+    (with-capability (TRANSFER sender receiver amount)
+      (debit sender amount)
+      (with-read coin-table receiver
+        { "guard" := g }
+
+        (credit receiver g amount))
+      )
+    )
+
+  (defun transfer-create:string
+    ( sender:string
+      receiver:string
+      receiver-guard:guard
+      amount:decimal )
+
+    @model [ (property conserves-mass) ]
+
+    (enforce (!= sender receiver)
+      "sender cannot be the receiver of a transfer")
+
+    (validate-account sender)
+    (validate-account receiver)
+
+    (enforce (> amount 0.0)
+      "transfer amount must be positive")
+
+    (enforce-unit amount)
+
+    (with-capability (TRANSFER sender receiver amount)
+      (debit sender amount)
+      (credit receiver receiver-guard amount))
+    )
+
+  (defun coinbase:string (account:string account-guard:guard amount:decimal)
+    @doc "Internal function for the initial creation of coins.  This function \
+    \cannot be used outside of the coin contract."
+
+    @model [ (property (valid-account account))
+             (property (> amount 0.0))
+           ]
+
+    (validate-account account)
+    (enforce-unit amount)
+
+    (require-capability (COINBASE))
+    (emit-event (TRANSFER "" account amount)) ;v3
+    (with-capability (CREDIT account)
+      (credit account account-guard amount))
+    )
+
+  (defun remediate:string (account:string amount:decimal)
+    @doc "Allows for remediation transactions. This function \
+         \is protected by the REMEDIATE capability"
+    @model [ (property (valid-account account))
+             (property (> amount 0.0))
+           ]
+
+    (validate-account account)
+
+    (enforce (> amount 0.0)
+      "Remediation amount must be positive")
+
+    (enforce-unit amount)
+
+    (require-capability (REMEDIATE))
+    (emit-event (TRANSFER "" account amount)) ;v3
+    (with-read coin-table account
+      { "balance" := balance }
+
+      (enforce (<= amount balance) "Insufficient funds")
+
+      (update coin-table account
+        { "balance" : (- balance amount) }
+        ))
+    )
+
+  (defpact fund-tx (sender:string miner:string miner-guard:guard total:decimal)
+    @doc "'fund-tx' is a special pact to fund a transaction in two steps,     \
+    \with the actual transaction transpiring in the middle:                   \
+    \                                                                         \
+    \  1) A buying phase, debiting the sender for total gas and fee, yielding \
+    \     TX_MAX_CHARGE.                                                      \
+    \  2) A settlement phase, resuming TX_MAX_CHARGE, and allocating to the   \
+    \     coinbase account for used gas and fee, and sender account for bal-  \
+    \     ance (unused gas, if any)."
+
+    @model [ (property (> total 0.0))
+             (property (valid-account sender))
+             (property (valid-account miner))
+             ;(property conserves-mass) not supported yet
+           ]
+
+    (step (buy-gas sender total))
+    (step (redeem-gas miner miner-guard sender total))
+    )
+
+  (defun debit:string (account:string amount:decimal)
+    @doc "Debit AMOUNT from ACCOUNT balance"
+
+    @model [ (property (> amount 0.0))
+             (property (valid-account account))
+           ]
+
+    (validate-account account)
+
+    (enforce (> amount 0.0)
+      "debit amount must be positive")
+
+    (enforce-unit amount)
+
+    (require-capability (DEBIT account))
+    (with-read coin-table account
+      { "balance" := balance }
+
+      (enforce (<= amount balance) "Insufficient funds")
+
+      (update coin-table account
+        { "balance" : (- balance amount) }
+        ))
+    )
+
+
+  (defun credit:string (account:string guard:guard amount:decimal)
+    @doc "Credit AMOUNT to ACCOUNT balance"
+
+    @model [ (property (> amount 0.0))
+             (property (valid-account account))
+           ]
+
+    (validate-account account)
+
+    (enforce (> amount 0.0) "credit amount must be positive")
+    (enforce-unit amount)
+
+    (require-capability (CREDIT account))
+    (with-default-read coin-table account
+      { "balance" : -1.0, "guard" : guard }
+      { "balance" := balance, "guard" := retg }
+      ; we don't want to overwrite an existing guard with the user-supplied one
+      (enforce (= retg guard)
+        "account guards do not match")
+
+      (let ((is-new
+             (if (= balance -1.0)
+                 (enforce-reserved account guard)
+               false)))
+
+        (write coin-table account
+          { "balance" : (if is-new amount (+ balance amount))
+          , "guard"   : retg
+          }))
+      ))
+
+  (defun check-reserved:string (account:string)
+    " Checks ACCOUNT for reserved name and returns type if \
+    \ found or empty string. Reserved names start with a \
+    \ single char and colon, e.g. 'c:foo', which would return 'c' as type."
+    (let ((pfx (take 2 account)))
+      (if (= ":" (take -1 pfx)) (take 1 pfx) "")))
+
+  (defun enforce-reserved:bool (account:string guard:guard)
+    @doc "Enforce reserved account name protocols."
+    (if (validate-principal guard account)
+      true
+      (let ((r (check-reserved account)))
+        (if (= r "")
+          true
+          (if (= r "k")
+            (enforce false "Single-key account protocol violation")
+            (enforce false
+              (format "Reserved protocol guard violation: {}" [r]))
+            )))))
+
+
+  (defschema crosschain-schema
+    @doc "Schema for yielded value in cross-chain transfers"
+    receiver:string
+    receiver-guard:guard
+    amount:decimal
+    source-chain:string)
+
+  (defpact transfer-crosschain:string
+    ( sender:string
+      receiver:string
+      receiver-guard:guard
+      target-chain:string
+      amount:decimal )
+
+    @model [ (property (> amount 0.0))
+             (property (valid-account sender))
+             (property (valid-account receiver))
+           ]
+
+    (step
+      (with-capability
+        (TRANSFER_XCHAIN sender receiver amount target-chain)
+
+        (validate-account sender)
+        (validate-account receiver)
+
+        (enforce (!= "" target-chain) "empty target-chain")
+        (enforce (!= (at 'chain-id (chain-data)) target-chain)
+          "cannot run cross-chain transfers to the same chain")
+
+        (enforce (> amount 0.0)
+          "transfer quantity must be positive")
+
+        (enforce-unit amount)
+
+        (enforce (contains target-chain VALID_CHAIN_IDS)
+          "target chain is not a valid chainweb chain id")
+
+        ;; step 1 - debit delete-account on current chain
+        (debit sender amount)
+        (emit-event (TRANSFER sender "" amount))
+
+        (let
+          ((crosschain-details:object{crosschain-schema}
+            { "receiver" : receiver
+            , "receiver-guard" : receiver-guard
+            , "amount" : amount
+            , "source-chain" : (at 'chain-id (chain-data))
+            }))
+          (yield crosschain-details target-chain)
+          )))
+
+    (step
+      (resume
+        { "receiver" := receiver
+        , "receiver-guard" := receiver-guard
+        , "amount" := amount
+        , "source-chain" := source-chain
+        }
+
+        (emit-event (TRANSFER "" receiver amount))
+        (emit-event (TRANSFER_XCHAIN_RECD "" receiver amount source-chain))
+
+        ;; step 2 - credit create account on target chain
+        (with-capability (CREDIT receiver)
+          (credit receiver receiver-guard amount))
+        ))
+    )
+
+
+  ; --------------------------------------------------------------------------
+  ; Coin allocations
+
+  (defschema allocation-schema
+    @doc "Genesis allocation registry"
+    ;@model [ (invariant (>= balance 0.0)) ]
+
+    balance:decimal
+    date:time
+    guard:guard
+    redeemed:bool)
+
+  (deftable allocation-table:{allocation-schema})
+
+  (defun create-allocation-account
+    ( account:string
+      date:time
+      keyset-ref:string
+      amount:decimal
+    )
+
+    @doc "Add an entry to the coin allocation table. This function \
+         \also creates a corresponding empty coin contract account \
+         \of the same name and guard. Requires GENESIS capability. "
+
+    @model [ (property (valid-account account)) ]
+
+    (require-capability (GENESIS))
+
+    (validate-account account)
+    (enforce (>= amount 0.0)
+      "allocation amount must be non-negative")
+
+    (enforce-unit amount)
+
+    (let
+      ((guard:guard (keyset-ref-guard keyset-ref)))
+
+      (create-account account guard)
+
+      (insert allocation-table account
+        { "balance" : amount
+        , "date" : date
+        , "guard" : guard
+        , "redeemed" : false
+        })))
+
+  (defun release-allocation
+    ( account:string )
+
+    @doc "Release funds associated with allocation ACCOUNT into main ledger.   \
+         \ACCOUNT must already exist in main ledger. Allocation is deactivated \
+         \after release."
+    @model [ (property (valid-account account)) ]
+
+    (validate-account account)
+
+    (with-read allocation-table account
+      { "balance" := balance
+      , "date" := release-time
+      , "redeemed" := redeemed
+      , "guard" := guard
+      }
+
+      (let ((curr-time:time (at 'block-time (chain-data))))
+
+        (enforce (not redeemed)
+          "allocation funds have already been redeemed")
+
+        (enforce
+          (>= curr-time release-time)
+          (format "funds locked until {}. current time: {}" [release-time curr-time]))
+
+        (with-capability (RELEASE_ALLOCATION account balance)
+
+        (enforce-guard guard)
+
+        (with-capability (CREDIT account)
+          (emit-event (TRANSFER "" account balance))
+          (credit account guard balance)
+
+          (update allocation-table account
+            { "redeemed" : true
+            , "balance" : 0.0
+            })
+
+          "Allocation successfully released to main ledger"))
+    )))
+
+)
+
+(create-table coin-table)
+(create-table allocation-table)

--- a/pact-tests/pact-tests/marmalade/pact/root/fungible-v2.pact
+++ b/pact-tests/pact-tests/marmalade/pact/root/fungible-v2.pact
@@ -1,0 +1,135 @@
+(interface fungible-v2
+
+  " Standard for fungible coins and tokens as specified in KIP-0002. "
+
+   ; ----------------------------------------------------------------------
+   ; Schema
+
+   (defschema account-details
+    @doc "Schema for results of 'account' operation."
+    @model [ (invariant (!= "" sender)) ]
+
+    account:string
+    balance:decimal
+    guard:guard)
+
+
+   ; ----------------------------------------------------------------------
+   ; Caps
+
+   (defcap TRANSFER:bool
+     ( sender:string
+       receiver:string
+       amount:decimal
+     )
+     @doc " Managed capability sealing AMOUNT for transfer from SENDER to \
+          \ RECEIVER. Permits any number of transfers up to AMOUNT."
+     @managed amount TRANSFER-mgr
+     )
+
+   (defun TRANSFER-mgr:decimal
+     ( managed:decimal
+       requested:decimal
+     )
+     @doc " Manages TRANSFER AMOUNT linearly, \
+          \ such that a request for 1.0 amount on a 3.0 \
+          \ managed quantity emits updated amount 2.0."
+     )
+
+   ; ----------------------------------------------------------------------
+   ; Functionality
+
+
+  (defun transfer:string
+    ( sender:string
+      receiver:string
+      amount:decimal
+    )
+    @doc " Transfer AMOUNT between accounts SENDER and RECEIVER. \
+         \ Fails if either SENDER or RECEIVER does not exist."
+    @model [ (property (> amount 0.0))
+             (property (!= sender ""))
+             (property (!= receiver ""))
+             (property (!= sender receiver))
+           ]
+    )
+
+   (defun transfer-create:string
+     ( sender:string
+       receiver:string
+       receiver-guard:guard
+       amount:decimal
+     )
+     @doc " Transfer AMOUNT between accounts SENDER and RECEIVER. \
+          \ Fails if SENDER does not exist. If RECEIVER exists, guard \
+          \ must match existing value. If RECEIVER does not exist, \
+          \ RECEIVER account is created using RECEIVER-GUARD. \
+          \ Subject to management by TRANSFER capability."
+     @model [ (property (> amount 0.0))
+              (property (!= sender ""))
+              (property (!= receiver ""))
+              (property (!= sender receiver))
+            ]
+     )
+
+   (defpact transfer-crosschain:string
+     ( sender:string
+       receiver:string
+       receiver-guard:guard
+       target-chain:string
+       amount:decimal
+     )
+     @doc " 2-step pact to transfer AMOUNT from SENDER on current chain \
+          \ to RECEIVER on TARGET-CHAIN via SPV proof. \
+          \ TARGET-CHAIN must be different than current chain id. \
+          \ First step debits AMOUNT coins in SENDER account and yields \
+          \ RECEIVER, RECEIVER_GUARD and AMOUNT to TARGET-CHAIN. \
+          \ Second step continuation is sent into TARGET-CHAIN with proof \
+          \ obtained from the spv 'output' endpoint of Chainweb. \
+          \ Proof is validated and RECEIVER is credited with AMOUNT \
+          \ creating account with RECEIVER_GUARD as necessary."
+     @model [ (property (> amount 0.0))
+              (property (!= sender ""))
+              (property (!= receiver ""))
+              (property (!= sender receiver))
+              (property (!= target-chain ""))
+            ]
+     )
+
+   (defun get-balance:decimal
+     ( account:string )
+     " Get balance for ACCOUNT. Fails if account does not exist."
+     )
+
+   (defun details:object{account-details}
+     ( account: string )
+     " Get an object with details of ACCOUNT. \
+     \ Fails if account does not exist."
+     )
+
+   (defun precision:integer
+     ()
+     "Return the maximum allowed decimal precision."
+     )
+
+   (defun enforce-unit:bool
+     ( amount:decimal )
+     " Enforce minimum precision allowed for transactions."
+     )
+
+   (defun create-account:string
+     ( account:string
+       guard:guard
+     )
+     " Create ACCOUNT with 0.0 balance, with GUARD controlling access."
+     )
+
+   (defun rotate:string
+     ( account:string
+       new-guard:guard
+     )
+     " Rotate guard for ACCOUNT. Transaction is validated against \
+     \ existing guard before installing new guard. "
+     )
+
+)

--- a/pact-tests/pact-tests/marmalade/pact/root/fungible-xchain-v1.pact
+++ b/pact-tests/pact-tests/marmalade/pact/root/fungible-xchain-v1.pact
@@ -1,0 +1,36 @@
+(interface fungible-xchain-v1
+
+  " This interface offers a standard capability for cross-chain \
+  \ transfers and associated events. "
+
+  (defcap TRANSFER_XCHAIN:bool
+    ( sender:string
+      receiver:string
+      amount:decimal
+      target-chain:string
+    )
+    @doc " Managed capability sealing AMOUNT for transfer \
+         \ from SENDER to RECEIVER on TARGET-CHAIN. Permits \
+         \ any number of cross-chain transfers up to AMOUNT."
+
+    @managed amount TRANSFER_XCHAIN-mgr
+    )
+
+  (defun TRANSFER_XCHAIN-mgr:decimal
+    ( managed:decimal
+      requested:decimal
+    )
+    @doc " Allows TRANSFER-XCHAIN AMOUNT to be less than or \
+         \ equal managed quantity as a one-shot, returning 0.0."
+  )
+
+  (defcap TRANSFER_XCHAIN_RECD:bool
+    ( sender:string
+      receiver:string
+      amount:decimal
+      source-chain:string
+    )
+    @doc "Event emitted on receipt of cross-chain transfer."
+    @event
+  )
+)

--- a/pact-tests/pact-tests/marmalade/pact/root/gas-payer-v1.pact
+++ b/pact-tests/pact-tests/marmalade/pact/root/gas-payer-v1.pact
@@ -1,0 +1,32 @@
+(interface gas-payer-v1
+
+  (defcap GAS_PAYER:bool
+    ( user:string
+      limit:integer
+      price:decimal
+    )
+    @doc
+    " Provide a capability indicating that declaring module supports \
+    \ gas payment for USER for gas LIMIT and PRICE. Functionality \
+    \ should require capability (coin.FUND_TX), and should validate \
+    \ the spend of (limit * price), possibly updating some database \
+    \ entry. \
+    \ Should compose capability required for 'create-gas-payer-guard'."
+    @model
+    [ (property (user != ""))
+      (property (limit > 0))
+      (property (price > 0.0))
+    ]
+  )
+
+  (defun create-gas-payer-guard:guard ()
+    @doc
+    " Provide a guard suitable for controlling a coin account that can \
+    \ pay gas via GAS_PAYER mechanics. Generally this is accomplished \
+    \ by having GAS_PAYER compose an unparameterized, unmanaged capability \
+    \ that is required in this guard. Thus, if coin contract is able to \
+    \ successfully acquire GAS_PAYER, the composed 'anonymous' cap required \
+    \ here will be in scope, and gas buy will succeed."
+  )
+
+)

--- a/pact-tests/pact-tests/marmalade/pact/root/ns.pact
+++ b/pact-tests/pact-tests/marmalade/pact/root/ns.pact
@@ -1,0 +1,91 @@
+(define-keyset 'ns-admin-keyset (read-keyset 'ns-admin-keyset))
+(define-keyset 'ns-operate-keyset (read-keyset 'ns-genesis-keyset))
+
+(module ns GOVERNANCE
+  "Administers definition of new namespaces in Chainweb."
+
+  (defschema reg-entry
+    admin-guard:guard
+    active:bool)
+
+  (deftable registry:{reg-entry})
+
+  (defcap GOVERNANCE ()
+    (enforce-keyset 'ns-admin-keyset))
+
+  (defcap OPERATE ()
+    (enforce-keyset 'ns-operate-keyset))
+
+  (defconst GUARD_SUCCESS (create-user-guard (success)))
+  (defconst GUARD_FAILURE (create-user-guard (failure)))
+
+  (defun success ()
+    true)
+  (defun failure ()
+    (enforce false "Disabled"))
+
+  (defun validate-name (name)
+    (enforce (!= "" name) "Empty name not allowed")
+    (enforce (< (length name) 64) "Name must be less than 64 characters long")
+    (enforce (is-charset CHARSET_LATIN1 name)
+             "Name must be in latin1 charset"))
+
+  (defun validate:bool
+      ( ns-name:string
+        ns-admin:guard
+        )
+    " Manages namespace install for Chainweb. Requires active row in registry \
+    \ for NS-NAME with guard matching NS-ADMIN."
+
+    (validate-name ns-name)
+
+    (with-default-read registry ns-name
+      { 'admin-guard : ns-admin
+      , 'active : false }
+      { 'admin-guard := ag
+      , 'active := is-active }
+
+        (enforce is-active "Inactive or unregistered namespace")
+        (enforce (= ns-admin ag) "Admin guard must match guard in registry")
+
+        true))
+
+  (defun write-registry:string
+      ( ns-name:string
+        guard:guard
+        active:bool
+        )
+    " Write entry with GUARD and ACTIVE into registry for NAME. \
+    \ Guarded by operate keyset. "
+
+    (with-capability (OPERATE)
+
+      (validate-name ns-name)
+
+      (write registry ns-name
+        { 'admin-guard: guard
+        , 'active: active })
+
+      "Register entry written"))
+
+  (defun query:object{reg-entry}
+      ( ns-name:string )
+    (read registry ns-name))
+
+  )
+
+(create-table registry)
+
+(write-registry "kadena"
+  (keyset-ref-guard 'ns-operate-keyset) true)
+(write-registry "user" GUARD_FAILURE true)
+(write-registry "free" GUARD_FAILURE true)
+
+(define-namespace "kadena"
+  (keyset-ref-guard 'ns-operate-keyset)
+  (keyset-ref-guard 'ns-operate-keyset))
+
+(define-namespace "user" GUARD_SUCCESS GUARD_FAILURE)
+(define-namespace "free" GUARD_SUCCESS GUARD_FAILURE)
+;;rotate to real operate keyset
+(define-keyset 'ns-operate-keyset (read-keyset 'ns-operate-keyset))

--- a/pact-tests/pact-tests/marmalade/pact/sale-contracts/conventional-auction/conventional-auction.pact
+++ b/pact-tests/pact-tests/marmalade/pact/sale-contracts/conventional-auction/conventional-auction.pact
@@ -1,0 +1,280 @@
+(namespace (read-msg 'ns))
+
+(module conventional-auction GOVERNANCE
+  @doc "Conventional auction contract"
+
+  (defconst ADMIN-KS:string "marmalade-sale.marmalade-contract-admin")
+
+  (defcap GOVERNANCE ()
+    (enforce-guard ADMIN-KS))
+
+  (use marmalade-v2.policy-manager)
+  (use marmalade-v2.policy-manager [BUYER-FUNGIBLE-ACCOUNT-MSG-KEY MARKETPLACE-FEE-KEY marketplace-fee-spec])
+  (use marmalade-v2.util-v1)
+  (implements marmalade-v2.sale-v2)
+
+  (defschema auctions-schema
+    token-id:string
+    start-date:integer
+    end-date:integer
+    highest-bid:decimal
+    highest-bid-id:string
+    reserve-price:decimal
+  )
+
+  (defschema bids-schema
+    bidder:string
+    bidder-guard:guard
+    bid:decimal
+  )
+
+  (deftable auctions:{auctions-schema})
+  (deftable bids:{bids-schema})
+  (deftable mk-fees:{marketplace-fee-spec})
+
+  (defcap AUCTION_CREATED:bool
+    ( sale-id:string
+      token-id:string
+      escrow:string
+    )
+    @event
+    true
+  )
+
+  (defcap MANAGE_AUCTION:bool (sale-id:string token-id:string)
+    (let* (
+      (quote-info:object{quote-schema} (get-quote-info sale-id))
+      (seller:string (at 'seller quote-info)))
+      (enforce-guard (marmalade-v2.ledger.account-guard token-id seller))
+    )
+  )
+
+  (defcap BID_PLACED:bool
+    ( bid-id:string
+      bidder:string
+      bidder-guard:guard
+      bid:decimal
+      token-id:string
+    )
+    @event
+    true
+  )
+
+  (defcap PLACE_BID:bool (bidder-guard:guard)
+    (enforce-guard bidder-guard)
+  )
+
+  (defcap REFUND_CAP:bool (sale-id:string) true)
+
+  (defun escrow-account:string (sale-id:string)
+    (create-principal (escrow-guard sale-id))
+  )
+
+  (defun escrow-guard(sale-id:string)
+    (util.guards1.guard-any [
+      (create-capability-guard (REFUND_CAP sale-id))
+      (create-user-guard (enforce-fungible-transfer sale-id))
+    ])
+  )
+
+  (defun enforce-fungible-transfer:bool (sale-id:string)
+    (require-capability (FUNGIBLE-TRANSFER-CALL sale-id) )
+  )
+
+  (defun enforce-quote-update:bool (sale-id:string price:decimal)
+    (require-capability (SALE-GUARD-CALL sale-id price))
+    (with-read auctions sale-id
+      { 'token-id:= token-id,
+        'start-date:= start-date,
+        'end-date:= end-date,
+        'highest-bid:= highest-bid,
+        'highest-bid-id:= highest-bid-id
+      }
+      (enforce (> (curr-time) end-date) "Auction is still ongoing")
+      (enforce (> highest-bid 0.0) "No bids have been placed")
+      (enforce (= price highest-bid) "Price does not match highest bid")
+      (enforce (= (read-msg BUYER-FUNGIBLE-ACCOUNT-MSG-KEY) (escrow-account sale-id)) "Buyer fungible account must match escrow account")
+      (with-read bids highest-bid-id
+        { 'bidder:= bidder,
+          'bidder-guard:= bidder-guard,
+          'bid:= bid
+        }
+        (enforce (= (read-msg "buyer") bidder) "Buyer does not match highest bidder")
+        (enforce (= (read-msg "buyer-guard" ) bidder-guard) "Buyer-guard does not match highest bidder-guard")
+      )
+      (with-default-read mk-fees highest-bid-id
+        { 'mk-account: "", 'mk-fee-percentage: 0.0 }
+        { 'mk-account:= mk-account,
+          'mk-fee-percentage:= mk-fee-percentage
+        }
+        (if (= mk-fee-percentage 0.0)
+          true
+          (let ((mk-fee-spec:object{marketplace-fee-spec} (try { "mk-account": "", "mk-fee-percentage": 0.0 } (read-msg MARKETPLACE-FEE-KEY))))
+            (enforce (= mk-account (at "mk-account" mk-fee-spec)) "Marketplace fee account does not match stored marketplace fee account")
+            (enforce (= mk-fee-percentage (at "mk-fee-percentage" mk-fee-spec)) "Marketplace fee percentage does not match stored marketplace fee percentage")
+          )
+        )
+      )
+    )
+    true
+  )
+
+  (defun enforce-withdrawal:bool (sale-id:string)
+    (with-read auctions sale-id
+      { 'end-date:= end-date,
+        'highest-bid:= highest-bid
+      }
+      (enforce (> (curr-time) end-date) "Auction is still ongoing or hasn't started yet")
+      (enforce (= highest-bid 0.0) "Bid has been placed, can't withdraw")
+    )
+    true
+  )
+
+  (defun create-bid-id:string (sale-id:string bidder:string)
+    (hash [sale-id bidder (int-to-str 10 (curr-time))]))
+
+  (defun create-auction
+    ( sale-id:string
+      token-id:string
+      start-date:integer
+      end-date:integer
+      reserve-price:decimal
+    )
+    (enforce (> start-date (curr-time)) "Start date must be in the future")
+    (enforce (> end-date start-date) "End date must be after start date")
+    (enforce (> reserve-price 0.0) "Reserve price must be greater than 0")
+    (let (
+      (quote-info:object{quote-schema} (get-quote-info sale-id)))
+
+      (enforce (= (at 'sale-price quote-info) 0.0) "Quote price must be 0")
+      (enforce (= (at 'sale-type quote-info) "marmalade-sale.conventional-auction") "Quote does not support auction")
+      (enforce (= token-id (at 'token-id quote-info)) "Token-id does not match quote token-id")
+    )
+
+    (with-capability (MANAGE_AUCTION sale-id token-id)
+      (insert auctions sale-id {
+        "token-id": token-id
+        ,"start-date": start-date
+        ,"end-date": end-date
+        ,"highest-bid": 0.0
+        ,"highest-bid-id": ""
+        ,"reserve-price": reserve-price
+      })
+      (emit-event (AUCTION_CREATED sale-id token-id (escrow-account sale-id)))
+    )
+  )
+
+  (defun update-auction
+    ( sale-id:string
+      start-date:integer
+      end-date:integer
+      reserve-price:decimal
+    )
+    (enforce (> start-date (curr-time)) "Start date must be in the future")
+    (enforce (> end-date start-date) "End date must be after start date")
+    (enforce (> reserve-price 0.0) "Reserve price must be greater than 0")
+
+    (with-read auctions sale-id
+      { 'token-id:= token-id,
+        'start-date:= curr-start-date
+      }
+      (enforce (> curr-start-date (curr-time)) "Can't update auction after it has started")
+
+      (with-capability (MANAGE_AUCTION sale-id token-id)
+        (update auctions sale-id {
+          "start-date": start-date
+          ,"end-date": end-date
+          ,"reserve-price": reserve-price
+        })
+      ))
+  )
+
+  (defun retrieve-auction (sale-id:string)
+    (read auctions sale-id)
+  )
+
+  (defun retrieve-bid (bid-id:string)
+    (read bids bid-id)
+  )
+
+  (defun place-bid:bool
+    ( sale-id:string
+      bidder:string
+      bidder-guard:guard
+      bid:decimal)
+    @model [
+      (property (is-principal bidder))
+    ]
+    (with-read auctions sale-id
+      { 'token-id:= token-id,
+        'start-date:= start-date,
+        'end-date:= end-date,
+        'highest-bid:= prev-highest-bid,
+        'highest-bid-id:= prev-highest-bid-id,
+        'reserve-price:= reserve-price
+      }
+      (enforce (> (curr-time) start-date) "Auction has not started yet")
+      (enforce (< (curr-time) end-date) "Auction has ended")
+      (enforce (> bid prev-highest-bid) "Bid is not higher than previous highest bid")
+      (enforce (> bid reserve-price) "Bid is not higher than reserve price")
+      (enforce (validate-principal bidder-guard bidder) "Incorrect account guard, only principal accounts allowed")
+      (let* (
+          (bid-id:string (create-bid-id sale-id bidder))
+          (quote-info:object{quote-schema} (get-quote-info sale-id))
+          (fungible:module{fungible-v2} (at 'fungible quote-info))
+          (mk-fee-spec:object{marketplace-fee-spec} (try { "mk-account": "", "mk-fee-percentage": 0.0 } (read-msg MARKETPLACE-FEE-KEY)))
+          (mk-fee-percentage:decimal (at "mk-fee-percentage" mk-fee-spec))
+          (mk-fee:decimal (floor (* mk-fee-percentage bid) (fungible::precision)))
+        )
+        (enforce (and (>= mk-fee-percentage 0.0) (<= mk-fee-percentage 1.0)) "Invalid market-fee percentage")
+        (with-capability (PLACE_BID bidder-guard)
+          ; Return amount to previous bidder if there was one
+          (if (> prev-highest-bid 0.0)
+            (with-read bids prev-highest-bid-id
+              { 'bidder:= previous-bidder,
+                'bidder-guard:= previous-bidder-guard
+              }
+              (with-capability (REFUND_CAP sale-id)
+                (install-capability (fungible::TRANSFER (escrow-account sale-id) previous-bidder (fungible::get-balance (escrow-account sale-id))))
+                (fungible::transfer (escrow-account sale-id) previous-bidder (fungible::get-balance (escrow-account sale-id)))
+              )
+            )
+            true
+          )
+
+          ; Transfer amount (including fee if applicable) from bidder to escrow-account
+          (fungible::transfer-create bidder (escrow-account sale-id) (escrow-guard sale-id) (+ bid mk-fee))
+
+          ; Write new bid and store highest bid in auction
+          (write bids bid-id {
+            "bidder": bidder
+            ,"bidder-guard": bidder-guard
+            ,"bid": bid
+          })
+
+          ; Store marketplace fee configuration
+          (if (= mk-fee-percentage 0.0)
+            true
+            (let (
+             (mk-account:string (at 'account (fungible::details (at 'mk-account mk-fee-spec)))))
+             (enforce (!= "" mk-account) "Marketplace fee account does not exist")
+              (write mk-fees bid-id mk-fee-spec)
+            )
+          )
+          (update auctions sale-id { 'highest-bid: bid, 'highest-bid-id: bid-id })
+          (emit-event (BID_PLACED bid-id bidder bidder-guard bid token-id))
+        ))
+      true
+    )
+  )
+)
+
+(if (read-msg "upgrade")
+  ["upgrade complete"]
+  [
+    (create-table mk-fees)
+    (create-table auctions)
+    (create-table bids)
+  ]
+)
+(enforce-guard ADMIN-KS)

--- a/pact-tests/pact-tests/marmalade/pact/sale-contracts/conventional-auction/conventional-auction.repl
+++ b/pact-tests/pact-tests/marmalade/pact/sale-contracts/conventional-auction/conventional-auction.repl
@@ -1,0 +1,678 @@
+(load "../../marmalade.repl")
+(begin-tx "Load modules")
+  (env-data
+    { 'ns: "marmalade-sale"
+    , 'upgrade: false })
+  (env-sigs [
+    { 'key: 'marmalade-user
+    ,'caps: []
+    }, {
+      'key: 'marmalade-contract-admin
+    ,'caps: []
+    }])
+  (load "conventional-auction.pact")
+  (marmalade-v2.policy-manager.add-sale-whitelist marmalade-sale.conventional-auction)
+(commit-tx)
+
+(typecheck "marmalade-sale.conventional-auction")
+
+(begin-tx "Create and mint a token")
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+  (env-hash (hash "create-tokens"))
+  (env-chain-data {"chain-id": "0"})
+  (env-data {
+    "token1-id": (create-token-id { 'uri: "conventional-auction-uri-1", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} ALWAYS-TRUE)
+   ,"creator": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+   ,"creator-guard":  {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+   ,"buyer": "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+   ,"buyer-guard":  {"keys": ["6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"], "pred": "keys-all"}
+   ,"next-buyer": "k:ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"
+   ,"next-buyer-guard":  {"keys": ["ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"], "pred": "keys-all"}
+   ,"royalty_spec": {
+      "fungible": coin
+     ,"creator": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+     ,"creator-guard":  {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+     ,"royalty-rate": 0.1
+    }
+  })
+
+  (test-capability (coin.COINBASE))
+  (coin.coinbase (read-string 'creator) (read-keyset 'creator-guard) 250.0)
+  (coin.coinbase (read-string 'buyer) (read-keyset 'buyer-guard) 250.0)
+  (coin.coinbase (read-string 'next-buyer) (read-keyset 'next-buyer-guard) 250.0)
+
+  (expect "Create the token"
+    true
+    (create-token (read-string "token1-id") 0 "conventional-auction-uri-1" (create-policies DEFAULT_ROYALTY) ALWAYS-TRUE))
+
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+    ,'caps: [
+      (marmalade-v2.ledger.MINT (read-msg 'token1-id) (read-string 'creator) 1.0)
+    ]
+    }])
+
+  (expect "Mint the token"
+    true
+    (mint (read-string "token1-id" ) (read-string 'creator) (read-keyset 'creator-guard ) 1.0))
+(commit-tx)
+
+(begin-tx "Offer token for sale with the conventional auction sale type and a non-finalized price")
+  (env-hash (hash "offer-token-1"))
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+
+  (env-data {
+    "token1-id": (create-token-id { 'uri: "conventional-auction-uri-1", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} ALWAYS-TRUE)
+    ,"creator": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+    ,"quote":{
+      "fungible": coin
+      ,"sale-price": 0.0
+      ,"seller-fungible-account": {
+          "account": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+        ,"guard": {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+      }
+      ,"sale-type": "marmalade-sale.conventional-auction"
+     }
+    })
+
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+     ,'caps: [
+      (marmalade-v2.ledger.OFFER (read-msg 'token1-id) (read-string 'creator) 1.0 0)]
+     }])
+
+  (expect "Offer token up for sale"
+    "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y"
+    (sale (read-msg 'token1-id) (read-string 'creator) 1.0 0))
+(commit-tx)
+
+(begin-tx "Create conventional auction")
+  (env-hash (hash "create-conventional-auction"))
+  (env-chain-data {"block-time": (time "2023-10-01T00:00:00Z")})
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+  (use marmalade-sale.conventional-auction)
+
+  (env-data {
+    "token1-id": (create-token-id { 'uri: "conventional-auction-uri-1", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} ALWAYS-TRUE)
+   ,"sale-id": "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y"
+   ,"creator-guard":  {"keys": ["e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"], "pred": "keys-all"}
+  })
+
+  (expect-failure "Creating a conventional auction in the past fails"
+    "Start date must be in the future"
+    (create-auction (read-string "sale-id") (read-string "token1-id") 1696104800 1696723200 50.0)
+  )
+
+  (expect-failure "Creating a conventional auction with end-date before startdate fails"
+    "End date must be after start date"
+    (create-auction (read-string "sale-id") (read-string "token1-id") 1696204800 1696204700 50.0)
+  )
+
+  (env-sigs [
+   { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+    ,'caps: [(MANAGE_AUCTION (read-msg 'sale-id) (read-msg 'token1-id))]
+    }])
+
+  (expect "Create a conventional auction"
+    true
+    (create-auction (read-string "sale-id") (read-string "token1-id") 1696204800 1696723200 50.0)
+  )
+
+  (expect "Auction info stored under sale-id"
+    { "token-id": (read-string "token1-id")
+      ,"start-date": 1696204800
+      ,"end-date": 1696723200
+      ,"highest-bid": 0.0
+      ,"highest-bid-id": ""
+      ,"reserve-price": 50.0
+    }
+    (retrieve-auction (read-string "sale-id"))
+  )
+
+  (expect "create-auction events"
+    [
+      {"name": "marmalade-sale.conventional-auction.AUCTION_CREATED","params": ["_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y" (read-msg "token1-id") "u:util.guards1.enforce-guard-any:8iBtcNCfjArejHvxJ0rde1DsWxuhHqOzd1w40jsDPV4"]}
+    ]
+    (map (remove "module-hash")  (env-events true))
+  )
+(commit-tx)
+
+(begin-tx "Update auction")
+  (env-hash (hash "update-auction"))
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+  (use marmalade-sale.conventional-auction)
+
+  (env-data {
+    "token1-id": (create-token-id { 'uri: "conventional-auction-uri-1", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} ALWAYS-TRUE)
+   ,"sale-id": "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y"
+  })
+  (env-sigs [])
+  (expect-failure "Update auction without rights fails"
+    "Keyset failure"
+    (update-auction (read-string "sale-id") 1696809600 1697328000 50.0)
+  )
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+     ,'caps: [(MANAGE_AUCTION (read-msg 'sale-id) (read-msg 'token1-id))]
+     }
+  ])
+  (expect "Update auction succeeds"
+    "Write succeeded"
+    (update-auction (read-string "sale-id") 1696809600 1697328000 80.0)
+  )
+(rollback-tx)
+
+(begin-tx "Update auction failure")
+  (env-hash (hash "update-auction-failure"))
+  (env-chain-data {"block-time": (time "2023-10-03T00:00:00Z")})
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+  (use marmalade-sale.conventional-auction)
+
+  (env-data {
+    "token1-id": (create-token-id { 'uri: "conventional-auction-uri-1", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} ALWAYS-TRUE)
+   ,"sale-id": "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y"
+  })
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+     ,'caps: [(MANAGE_AUCTION (read-msg 'sale-id) (read-msg 'token1-id))]
+     }
+  ])
+  (expect-failure "Update auction after it has started fails"
+    "Can't update auction after it has started"
+    (update-auction (read-string "sale-id") 1696809600 1697328000 80.0)
+  )
+(rollback-tx)
+
+(begin-tx "Withdrawal before auction start")
+  (env-hash (hash "bid-withdrawal-before-start"))
+  (env-chain-data {"block-time": (time "2023-10-01T00:00:00Z")})
+  (use marmalade-v2.ledger)
+
+  (env-data {
+    "sale-id": "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y"
+  })
+
+  (expect-failure "withdrawing before the auction has ended fails"
+    "Auction is still ongoing or hasn't started yet"
+    (continue-pact 0 true (read-msg 'sale-id))
+  )
+(rollback-tx)
+
+(begin-tx "Withdrawal after auction end")
+  (env-hash (hash "bid-withdrawal-after-end"))
+  (env-chain-data {"block-time": (time "2023-10-10T00:00:00Z")})
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+
+  (env-data {
+    "token1-id": (create-token-id { 'uri: "conventional-auction-uri-1", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} ALWAYS-TRUE)
+    ,"creator": "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3"
+    ,"sale-id": "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y"
+  })
+
+  (env-sigs [
+    { 'key: 'e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3
+     ,'caps: [(marmalade-v2.ledger.WITHDRAW (read-msg 'token1-id) (read-string 'creator) 1.0 0 (read-msg 'sale-id))]
+     }
+  ])
+
+  (expect "withdrawing after the auction has ended withoud bids succeed"
+    "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y"
+    (continue-pact 0 true (read-msg 'sale-id))
+  )
+(rollback-tx)
+
+(begin-tx "Conventional auction bidding validations")
+  (env-hash (hash "bid-conventional-auction-validation"))
+  (env-chain-data {"block-time": (time "2023-10-01T00:00:00Z")})
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+  (use marmalade-sale.conventional-auction)
+
+   (env-data {
+     "buyer-guard":  {"keys": ["buyer"], "pred": "keys-all"}
+     ,"sale-id": "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y"
+   })
+
+  (expect-failure "Bid on non-existent auction fails"
+    "row not found"
+    (place-bid "bogus-sale-id" "k:buyer" (read-keyset 'buyer-guard) 100.0)
+  )
+  (expect-failure "Bid while auction is still closed"
+    "Auction has not started yet"
+    (place-bid (read-string "sale-id") "k:buyer" (read-keyset 'buyer-guard) 100.0)
+  )
+(rollback-tx)
+
+(begin-tx "Place bids")
+  (env-hash (hash "place-conventional-auction-bid"))
+  (env-chain-data {"block-time": (time "2023-10-03T00:00:00Z")})
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+  (use marmalade-sale.conventional-auction)
+
+  (env-data {
+    "token1-id": (create-token-id { 'uri: "conventional-auction-uri-1", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} ALWAYS-TRUE)
+    ,"sale-id": "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y"
+    ,"buyer": "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+    ,"buyer-guard":  {"keys": ["6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"], "pred": "keys-all"}
+  })
+  (expect-failure "Bid below reserve price"
+    "Bid is not higher than reserve price"
+    (place-bid (read-string "sale-id") (read-string 'buyer) (read-keyset 'buyer-guard) 40.0)
+  )
+
+  (expect-failure "Bid using a named account"
+    "Incorrect account guard, only principal accounts allowed"
+    (place-bid (read-string "sale-id") "buyer" (read-keyset 'buyer-guard) 100.0)
+  )
+
+  (env-sigs [
+    { 'key: "6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+     ,'caps: [
+      (PLACE_BID (read-keyset 'buyer-guard)),
+      (coin.TRANSFER (read-string 'buyer) "u:util.guards1.enforce-guard-any:8iBtcNCfjArejHvxJ0rde1DsWxuhHqOzd1w40jsDPV4" 75.0)
+    ]}])
+  (expect "Place bid succeeds"
+    true
+    (place-bid (read-string "sale-id") (read-string 'buyer) (read-keyset 'buyer-guard) 75.0)
+  )
+  (expect "Buyer balance has been deducted"
+    175.0
+    (coin.get-balance (read-string 'buyer))
+  )
+  (expect "The highest bid has been noted in the auction"
+    { "token-id": (read-string "token1-id")
+      ,"start-date": 1696204800
+      ,"end-date": 1696723200
+      ,"highest-bid": 75.0
+      ,"highest-bid-id": (create-bid-id (read-msg "sale-id") (read-string 'buyer))
+      ,"reserve-price": 50.0
+    }
+    (retrieve-auction (read-string "sale-id"))
+  )
+(commit-tx)
+
+(begin-tx "Overbid the previous bid")
+  (env-hash (hash "overbid-conventional-auction"))
+  (env-chain-data {"block-time": (time "2023-10-04T00:00:00Z")})
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+  (use marmalade-sale.conventional-auction)
+
+  (env-data {
+    "token1-id": (create-token-id { 'uri: "conventional-auction-uri-1", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} ALWAYS-TRUE)
+    ,"sale-id": "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y"
+    ,"buyer": "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+    ,"next-buyer": "k:ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"
+    ,"next-buyer-guard":  {"keys": ["ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"], "pred": "keys-all"}
+  })
+  (expect-failure "Place a bid lower than the previous bid"
+    "Bid is not higher than previous highest bid"
+    (place-bid (read-string "sale-id") (read-string 'next-buyer) (read-keyset 'next-buyer-guard) 70.0)
+  )
+
+  (env-sigs [
+    { 'key: 'ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c
+     ,'caps: [
+      (PLACE_BID (read-keyset 'next-buyer-guard)),
+      (coin.TRANSFER (read-string 'next-buyer) "u:util.guards1.enforce-guard-any:8iBtcNCfjArejHvxJ0rde1DsWxuhHqOzd1w40jsDPV4" 125.0)
+    ]}])
+  (expect "Place bid succeeds"
+    true
+    (place-bid (read-string "sale-id") (read-string 'next-buyer) (read-keyset 'next-buyer-guard) 125.0)
+  )
+
+  (expect "Previous bidder has received his bid amount back"
+    250.0
+    (coin.get-balance (read-string 'buyer))
+  )
+  (expect "Next bidder's balance has been deducted"
+    125.0
+    (coin.get-balance (read-string 'next-buyer))
+  )
+
+  (expect "The highest bid has been noted in the auction"
+    { "token-id": (read-string "token1-id")
+      ,"start-date": 1696204800
+      ,"end-date": 1696723200
+      ,"highest-bid": 125.0
+      ,"highest-bid-id": (create-bid-id (read-msg "sale-id") (read-string 'next-buyer))
+      ,"reserve-price": 50.0
+    }
+    (retrieve-auction (read-string "sale-id"))
+  )
+(commit-tx)
+
+(begin-tx "Claiming the token fails before the sale has ended")
+  (env-hash (hash "conventional-auction-claim-failure"))
+  (env-chain-data {"block-time": (time "2023-10-04T00:00:00Z")})
+  (use marmalade-sale.conventional-auction)
+
+  (env-data {
+    'buyer: "k:ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c",
+    'buyer-guard: {"keys": ["ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"], "pred": "keys-all"},
+    'buyer_fungible_account: (escrow-account "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y")
+    ,'updated_price: 125.0
+    })
+
+  (expect-failure "Try to claim the token before the sale has ended"
+    "Auction is still ongoing"
+    (continue-pact 1 false "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y")
+  )
+(rollback-tx)
+
+(begin-tx "Claiming the token with the wrong price fails")
+  (env-hash (hash "conventional-auction-price-failure"))
+  (env-chain-data {"block-time": (time "2023-10-09T00:00:00Z")})
+  (use marmalade-v2.ledger)
+  (use marmalade-sale.conventional-auction)
+
+  (env-data {
+    'buyer: "k:ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c",
+    'buyer-guard: {"keys": ["ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"], "pred": "keys-all"},
+    'buyer_fungible_account: (escrow-account "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y")
+    ,'updated_price: 25.0
+    })
+
+  (expect-failure "Try to claim the token with the wrong price"
+    "Price does not match highest bid"
+    (continue-pact 1 false "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y")
+  )
+(rollback-tx)
+
+(begin-tx "Withdrawal when bids are placed")
+  (env-hash (hash "bid-withdrawal-bids-placed"))
+  (env-chain-data {"block-time": (time "2023-10-09T00:00:00Z")})
+  (use marmalade-v2.ledger)
+
+  (env-data {
+    "sale-id": "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y"
+  })
+
+  (expect-failure "withdrawing after the auction has ended fails when there are bids placed"
+    "Bid has been placed, can't withdraw"
+    (continue-pact 0 true (read-msg 'sale-id))
+  )
+(rollback-tx)
+
+(begin-tx "Claim the token")
+  (env-hash (hash "conventional-auction-claim-success"))
+  (env-chain-data {"block-time": (time "2023-10-09T00:00:00Z")})
+  (use marmalade-v2.ledger)
+  (use marmalade-sale.conventional-auction)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+
+  (env-data {
+    "token1-id": (create-token-id { 'uri: "conventional-auction-uri-1", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} ALWAYS-TRUE),
+    'buyer: "k:ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c",
+    'buyer-guard: {"keys": ["ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"], "pred": "keys-all"},
+    'buyer_fungible_account: (escrow-account "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y")
+    ,'updated_price: 125.0
+    })
+
+  (env-sigs [
+    { 'key: 'any
+     ,'caps: [(marmalade-v2.ledger.BUY (read-msg "token1-id") "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3" (read-string 'buyer) 1.0 "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y")]
+     }])
+
+  (expect "Claim the token succeeds"
+    "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y"
+    (continue-pact 1 false "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y"))
+
+  (expect "Escrow account balance has been deducted"
+    0.0
+    (coin.get-balance (escrow-account "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y"))
+  )
+
+  (expect "Seller balance has increased"
+    375.0
+    (coin.get-balance "k:e4c6807d79d8bf4695e10e5678ebf72862f59b71f971d39dd3349f4beeacd6e3")
+  )
+(commit-tx)
+
+(begin-tx "Create another conventional auction to bid with marketplace fees")
+  (env-hash (hash "create-conventional-auction-mk-fee"))
+  (env-chain-data {"block-time": (time "2023-10-01T00:00:00Z")})
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+  (use marmalade-sale.conventional-auction)
+
+  (env-data {
+    "token1-id": (create-token-id { 'uri: "conventional-auction-uri-1", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} ALWAYS-TRUE)
+    ,"seller": "k:ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"
+    ,"quote":{
+      "fungible": coin
+      ,"sale-price": 0.0
+      ,"seller-fungible-account": {
+          "account": "k:ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"
+        ,"guard": {"keys": ["ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c"], "pred": "keys-all"}
+      }
+      ,"sale-type": "marmalade-sale.conventional-auction"
+     }
+    ,"marketplace-account": "k:cad725b9789b04dd1ee21e02287a0b65201c1c8b17275860e8e82aa68b12be2d"
+    ,"marketplace-guard": { "keys": ["cad725b9789b04dd1ee21e02287a0b65201c1c8b17275860e8e82aa68b12be2d"], "pred": "keys-all" }
+  })
+
+  (test-capability (coin.COINBASE))
+  (coin.coinbase (read-string 'marketplace-account) (read-keyset 'marketplace-guard) 250.0)
+
+  (env-sigs [
+    { 'key: 'ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c
+     ,'caps: [
+      (marmalade-v2.ledger.OFFER (read-msg 'token1-id) (read-string 'seller) 1.0 0)]
+     }])
+
+  (expect "Offer token up for sale"
+    "L8MyXGnK9uOtzMsi8JPGcdMrOybW862pHZHnnuYHVhs"
+    (sale (read-msg 'token1-id) (read-string 'seller) 1.0 0))
+
+  (env-data {
+    "token1-id": (create-token-id { 'uri: "conventional-auction-uri-1", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} ALWAYS-TRUE)
+   ,"sale-id": "L8MyXGnK9uOtzMsi8JPGcdMrOybW862pHZHnnuYHVhs"
+  })
+
+  (env-sigs [
+   { 'key: 'ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c
+    ,'caps: [(MANAGE_AUCTION (read-msg 'sale-id) (read-msg 'token1-id))]
+    }])
+
+  (expect "Create a conventional auction"
+    true
+    (create-auction (read-string "sale-id") (read-string "token1-id") 1696204800 1696723200 50.0)
+  )
+(commit-tx)
+
+(begin-tx "Place bids with invalid marketplace fee spec fails")
+  (env-hash (hash "place-conventional-auction-bid-mk-fee"))
+  (env-chain-data {"block-time": (time "2023-10-03T00:00:00Z")})
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+  (use marmalade-sale.conventional-auction)
+
+  (env-data {
+    "token1-id": (create-token-id { 'uri: "conventional-auction-uri-1", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} ALWAYS-TRUE)
+    ,"sale-id": "L8MyXGnK9uOtzMsi8JPGcdMrOybW862pHZHnnuYHVhs"
+    ,"buyer": "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+    ,"buyer-guard": {"keys": ["6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"], "pred": "keys-all"}
+    ,"marketplace_fee": {
+      "mk-account": "k:bdd725b9789b04dd1ee21e02287a0b65201c1c8b17275860e8e82aa68b12be2d"
+      ,"mk-fee-percentage": 0.1
+    }
+  })
+
+  (env-sigs [
+    { 'key: "6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+     ,'caps: [
+      (PLACE_BID (read-keyset 'buyer-guard)),
+      (coin.TRANSFER (read-string 'buyer) "u:util.guards1.enforce-guard-any:pL1c4j8Ex_J4FE6nlpKwUhyyNuj2PCE2zvTb_2pmfV0" 110.0)
+    ]}])
+
+  (expect-failure "Place bid fails when marketplace account doesn't exist"
+    "row not found"
+    (place-bid (read-string "sale-id") (read-string 'buyer) (read-keyset 'buyer-guard) 100.0)
+  )
+
+  (env-data {
+    "token1-id": (create-token-id { 'uri: "conventional-auction-uri-1", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} ALWAYS-TRUE)
+    ,"sale-id": "L8MyXGnK9uOtzMsi8JPGcdMrOybW862pHZHnnuYHVhs"
+    ,"buyer": "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+    ,"buyer-guard": {"keys": ["6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"], "pred": "keys-all"}
+    ,"marketplace_fee": {
+      "mk-account": "k:cad725b9789b04dd1ee21e02287a0b65201c1c8b17275860e8e82aa68b12be2d"
+      ,"mk-fee-percentage": -0.99999999
+    }
+  })
+
+  (expect-failure
+    "Invalid market-fee percentage"
+    (place-bid (read-string "sale-id") (read-string 'buyer) (read-keyset 'buyer-guard ) 10000000000.0) )
+
+(rollback-tx)
+
+(begin-tx "Place bids with marketplace fees")
+  (env-hash (hash "place-conventional-auction-bid-mk-fee"))
+  (env-chain-data {"block-time": (time "2023-10-03T00:00:00Z")})
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+  (use marmalade-sale.conventional-auction)
+
+  (env-data {
+    "token1-id": (create-token-id { 'uri: "conventional-auction-uri-1", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} ALWAYS-TRUE)
+    ,"sale-id": "L8MyXGnK9uOtzMsi8JPGcdMrOybW862pHZHnnuYHVhs"
+    ,"buyer": "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+    ,"buyer-guard": {"keys": ["6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"], "pred": "keys-all"}
+    ,"marketplace_fee": {
+      "mk-account": "k:cad725b9789b04dd1ee21e02287a0b65201c1c8b17275860e8e82aa68b12be2d"
+      ,"mk-fee-percentage": 0.1
+    }
+  })
+
+  (env-sigs [
+    { 'key: "6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"
+     ,'caps: [
+      (PLACE_BID (read-keyset 'buyer-guard)),
+      (coin.TRANSFER (read-string 'buyer) "u:util.guards1.enforce-guard-any:pL1c4j8Ex_J4FE6nlpKwUhyyNuj2PCE2zvTb_2pmfV0" 110.0)
+    ]}])
+  (expect "Place bid succeeds"
+    true
+    (place-bid (read-string "sale-id") (read-string 'buyer) (read-keyset 'buyer-guard) 100.0)
+  )
+
+  (expect "Buyer balance has been deducted"
+    140.0
+    (coin.get-balance (read-string 'buyer))
+  )
+
+  (expect "Escrow account contains bid amount including marketplace fees"
+    110.0
+    (coin.get-balance "u:util.guards1.enforce-guard-any:pL1c4j8Ex_J4FE6nlpKwUhyyNuj2PCE2zvTb_2pmfV0"))
+
+  (expect "The highest bid has been noted in the auction"
+    { "token-id": (read-string "token1-id")
+      ,"start-date": 1696204800
+      ,"end-date": 1696723200
+      ,"highest-bid": 100.0
+      ,"highest-bid-id": (create-bid-id (read-msg "sale-id") (read-string 'buyer))
+      ,"reserve-price": 50.0
+    }
+    (retrieve-auction (read-string "sale-id"))
+  )
+(commit-tx)
+
+(begin-tx "Claim the token with marketplace fees")
+  (env-hash (hash "conventional-auction-claim-marketplace-success"))
+  (env-chain-data {"block-time": (time "2023-10-09T00:00:00Z")})
+  (use marmalade-v2.ledger)
+  (use marmalade-sale.conventional-auction)
+
+  (env-data {
+    'buyer: "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3",
+    'buyer-guard: {"keys": ["6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"], "pred": "keys-all"},
+    'buyer_fungible_account: (escrow-account "L8MyXGnK9uOtzMsi8JPGcdMrOybW862pHZHnnuYHVhs"),
+    'updated_price: 100.0,
+    "marketplace_fee": {
+      "mk-account": "k:e14b9a83582b450a98220d10a52f7069901bc13ec4de189b03b2492ce29d86a7"
+      ,"mk-fee-percentage": 0.1
+    }
+  })
+
+  (expect-failure "Claim the token fails when the marketplace_fee account differs"
+    "Marketplace fee account does not match stored marketplace fee account"
+    (continue-pact 1 false "L8MyXGnK9uOtzMsi8JPGcdMrOybW862pHZHnnuYHVhs"))
+
+  (env-data {
+    'buyer: "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3",
+    'buyer-guard: {"keys": ["6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"], "pred": "keys-all"},
+    'buyer_fungible_account: (escrow-account "L8MyXGnK9uOtzMsi8JPGcdMrOybW862pHZHnnuYHVhs"),
+    'updated_price: 100.0,
+    "marketplace_fee": {
+      "mk-account": "k:cad725b9789b04dd1ee21e02287a0b65201c1c8b17275860e8e82aa68b12be2d"
+      ,"mk-fee-percentage": 0.8
+    }
+  })
+
+  (expect-failure "Claim the token fails when the marketplace_fee percentage differs"
+    "Marketplace fee percentage does not match stored marketplace fee percentage"
+    (continue-pact 1 false "L8MyXGnK9uOtzMsi8JPGcdMrOybW862pHZHnnuYHVhs"))
+
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+
+  (env-data {
+    "token1-id": (create-token-id { 'uri: "conventional-auction-uri-1", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} ALWAYS-TRUE),
+    'seller: "k:ae511ecee78c71793b7915bc51f2e2b9a0b274aefa0ece5cb76bfcb8e0e1151c",
+    'buyer: "k:6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3",
+    'buyer-guard: {"keys": ["6778a9153dbfcfb787c9eb1700455a59af62b15008b71f805398d857bddb48f3"], "pred": "keys-all"},
+    'buyer_fungible_account: (escrow-account "L8MyXGnK9uOtzMsi8JPGcdMrOybW862pHZHnnuYHVhs"),
+    'updated_price: 100.0,
+    "marketplace_fee": {
+      "mk-account": "k:cad725b9789b04dd1ee21e02287a0b65201c1c8b17275860e8e82aa68b12be2d"
+      ,"mk-fee-percentage": 0.1
+    }
+  })
+
+  (env-sigs [
+    { 'key: 'any
+     ,'caps: [(marmalade-v2.ledger.BUY (read-msg "token1-id") (read-string 'seller) (read-string 'buyer) 1.0 "L8MyXGnK9uOtzMsi8JPGcdMrOybW862pHZHnnuYHVhs")]
+    }])
+
+  (expect "Claim the token succeeds"
+    "L8MyXGnK9uOtzMsi8JPGcdMrOybW862pHZHnnuYHVhs"
+    (continue-pact 1 false "L8MyXGnK9uOtzMsi8JPGcdMrOybW862pHZHnnuYHVhs"))
+
+  (expect "Escrow account balance has been deducted"
+    0.0
+    (coin.get-balance (escrow-account "L8MyXGnK9uOtzMsi8JPGcdMrOybW862pHZHnnuYHVhs"))
+  )
+
+  (expect "Seller balance has increased with sell amount minus royalties"
+    215.0
+    (coin.get-balance (read-string 'seller))
+  )
+
+  (expect "Marketplace balance has been increased with marketplace fees"
+    260.0
+    (coin.get-balance "k:cad725b9789b04dd1ee21e02287a0b65201c1c8b17275860e8e82aa68b12be2d")
+  )
+(commit-tx)

--- a/pact-tests/pact-tests/marmalade/pact/sale-contracts/dutch-auction/dutch-auction.pact
+++ b/pact-tests/pact-tests/marmalade/pact/sale-contracts/dutch-auction/dutch-auction.pact
@@ -1,0 +1,217 @@
+(namespace (read-msg 'ns))
+
+(module dutch-auction GOVERNANCE
+  @doc "Dutch auction contract"
+
+  (defconst ADMIN-KS:string "marmalade-sale.marmalade-contract-admin")
+
+  (defcap GOVERNANCE ()
+    (enforce-guard ADMIN-KS))
+
+  (use marmalade-v2.policy-manager)
+  (use marmalade-v2.policy-manager [BUYER-FUNGIBLE-ACCOUNT-MSG-KEY])
+  (use marmalade-v2.util-v1)
+  (implements marmalade-v2.sale-v2)
+
+  (defschema auctions-schema
+    token-id:string
+    start-date:integer
+    end-date:integer
+    start-price:decimal
+    reserve-price:decimal
+    sell-price:decimal
+    price-interval-seconds:integer
+    buyer:string
+    buyer-guard:guard
+  )
+
+  (deftable auctions:{auctions-schema})
+
+  (defcap AUCTION_CREATED:bool
+    ( sale-id:string
+      token-id:string
+    )
+    @event
+    true
+  )
+
+  (defcap MANAGE_AUCTION:bool (sale-id:string token-id:string)
+    (let* (
+      (quote-info:object{quote-schema} (get-quote-info sale-id))
+      (seller:string (at 'seller quote-info)))
+      (enforce-guard (marmalade-v2.ledger.account-guard token-id seller))
+    )
+  )
+
+  (defcap PRICE_ACCEPTED:bool
+    ( sale-id:string
+      buyer:string
+      buyer-guard:guard
+      price:decimal
+      token-id:string
+    )
+    @event
+    true
+  )
+
+  (defcap DUMMY:bool () true)
+  (defconst DUMMY_GUARD:guard (create-capability-guard (DUMMY)))
+
+  (defun enforce-quote-update:bool (sale-id:string price:decimal)
+    (require-capability (SALE-GUARD-CALL sale-id price))
+    (with-read auctions sale-id
+      { 'token-id:= token-id,
+        'start-date:= start-date,
+        'end-date:= end-date,
+        'sell-price:= sell-price
+      }
+
+      (enforce (> (curr-time) start-date) "Auction has not started yet")
+      (enforce (< (curr-time) end-date) "Auction has already ended")
+      (enforce (= sell-price 0.0) "Price has already been accepted")
+      (let (
+        (current-price:decimal (get-current-price sale-id))
+        (buyer:string (read-msg "buyer"))
+        (buyer-guard:guard (read-msg "buyer-guard")))
+
+        (enforce (= price current-price) "Price does not match current price")
+
+        ; Update auction with sell-price and buyer information
+        (update auctions sale-id {
+          "sell-price": current-price
+          ,"buyer": buyer
+          ,"buyer-guard": buyer-guard
+        })
+
+        (emit-event (PRICE_ACCEPTED sale-id buyer buyer-guard current-price token-id))
+      )
+    )
+    true
+  )
+
+  (defun enforce-withdrawal:bool (sale-id:string)
+    (with-read auctions sale-id
+      { 'end-date:= end-date,
+        'sell-price:= sell-price
+      }
+      (enforce (> (curr-time) end-date) "Auction is still ongoing or hasn't started yet")
+      (enforce (= sell-price 0.0) "Price has been accepted, can't withdraw")
+    )
+    true
+  )
+
+  (defun validate-auction:bool (
+    start-date:integer
+    end-date:integer
+    reserve-price:decimal
+    start-price:decimal
+    price-interval-seconds:integer)
+    (enforce (> start-date (curr-time)) "Start date must be in the future")
+    (enforce (> end-date start-date) "End date must be after start date")
+    (enforce (> reserve-price 0.0) "Reserve price must be greater than 0")
+    (enforce (> start-price reserve-price) "Start price must be greater than reserve price")
+    (enforce (> price-interval-seconds 0) "Price interval must be greater than 0")
+    (enforce (> (- end-date start-date) price-interval-seconds) "Auction duration must be greather than price interval")
+  )
+
+  (defun create-auction
+    ( sale-id:string
+      token-id:string
+      start-date:integer
+      end-date:integer
+      reserve-price:decimal
+      start-price:decimal
+      price-interval-seconds:integer
+    )
+    (validate-auction start-date end-date reserve-price start-price price-interval-seconds)
+    (let (
+      (quote-info:object{quote-schema} (get-quote-info sale-id)))
+
+      (enforce (= (at 'sale-price quote-info) 0.0) "Quote price must be 0")
+      (enforce (= (at 'sale-type quote-info) "marmalade-sale.dutch-auction") "Quote does not support auction")
+      (enforce (= token-id (at 'token-id quote-info)) "Token-id does not match quote token-id")
+    )
+
+    (with-capability (MANAGE_AUCTION sale-id token-id)
+      (insert auctions sale-id {
+        "token-id": token-id
+        ,"start-date": start-date
+        ,"end-date": end-date
+        ,"start-price": start-price
+        ,"reserve-price": reserve-price
+        ,"price-interval-seconds": price-interval-seconds
+        ,"sell-price": 0.0
+        ,"buyer": ""
+        ,"buyer-guard": DUMMY_GUARD
+      })
+      (emit-event (AUCTION_CREATED sale-id token-id))
+    )
+  )
+
+  (defun update-auction
+    ( sale-id:string
+      start-date:integer
+      end-date:integer
+      start-price:decimal
+      reserve-price:decimal
+      price-interval-seconds:integer
+    )
+    (validate-auction start-date end-date reserve-price start-price price-interval-seconds)
+
+    (with-read auctions sale-id
+      { 'token-id:= token-id,
+        'start-date:= curr-start-date
+      }
+      (enforce (> curr-start-date (curr-time)) "Can't update auction after it has started")
+
+      (with-capability (MANAGE_AUCTION sale-id token-id)
+        (update auctions sale-id {
+          "start-date": start-date
+          ,"end-date": end-date
+          ,"start-price": start-price
+          ,"reserve-price": reserve-price
+          ,"price-interval-seconds": price-interval-seconds
+        })
+      )
+    )
+  )
+
+  (defun retrieve-auction (sale-id:string)
+    (read auctions sale-id)
+  )
+
+  (defun get-current-price:decimal (sale-id:string)
+    @doc "Returns the current price of the auction"
+    (with-read auctions sale-id
+      {
+        'start-date:= start-date,
+        'end-date:= end-date,
+        'reserve-price:= reserve-price,
+        'start-price:= start-price,
+        'price-interval-seconds:= price-interval-seconds
+      }
+
+      (let* (
+        (auction-duration-seconds:decimal (* (- end-date start-date) 1.0))
+        (sale-period-full-intervals:integer  (- (ceiling (/ auction-duration-seconds (* price-interval-seconds 1.0))) 1))
+        (remaining-intervals:integer (- (ceiling (/ (- end-date (curr-time)) (* price-interval-seconds 1.0))) 1))
+        (price-range:decimal (- start-price reserve-price))
+        (price-drop-per-interval:decimal (/ price-range sale-period-full-intervals))
+        )
+        (if (or (< (curr-time) start-date) (>= (curr-time) end-date))
+          0.0
+          (round (+ reserve-price (* remaining-intervals price-drop-per-interval)) 2)
+        )
+      )
+    )
+  )
+)
+
+(if (read-msg "upgrade")
+  ["upgrade complete"]
+  [
+    (create-table auctions)
+  ]
+)
+
+(enforce-guard ADMIN-KS)

--- a/pact-tests/pact-tests/marmalade/pact/sale-contracts/dutch-auction/dutch-auction.repl
+++ b/pact-tests/pact-tests/marmalade/pact/sale-contracts/dutch-auction/dutch-auction.repl
@@ -1,0 +1,582 @@
+(load "../../marmalade.repl")
+(begin-tx "Load modules")
+  (env-data
+    { 'ns: "marmalade-sale"
+    , 'upgrade: false })
+  (env-sigs [
+    { 'key: 'marmalade-user
+    ,'caps: []
+    }, {
+      'key: 'marmalade-contract-admin
+    ,'caps: []
+    }])
+  (load "dutch-auction.pact")
+  (marmalade-v2.policy-manager.add-sale-whitelist marmalade-sale.dutch-auction)
+(commit-tx)
+
+(typecheck "marmalade-sale.dutch-auction")
+
+(begin-tx "Create and mint a token")
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.policy-manager)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+  (env-hash (hash "create-tokens"))
+  (env-chain-data {"chain-id": "0"})
+  (env-data {
+    "token1-id": (create-token-id { 'uri: "dutch-auction-uri-1", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} ALWAYS-TRUE)
+   ,"creator-guard":  {"keys": ["05df86b4fda15ac84cdd2ab4facb433db6098d10b6b09803eedbaea78d10723e"], "pred": "keys-all"}
+   ,"buyer-guard":  {"keys": ["15071b931200c63c8d84870c387534216533810919b382924514003b2c90c0d7"], "pred": "keys-all"}
+   ,"royalty_spec": {
+      "fungible": coin
+     ,"creator": "k:05df86b4fda15ac84cdd2ab4facb433db6098d10b6b09803eedbaea78d10723e"
+     ,"creator-guard":  {"keys": ["05df86b4fda15ac84cdd2ab4facb433db6098d10b6b09803eedbaea78d10723e"], "pred": "keys-all"}
+     ,"royalty-rate": 0.1
+    }
+  })
+
+  (test-capability (coin.COINBASE))
+  (coin.coinbase "k:05df86b4fda15ac84cdd2ab4facb433db6098d10b6b09803eedbaea78d10723e" (read-keyset 'creator-guard) 250.0)
+  (coin.coinbase "k:15071b931200c63c8d84870c387534216533810919b382924514003b2c90c0d7" (read-keyset 'buyer-guard) 250.0)
+  ;  (coin.coinbase "k:next-buyer" (read-keyset 'next-buyer-guard) 250.0)
+
+  (expect "Create the token"
+    true
+    (create-token (read-string "token1-id") 0 "dutch-auction-uri-1" (create-policies DEFAULT_ROYALTY) ALWAYS-TRUE))
+
+  (env-sigs [
+    { 'key: "05df86b4fda15ac84cdd2ab4facb433db6098d10b6b09803eedbaea78d10723e"
+    ,'caps: [
+      (marmalade-v2.ledger.MINT (read-msg 'token1-id) "k:05df86b4fda15ac84cdd2ab4facb433db6098d10b6b09803eedbaea78d10723e" 1.0)
+    ]
+    }])
+
+  (expect "Mint the token"
+    true
+    (mint (read-string "token1-id" ) "k:05df86b4fda15ac84cdd2ab4facb433db6098d10b6b09803eedbaea78d10723e" (read-keyset 'creator-guard ) 1.0))
+(commit-tx)
+
+ (begin-tx "Offer token for sale with the dutch auction sale type and a non-finalized price")
+   (env-hash (hash "offer-token-1"))
+   (use marmalade-v2.ledger)
+   (use marmalade-v2.policy-manager)
+   (use marmalade-v2.util-v1)
+   (use mini-guard-utils)
+
+   (env-data {
+     "token1-id": (create-token-id { 'uri: "dutch-auction-uri-1", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} ALWAYS-TRUE)
+     ,"quote":{
+       "fungible": coin
+       ,"sale-price": 0.0
+       ,"seller-fungible-account": {
+           "account": "k:05df86b4fda15ac84cdd2ab4facb433db6098d10b6b09803eedbaea78d10723e"
+         ,"guard": {"keys": ["05df86b4fda15ac84cdd2ab4facb433db6098d10b6b09803eedbaea78d10723e"], "pred": "keys-all"}
+       }
+       ,"sale-type": "marmalade-sale.dutch-auction"
+      }
+     })
+
+   (env-sigs [
+     { 'key: "05df86b4fda15ac84cdd2ab4facb433db6098d10b6b09803eedbaea78d10723e"
+      ,'caps: [
+       (marmalade-v2.ledger.OFFER (read-msg 'token1-id) "k:05df86b4fda15ac84cdd2ab4facb433db6098d10b6b09803eedbaea78d10723e" 1.0 0)]
+      }])
+
+   (expect "Offer token up for sale"
+     "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y"
+     (sale (read-msg 'token1-id) "k:05df86b4fda15ac84cdd2ab4facb433db6098d10b6b09803eedbaea78d10723e" 1.0 0))
+ (commit-tx)
+
+
+ (begin-tx "Create dutch auction")
+   (env-hash (hash "create-dutch-auction"))
+   (env-chain-data {"block-time": (time "2023-10-01T00:00:00Z")})
+   (use marmalade-v2.ledger)
+   (use marmalade-v2.util-v1)
+   (use mini-guard-utils)
+   (use marmalade-sale.dutch-auction)
+
+   (env-data {
+     "token1-id": (create-token-id { 'uri: "dutch-auction-uri-1", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} ALWAYS-TRUE)
+    ,"sale-id": "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y"
+    ,"creator-guard":  {"keys": ["05df86b4fda15ac84cdd2ab4facb433db6098d10b6b09803eedbaea78d10723e"], "pred": "keys-all"}
+   })
+
+   (expect-failure "Creating a ducth auction in the past fails"
+     "Start date must be in the future"
+     (create-auction (read-string "sale-id") (read-string "token1-id") 1696104800 1696723200 50.0 100.0 3600)
+   )
+
+   (expect-failure "Creating a dutch auction with end-date before startdate fails"
+     "End date must be after start date"
+     (create-auction (read-string "sale-id") (read-string "token1-id") 1696204800 1696204700 50.0 100.0 3600)
+   )
+
+   (expect-failure "Creating a dutch auction with reserve-price below start-price fails"
+     "Start price must be greater than reserve price"
+     (create-auction (read-string "sale-id") (read-string "token1-id") 1696204800 1696723200 100.0 50.0 3600)
+   )
+
+   (expect-failure "Auction must last atleast one interval"
+     "Auction duration must be greather than price interval"
+     (create-auction (read-string "sale-id") (read-string "token1-id") 1696204800 1696205000 50.0 100.0 1000)
+   )
+
+   (env-sigs [
+    { 'key: "05df86b4fda15ac84cdd2ab4facb433db6098d10b6b09803eedbaea78d10723e"
+     ,'caps: [(MANAGE_AUCTION (read-msg 'sale-id) (read-msg 'token1-id))]
+     }])
+
+   (expect "Create a dutch auction"
+     true
+     (create-auction (read-string "sale-id") (read-string "token1-id") 1696204800 1696723200 50.0 100.0 3600)
+   )
+
+   (expect "Auction info stored with identifier 1"
+     { "token-id": (read-string "token1-id")
+       ,"start-date": 1696204800
+       ,"end-date": 1696723200
+       ,"start-price": 100.0
+       ,"reserve-price": 50.0
+       ,"price-interval-seconds": 3600
+       ,"sell-price": 0.0
+       ,"buyer": ""
+       ,"buyer-guard": marmalade-sale.dutch-auction.DUMMY_GUARD
+     }
+     (retrieve-auction (read-string "sale-id"))
+   )
+
+   (expect "create-auction events"
+     [
+       {"name": "marmalade-sale.dutch-auction.AUCTION_CREATED","params": ["_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y" (read-msg "token1-id")]}
+     ]
+     (map (remove "module-hash")  (env-events true))
+   )
+ (commit-tx)
+
+ (begin-tx "Update auction")
+   (env-hash (hash "update-auction"))
+   (use marmalade-v2.ledger)
+   (use marmalade-v2.util-v1)
+   (use mini-guard-utils)
+   (use marmalade-sale.dutch-auction)
+
+   (env-data {
+     "token1-id": (create-token-id { 'uri: "dutch-auction-uri-1", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} ALWAYS-TRUE)
+    ,"sale-id": "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y"
+   })
+   (env-sigs [])
+   (expect-failure "Update auction without rights fails"
+     "Keyset failure"
+     (update-auction (read-string "sale-id") 1696809600 1697328000 100.0 50.0 3600)
+   )
+   (env-sigs [
+     { 'key: "05df86b4fda15ac84cdd2ab4facb433db6098d10b6b09803eedbaea78d10723e"
+      ,'caps: [(MANAGE_AUCTION (read-msg 'sale-id) (read-msg 'token1-id))]
+      }
+   ])
+   (expect "Update auction succeeds"
+     "Write succeeded"
+     (update-auction (read-string "sale-id") 1696809600 1697328000 110.0 50.0 3600)
+   )
+ (rollback-tx)
+
+ (begin-tx "Update auction failure")
+   (env-hash (hash "update-auction-failure"))
+   (env-chain-data {"block-time": (time "2023-10-03T00:00:00Z")})
+   (use marmalade-v2.ledger)
+   (use marmalade-v2.util-v1)
+   (use mini-guard-utils)
+   (use marmalade-sale.dutch-auction)
+
+   (env-data {
+     "token1-id": (create-token-id { 'uri: "dutch-auction-uri-1", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} ALWAYS-TRUE)
+    ,"sale-id": "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y"
+   })
+   (env-sigs [
+     { 'key: "05df86b4fda15ac84cdd2ab4facb433db6098d10b6b09803eedbaea78d10723e"
+      ,'caps: [(MANAGE_AUCTION (read-msg 'sale-id) (read-msg 'token1-id))]
+      }
+   ])
+   (expect-failure "Update auction after it has started fails"
+     "Can't update auction after it has started"
+     (update-auction (read-string "sale-id") 1696809600 1697328000 110.0 50.0 3600)
+   )
+ (rollback-tx)
+
+ (begin-tx "Withdrawal before auction start")
+   (env-hash (hash "bid-withdrawal-before-start"))
+   (env-chain-data {"block-time": (time "2023-10-01T00:00:00Z")})
+   (use marmalade-v2.ledger)
+
+   (env-data {
+     "sale-id": "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y"
+   })
+
+   (expect-failure "withdrawing before the auction has ended fails"
+     "Auction is still ongoing or hasn't started yet"
+     (continue-pact 0 true (read-msg 'sale-id))
+   )
+ (rollback-tx)
+
+ (begin-tx "Withdrawal after auction end")
+   (env-hash (hash "bid-withdrawal-after-end"))
+   (env-chain-data {"block-time": (time "2023-10-10T00:00:00Z")})
+   (use marmalade-v2.ledger)
+   (use marmalade-v2.util-v1)
+   (use mini-guard-utils)
+
+   (env-data {
+     "token1-id": (create-token-id { 'uri: "dutch-auction-uri-1", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} ALWAYS-TRUE)
+     ,"sale-id": "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y"
+   })
+
+   (env-sigs [
+     { 'key: "05df86b4fda15ac84cdd2ab4facb433db6098d10b6b09803eedbaea78d10723e"
+      ,'caps: [(marmalade-v2.ledger.WITHDRAW (read-msg 'token1-id) "k:05df86b4fda15ac84cdd2ab4facb433db6098d10b6b09803eedbaea78d10723e" 1.0 0 (read-msg 'sale-id))]
+      }
+   ])
+
+   (expect "withdrawing after the auction has ended withoud a price accepted succeeds"
+     "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y"
+     (continue-pact 0 true (read-msg 'sale-id))
+   )
+ (rollback-tx)
+
+ (begin-tx "Auction price validations")
+  (env-hash (hash "auction-price-validations"))
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.util-v1)
+  (use mini-guard-utils)
+  (use marmalade-sale.dutch-auction)
+
+  (env-data {
+    "token1-id": (create-token-id { 'uri: "dutch-auction-uri-1", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} ALWAYS-TRUE)
+    ,"sale-id": "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y"
+  })
+
+  (env-chain-data {"block-time": (time "2023-10-01T00:00:00Z")})
+  (expect "Dutch auction current price returns 0 before the auction has started"
+    0.0
+    (get-current-price (read-string 'sale-id))
+  )
+
+  (env-chain-data {"block-time": (time "2023-10-02T00:00:00Z")})
+  (expect "Current price returns opening price at start"
+    100.0
+    (get-current-price (read-string 'sale-id))
+  )
+
+  (env-chain-data {"block-time": (time "2023-10-02T00:59:00Z")})
+  (expect "Current price remains opening price during the first hour"
+    100.0
+    (get-current-price (read-string 'sale-id))
+  )
+
+  (env-chain-data {"block-time": (time "2023-10-02T01:10:00Z")})
+  (expect "Current price drops as time progresses"
+    99.65
+    (get-current-price (read-string 'sale-id))
+  )
+
+  (env-chain-data {"block-time": (time "2023-10-06T00:00:00Z")})
+  (expect "Current price drops as time progresses"
+    66.43
+    (get-current-price (read-string 'sale-id))
+  )
+
+  (env-chain-data {"block-time": (time "2023-10-07T23:00:00Z")})
+  (expect "In the last hour the price is at reserve price"
+    50.00
+    (get-current-price (read-string 'sale-id))
+  )
+
+  (env-chain-data {"block-time": (time "2023-10-07T23:45:00Z")})
+  (expect "Just before closing the price is at reserve price"
+    50.00
+    (get-current-price (read-string 'sale-id))
+  )
+
+  (env-chain-data {"block-time": (time "2023-10-08T00:00:00Z")})
+  (expect "At closing the price is at 0 again"
+    0.0
+    (get-current-price (read-string 'sale-id))
+  )
+(rollback-tx)
+
+(begin-tx "Auction price validations with 30-minute interval")
+ (env-hash (hash "auction-price-validations-30m"))
+ (use marmalade-v2.ledger)
+ (use marmalade-v2.util-v1)
+ (use mini-guard-utils)
+ (use marmalade-sale.dutch-auction)
+
+ (env-data {
+   "token1-id": (create-token-id { 'uri: "dutch-auction-uri-1", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} ALWAYS-TRUE)
+   ,"sale-id": "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y"
+ })
+
+ (env-sigs [
+   { 'key: "05df86b4fda15ac84cdd2ab4facb433db6098d10b6b09803eedbaea78d10723e"
+    ,'caps: [(MANAGE_AUCTION (read-msg 'sale-id) (read-msg 'token1-id))]
+    }
+ ])
+
+ (env-chain-data {"block-time": (time "2023-10-01T00:00:00Z")})
+ (expect "Update auction to 30-minute interval"
+   "Write succeeded"
+   (update-auction (read-string "sale-id") 1696809600 1697328000 100.0 50.0 1800)
+ )
+
+ (env-chain-data {"block-time": (time "2023-10-09T00:00:00Z")})
+ (expect "Current price returns opening price at start"
+   100.0
+   (get-current-price (read-string 'sale-id))
+ )
+
+ (env-chain-data {"block-time": (time "2023-10-09T00:25:01Z")})
+ (expect "Current price remains the same in the first interval"
+   100.0
+   (get-current-price (read-string 'sale-id))
+ )
+
+ (env-chain-data {"block-time": (time "2023-10-09T00:44:01Z")})
+ (expect "Current price drops as time progresses"
+   99.83
+   (get-current-price (read-string 'sale-id))
+ )
+
+ (env-chain-data {"block-time": (time "2023-10-09T00:59:00Z")})
+ (expect "15 minutes later the price remains the same"
+   99.83
+   (get-current-price (read-string 'sale-id))
+ )
+
+ (env-chain-data {"block-time": (time "2023-10-09T01:15:00Z")})
+ (expect "16 minutes later the price drops again"
+   99.65
+   (get-current-price (read-string 'sale-id))
+ )
+
+ (env-chain-data {"block-time": (time "2023-10-09T01:45:00Z")})
+ (expect "30 minutes later the price drops again"
+   99.48
+   (get-current-price (read-string 'sale-id))
+ )
+
+ (env-chain-data {"block-time": (time "2023-10-14T23:35:00Z")})
+ (expect "Just before closing the price is at reserve price"
+   50.00
+   (get-current-price (read-string 'sale-id))
+ )
+
+ (env-chain-data {"block-time": (time "2023-10-15T00:00:00Z")})
+ (expect "At closing the price is at 0 again"
+   0.0
+   (get-current-price (read-string 'sale-id))
+ )
+(rollback-tx)
+
+(begin-tx "Auction price validations with a broken interval")
+ (env-hash (hash "auction-price-validations-broken"))
+ (use marmalade-v2.ledger)
+ (use marmalade-v2.util-v1)
+ (use mini-guard-utils)
+ (use marmalade-sale.dutch-auction)
+
+ (env-data {
+   "token1-id": (create-token-id { 'uri: "dutch-auction-uri-1", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} ALWAYS-TRUE)
+   ,"sale-id": "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y"
+ })
+
+ (env-sigs [
+   { 'key: "05df86b4fda15ac84cdd2ab4facb433db6098d10b6b09803eedbaea78d10723e"
+    ,'caps: [(MANAGE_AUCTION (read-msg 'sale-id) (read-msg 'token1-id))]
+    }
+ ])
+
+ (env-chain-data {"block-time": (time "2023-10-01T00:00:00Z")})
+ (expect "Update auction to 30-minute interval"
+   "Write succeeded"
+   (update-auction (read-string "sale-id") 1696859100 1696874400 100.0 50.0 1800)
+ )
+
+ (env-chain-data {"block-time": (time "2023-10-09T13:45:00Z")})
+ (expect "Current price returns opening price at start"
+   100.0
+   (get-current-price (read-string 'sale-id))
+ )
+
+ (env-chain-data {"block-time": (time "2023-10-09T14:05:00Z")})
+ (expect "First price drop occurs after 15 minutes (broken interval slot)"
+   93.75
+   (get-current-price (read-string 'sale-id))
+ )
+
+ (env-chain-data {"block-time": (time "2023-10-09T14:25:00Z")})
+ (expect "Price remains the same before next full interval"
+   93.75
+   (get-current-price (read-string 'sale-id))
+ )
+
+ (env-chain-data {"block-time": (time "2023-10-09T14:35:00Z")})
+ (expect "Second price drop occurs after next full interval"
+   87.50
+   (get-current-price (read-string 'sale-id))
+ )
+
+ (env-chain-data {"block-time": (time "2023-10-09T17:35:00Z")})
+ (expect "Just before closing the price is at reserve price"
+   50.00
+   (get-current-price (read-string 'sale-id))
+ )
+
+ (env-chain-data {"block-time": (time "2023-10-09T18:00:00Z")})
+ (expect "At closing the price is at 0 again"
+   0.0
+   (get-current-price (read-string 'sale-id))
+ )
+(rollback-tx)
+
+(begin-tx "Auction price validations with a short interval")
+ (env-hash (hash "auction-price-validations-broken"))
+ (use marmalade-v2.ledger)
+ (use marmalade-v2.util-v1)
+ (use mini-guard-utils)
+ (use marmalade-sale.dutch-auction)
+
+ (env-data {
+   "token1-id": (create-token-id { 'uri: "dutch-auction-uri-1", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} ALWAYS-TRUE)
+   ,"sale-id": "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y"
+ })
+
+ (env-sigs [
+   { 'key: "05df86b4fda15ac84cdd2ab4facb433db6098d10b6b09803eedbaea78d10723e"
+    ,'caps: [(MANAGE_AUCTION (read-msg 'sale-id) (read-msg 'token1-id))]
+    }
+ ])
+
+ (env-chain-data {"block-time": (time "2023-10-01T00:00:00Z")})
+ (expect "Update auction to 10-minute interval"
+   "Write succeeded"
+   (update-auction (read-string "sale-id") 1696866000 1696869900 100.0 50.0 600)
+ )
+
+ (env-chain-data {"block-time": (time "2023-10-09T15:40:00Z")})
+ (expect "Current price returns opening price at start"
+   100.0
+   (get-current-price (read-string 'sale-id))
+ )
+
+ (env-chain-data {"block-time": (time "2023-10-09T15:45:00Z")})
+ (expect "First price drop occurs after 5 minutes (broken interval slot)"
+   91.67
+   (get-current-price (read-string 'sale-id))
+ )
+
+ (env-chain-data {"block-time": (time "2023-10-09T15:50:00Z")})
+ (expect "Price remains the same before next full interval"
+   91.67
+   (get-current-price (read-string 'sale-id))
+ )
+
+ (env-chain-data {"block-time": (time "2023-10-09T15:55:00Z")})
+ (expect "Second price drop occurs after next full interval"
+   83.33
+   (get-current-price (read-string 'sale-id))
+ )
+
+ (env-chain-data {"block-time": (time "2023-10-09T16:25:00Z")})
+ (expect "Current price drops as time progresses"
+   58.33
+   (get-current-price (read-string 'sale-id))
+ )
+
+ (env-chain-data {"block-time": (time "2023-10-09T16:40:00Z")})
+ (expect "Just before closing the price is at reserve price"
+   50.00
+   (get-current-price (read-string 'sale-id))
+ )
+
+ (env-chain-data {"block-time": (time "2023-10-09T16:45:00Z")})
+ (expect "At closing the price is at 0 again"
+   0.0
+   (get-current-price (read-string 'sale-id))
+ )
+(rollback-tx)
+
+ (begin-tx "Buying the token with the wrong price fails")
+   (env-hash (hash "dutch-auction-price-failure"))
+   (env-chain-data {"block-time": (time "2023-10-07T00:00:00Z")})
+   (use marmalade-v2.ledger)
+   (use marmalade-sale.dutch-auction)
+
+   (env-data {
+     'buyer: "k:15071b931200c63c8d84870c387534216533810919b382924514003b2c90c0d7",
+     'buyer-guard: {"keys": ["15071b931200c63c8d84870c387534216533810919b382924514003b2c90c0d7"], "pred": "keys-all"},
+     'buyer_fungible_account: "k:15071b931200c63c8d84870c387534216533810919b382924514003b2c90c0d7"
+     ,'updated_price: 25.0
+     })
+
+   (expect-failure "Try to claim the token with the wrong price"
+     "Price does not match current price"
+     (continue-pact 1 false "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y")
+   )
+ (rollback-tx)
+
+ (begin-tx "Buying the token at current price succeeds")
+   (env-hash (hash "dutch-auction-claim-success"))
+   (env-chain-data {"block-time": (time "2023-10-06T00:00:00Z")})
+   (use marmalade-v2.ledger)
+   (use marmalade-v2.policy-manager)
+   (use marmalade-v2.util-v1)
+   (use mini-guard-utils)
+   (use marmalade-sale.dutch-auction)
+
+   (env-data {
+     "token1-id":(create-token-id { 'uri: "dutch-auction-uri-1", 'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY)} ALWAYS-TRUE),
+     'buyer: "k:15071b931200c63c8d84870c387534216533810919b382924514003b2c90c0d7",
+     'buyer-guard: {"keys": ["15071b931200c63c8d84870c387534216533810919b382924514003b2c90c0d7"], "pred": "keys-all"},
+     'buyer_fungible_account: "k:15071b931200c63c8d84870c387534216533810919b382924514003b2c90c0d7",
+     'policy-manager-escrow: (at 'account (get-escrow-account "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y")),
+     'updated_price: 66.43,
+     "sale-id": "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y"
+     })
+
+   (env-sigs [
+     { 'key: 'f0b8d36c97d77c782eec5facc3e235d1ac6b10247a36de52ea16908945d95ba9 ;; any key
+      ,'caps: [(marmalade-v2.ledger.BUY (read-msg "token1-id") "k:05df86b4fda15ac84cdd2ab4facb433db6098d10b6b09803eedbaea78d10723e" "k:15071b931200c63c8d84870c387534216533810919b382924514003b2c90c0d7" 1.0 "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y")]
+      },
+      { 'key: "15071b931200c63c8d84870c387534216533810919b382924514003b2c90c0d7"
+       ,'caps: [(coin.TRANSFER "k:15071b931200c63c8d84870c387534216533810919b382924514003b2c90c0d7" (read-string 'policy-manager-escrow) 66.43)]
+       }])
+
+   (expect "Claim the token succeeds"
+     "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y"
+     (continue-pact 1 false "_vS1Y4nXQavtHxQAUCNDeRzG5Jc8Se22Ocg4RNP5B2Y"))
+
+   (expect "Buyer account balance has been deducted"
+     183.57
+     (coin.get-balance "k:15071b931200c63c8d84870c387534216533810919b382924514003b2c90c0d7")
+   )
+
+   (expect "Seller balance has increased"
+     316.43
+     (coin.get-balance "k:05df86b4fda15ac84cdd2ab4facb433db6098d10b6b09803eedbaea78d10723e")
+   )
+
+   (expect "auction table is updated with sell-price, buyer information"
+    { "token-id": (read-string 'token1-id )
+     ,"start-date": 1696204800
+     ,"end-date": 1696723200
+     ,"start-price": 100.0
+     ,"reserve-price": 50.0
+     ,"price-interval-seconds": 3600
+     ,"sell-price": 66.43
+     ,"buyer": (read-string 'buyer )
+     ,"buyer-guard": (read-keyset 'buyer-guard )
+    }
+    (retrieve-auction (read-string 'sale-id ))
+   )
+
+ (commit-tx)

--- a/pact-tests/pact-tests/marmalade/pact/sale-contracts/sale-init.pact
+++ b/pact-tests/pact-tests/marmalade/pact/sale-contracts/sale-init.pact
@@ -1,0 +1,3 @@
+(namespace (read-string 'ns))
+(policy-manager.add-sale-whitelist marmalade-sale.conventional-auction)
+(policy-manager.add-sale-whitelist marmalade-sale.dutch-auction)

--- a/pact-tests/pact-tests/marmalade/pact/test/abc.pact
+++ b/pact-tests/pact-tests/marmalade/pact/test/abc.pact
@@ -1,0 +1,167 @@
+(namespace (read-msg 'ns))
+(module abc GOVERNANCE
+
+  (implements fungible-v2)
+  (use util.fungible-util)
+
+  (defschema entry
+    balance:decimal
+    guard:guard)
+
+  (deftable ledger:{entry})
+
+  (defcap GOVERNANCE ()
+    (enforce-guard (keyset-ref-guard 'marmalade-admin )))
+
+  (defcap DEBIT (sender:string)
+    (enforce-guard (at 'guard (read ledger sender))))
+
+  (defcap CREDIT (receiver:string) true)
+
+  (defcap TRANSFER:bool
+    ( sender:string
+      receiver:string
+      amount:decimal
+    )
+    @managed amount TRANSFER-mgr
+    (enforce-valid-transfer sender receiver (precision) amount)
+    (compose-capability (DEBIT sender))
+    (compose-capability (CREDIT receiver))
+  )
+
+  (defun TRANSFER-mgr:decimal
+    ( managed:decimal
+      requested:decimal
+    )
+
+    (let ((newbal (- managed requested)))
+      (enforce (>= newbal 0.0)
+        (format "TRANSFER exceeded for balance {}" [managed]))
+      newbal)
+  )
+
+  (defconst MINIMUM_PRECISION 14)
+
+  (defun enforce-unit:bool (amount:decimal)
+    (enforce-precision (precision) amount))
+
+  (defun create-account:string
+    ( account:string
+      guard:guard
+    )
+    (enforce-reserved account guard)
+    (insert ledger account
+      { "balance" : 0.0
+      , "guard"   : guard
+      })
+    )
+
+  (defun get-balance:decimal (account:string)
+    (at 'balance (read ledger account))
+  )
+
+  (defun details:object{fungible-v2.account-details}
+    ( account:string )
+    (with-read ledger account
+      { "balance" := bal
+      , "guard" := g }
+      { "account" : account
+      , "balance" : bal
+      , "guard": g })
+    )
+
+  (defun rotate:string (account:string new-guard:guard)
+    (with-read ledger account
+      { "guard" := old-guard }
+
+      (enforce-guard old-guard)
+
+      (update ledger account
+        { "guard" : new-guard }))
+    )
+
+  (defun fund:string (account:string amount:decimal)
+    ; (with-capability (GOVERNANCE)
+      (with-capability (CREDIT account)
+        (credit account
+          (at 'guard (read ledger account))
+          amount)))
+
+  (defun precision:integer ()
+    MINIMUM_PRECISION)
+
+  (defun transfer:string (sender:string receiver:string amount:decimal)
+
+    (enforce (!= sender receiver)
+      "sender cannot be the receiver of a transfer")
+    (enforce-valid-transfer sender receiver (precision) amount)
+
+    (with-capability (TRANSFER sender receiver amount)
+      (debit sender amount)
+      (with-read ledger receiver
+        { "guard" := g }
+        (credit receiver g amount))
+      )
+    )
+
+  (defun transfer-create:string
+    ( sender:string
+      receiver:string
+      receiver-guard:guard
+      amount:decimal )
+
+    (enforce (!= sender receiver)
+      "sender cannot be the receiver of a transfer")
+    (enforce-valid-transfer sender receiver (precision) amount)
+
+    (with-capability (TRANSFER sender receiver amount)
+      (debit sender amount)
+      (credit receiver receiver-guard amount))
+    )
+
+  (defun debit:string (account:string amount:decimal)
+
+    (require-capability (DEBIT account))
+    (with-read ledger account
+      { "balance" := balance }
+
+      (enforce (<= amount balance) "Insufficient funds")
+
+      (update ledger account
+        { "balance" : (- balance amount) }
+        ))
+    )
+
+
+  (defun credit:string (account:string guard:guard amount:decimal)
+
+    (require-capability (CREDIT account))
+    (with-default-read ledger account
+      { "balance" : 0.0, "guard" : guard }
+      { "balance" := balance, "guard" := retg }
+      ; we don't want to overwrite an existing guard with the user-supplied one
+      (enforce (= retg guard)
+        "account guards do not match")
+
+      (write ledger account
+        { "balance" : (+ balance amount)
+        , "guard"   : retg
+        })
+      ))
+
+
+  (defpact transfer-crosschain:string
+    ( sender:string
+      receiver:string
+      receiver-guard:guard
+      target-chain:string
+      amount:decimal )
+    (step (enforce false "cross chain not supported"))
+    )
+
+)
+
+(if (read-msg 'upgrade)
+  ["upgrade"]
+  [(create-table ledger)]
+)

--- a/pact-tests/pact-tests/marmalade/pact/test/def.pact
+++ b/pact-tests/pact-tests/marmalade/pact/test/def.pact
@@ -1,0 +1,167 @@
+(namespace (read-msg 'ns))
+(module def GOVERNANCE
+
+  (implements fungible-v2)
+  (use util.fungible-util)
+
+  (defschema entry
+    balance:decimal
+    guard:guard)
+
+  (deftable ledger:{entry})
+
+  (defcap GOVERNANCE ()
+    (enforce-guard (keyset-ref-guard 'marmalade-admin )))
+
+  (defcap DEBIT (sender:string)
+    (enforce-guard (at 'guard (read ledger sender))))
+
+  (defcap CREDIT (receiver:string) true)
+
+  (defcap TRANSFER:bool
+    ( sender:string
+      receiver:string
+      amount:decimal
+    )
+    @managed amount TRANSFER-mgr
+    (enforce-valid-transfer sender receiver (precision) amount)
+    (compose-capability (DEBIT sender))
+    (compose-capability (CREDIT receiver))
+  )
+
+  (defun TRANSFER-mgr:decimal
+    ( managed:decimal
+      requested:decimal
+    )
+
+    (let ((newbal (- managed requested)))
+      (enforce (>= newbal 0.0)
+        (format "TRANSFER exceeded for balance {}" [managed]))
+      newbal)
+  )
+
+  (defconst MINIMUM_PRECISION 14)
+
+  (defun enforce-unit:bool (amount:decimal)
+    (enforce-precision (precision) amount))
+
+  (defun create-account:string
+    ( account:string
+      guard:guard
+    )
+    (enforce-reserved account guard)
+    (insert ledger account
+      { "balance" : 0.0
+      , "guard"   : guard
+      })
+    )
+
+  (defun get-balance:decimal (account:string)
+    (at 'balance (read ledger account))
+  )
+
+  (defun details:object{fungible-v2.account-details}
+    ( account:string )
+    (with-read ledger account
+      { "balance" := bal
+      , "guard" := g }
+      { "account" : account
+      , "balance" : bal
+      , "guard": g })
+    )
+
+  (defun rotate:string (account:string new-guard:guard)
+    (with-read ledger account
+      { "guard" := old-guard }
+
+      (enforce-guard old-guard)
+
+      (update ledger account
+        { "guard" : new-guard }))
+    )
+
+  (defun fund:string (account:string amount:decimal)
+    ; (with-capability (GOVERNANCE)
+      (with-capability (CREDIT account)
+        (credit account
+          (at 'guard (read ledger account))
+          amount)))
+
+  (defun precision:integer ()
+    MINIMUM_PRECISION)
+
+  (defun transfer:string (sender:string receiver:string amount:decimal)
+
+    (enforce (!= sender receiver)
+      "sender cannot be the receiver of a transfer")
+    (enforce-valid-transfer sender receiver (precision) amount)
+
+    (with-capability (TRANSFER sender receiver amount)
+      (debit sender amount)
+      (with-read ledger receiver
+        { "guard" := g }
+        (credit receiver g amount))
+      )
+    )
+
+  (defun transfer-create:string
+    ( sender:string
+      receiver:string
+      receiver-guard:guard
+      amount:decimal )
+
+    (enforce (!= sender receiver)
+      "sender cannot be the receiver of a transfer")
+    (enforce-valid-transfer sender receiver (precision) amount)
+
+    (with-capability (TRANSFER sender receiver amount)
+      (debit sender amount)
+      (credit receiver receiver-guard amount))
+    )
+
+  (defun debit:string (account:string amount:decimal)
+
+    (require-capability (DEBIT account))
+    (with-read ledger account
+      { "balance" := balance }
+
+      (enforce (<= amount balance) "Insufficient funds")
+
+      (update ledger account
+        { "balance" : (- balance amount) }
+        ))
+    )
+
+
+  (defun credit:string (account:string guard:guard amount:decimal)
+
+    (require-capability (CREDIT account))
+    (with-default-read ledger account
+      { "balance" : 0.0, "guard" : guard }
+      { "balance" := balance, "guard" := retg }
+      ; we don't want to overwrite an existing guard with the user-supplied one
+      (enforce (= retg guard)
+        "account guards do not match")
+
+      (write ledger account
+        { "balance" : (+ balance amount)
+        , "guard"   : retg
+        })
+      ))
+
+
+  (defpact transfer-crosschain:string
+    ( sender:string
+      receiver:string
+      receiver-guard:guard
+      target-chain:string
+      amount:decimal )
+    (step (enforce false "cross chain not supported"))
+    )
+
+)
+
+(if (read-msg 'upgrade)
+  ["upgrade"]
+  [(create-table ledger)]
+)

--- a/pact-tests/pact-tests/marmalade/pact/test/fungible.repl
+++ b/pact-tests/pact-tests/marmalade/pact/test/fungible.repl
@@ -1,0 +1,787 @@
+
+
+(env-enable-repl-natives true)
+(env-data
+  { "alice": ["alice-key"]
+  , "bob": ["bob-key"]}
+  )
+
+(interface fungible-test-helper
+  "Interface for interacting with test."
+  (defun setup-rotate:bool
+    ( account:string
+      old-key:string
+    )
+    " Supply setup for 'rotate'. Simply return 'false' to use \
+    \ non-managed key-based setup, or perform managed capability \
+    \ setup with OLD_KEY and return 'true'."
+  )
+)
+
+(module fungible-test-helper-default G
+  (defcap G () true)
+  (implements fungible-test-helper)
+  (defun setup-rotate:bool (account:string old-key:string) false)
+)
+
+(module fungible-v2-test G
+  " Test suite for fungibles. "
+  (defcap G () true)
+
+  (defconst FUNDER_ACCT "FUNDER_ACCT"
+    "Name of test funding account")
+
+  (defconst FUNDER_GUARD:guard (funder-guard)
+    "Guard for test funding account")
+
+  (defconst FUNDER_BALANCE 10000.0
+    "Initial balance for test funding account")
+
+  (defcap XCHAIN ()
+    " Dummy capability for bringing sigs into scope \
+    \ for transfer-crosschain."
+    true
+  )
+
+  (defcap ROTATE ()
+    " Dummy capability for bringing sigs into scope \
+    \ for rotate."
+    true
+  )
+
+  (defconst ALICE "alice")
+  (defconst ALICE_KEY:string (at 0 (read-msg ALICE)))
+  (defconst ALICE_GUARD (read-keyset ALICE))
+
+  (defconst BOB "bob")
+  (defconst BOB_KEY (at 0 (read-msg BOB)))
+  (defconst BOB_GUARD (read-keyset BOB))
+
+  (defconst XCHAIN_HASH (hash "XCHAIN"))
+  (defconst CHAIN_0 "0")
+  (defconst CHAIN_1 "1")
+
+  (defun funder-guard ()
+    (create-module-guard "FUNDER_ACCT"))
+
+  (defun fund-create
+    ( f:module{fungible-v2}
+      account:string
+      guard:guard
+      amount:decimal )
+    "Fixture: create and fund ACCOUNT with GUARD for AMOUNT"
+    (install-capability (f::TRANSFER FUNDER_ACCT account amount))
+    (f::transfer-create FUNDER_ACCT account guard amount)
+  )
+
+  (defun fund
+    ( f:module{fungible-v2}
+      account:string
+      amount:decimal )
+    "Fixture: Fund existing ACCOUNT for AMOUNT"
+    (install-capability (f::TRANSFER FUNDER_ACCT account amount))
+    (f::transfer FUNDER_ACCT account amount)
+  )
+
+  (defun pow (v:decimal e:integer)
+    "Support negative exponents"
+    (if (>= e 0) (^ v e)
+      (fold (/) 1.0 (make-list (- e) v))))
+
+
+  (defun precision-min-value (f:module{fungible-v2})
+    "Compute minimum value for F fungible."
+    (pow 10.0 (- (f::precision))))
+
+
+  (defun begin-xchain
+    ( f:module{fungible-v2}
+      i:integer
+      account:string
+      guard:guard
+      key:string
+      fund-amount:decimal
+    )
+    " Fixture: set up transaction I for cross-chain, \
+    \ funding ACCOUNT/GUARD for FUND-AMOUNT \
+    \ and signing with KEY, setting hash to XCHAIN_HASH \
+    \ and sending chain to CHAIN_0."
+    (begin-tx (format "xchain-{}" [i]))
+    (fund-create f account guard fund-amount)
+    (env-hash XCHAIN_HASH)
+    (env-chain-data { 'chain-id: CHAIN_0 })
+    (env-sigs [{"key": key,"caps":[(XCHAIN)]}])
+  )
+
+
+  ;;
+  ;; TEST SUITE
+  ;;
+
+  (defun suite
+    ( f:module{fungible-v2}
+      h:module{fungible-test-helper}
+      skip:string
+    )
+    " Run suite on fungible module F. Requires special account \
+    \ 'FUNDER_ACCT' to exist with 'FUNDER_GUARD' guard and \
+    \ 'FUNDER_BALANCE' balance."
+    (fixture-tests f)
+    (or (contains "create-account-tests" skip)
+      (create-account-tests f))
+    (or (contains "transfer-tests" skip)
+      (transfer-tests f))
+    (or (contains "transfer-create-tests" skip)
+      (transfer-create-tests f))
+    (or (contains "transfer-crosschain-tests" skip)
+      (transfer-crosschain-tests f))
+    (or (contains "rotate-tests" skip)
+      (rotate-tests f h))
+    (or (contains "enforce-unit-tests" skip)
+      (enforce-unit-tests f))
+  )
+
+  (defun fixture-tests:bool (f:module{fungible-v2})
+    (expect "Funder account funded" 10000.0
+      (f::get-balance FUNDER_ACCT))
+    (expect "pow 10 -1" 0.1 (pow 10.0 -1))
+    (expect "pow 10 -2" 0.01 (pow 10.0 -2))
+    (expect "pow 4 -3" 0.015625 (pow 4.0 -3))
+    (expect "pow 9 3" 729.0 (pow 9.0 3))
+  )
+
+  (defun create-account-tests:bool (f:module{fungible-v2})
+    " Covers:                                  \
+    \ 1) inherent create-account invariants.   "
+
+    (begin-tx "create-account-tests")
+
+    (expect-failure
+      "Uncreated account does not exist"
+      (f::details BOB))
+
+    (expect-failure
+      "Account creation with empty ID fails [implied by transfer properties]"
+      (f::create-account "" BOB_GUARD))
+
+    (expect-that "Account creation succeeds"
+      (constantly true) ;; avoid requiring specific response
+      (f::create-account BOB BOB_GUARD))
+
+    (expect
+      "Account successfully created with correct details"
+      { 'account: BOB
+      , 'balance: 0.0
+      , 'guard: BOB_GUARD
+      }
+      (f::details BOB))
+
+    (expect
+      "Account balance correct"
+      0.0
+      (f::get-balance BOB))
+
+    (expect-failure
+      "Creation of account with existing account ID fails"
+      (f::create-account BOB BOB_KEY))
+
+    ;; fund for testing
+    (fund f BOB 1.0)
+    ;; test ownership
+    (env-sigs
+      [ {"key": ALICE_KEY
+      , "caps": [(f::TRANSFER BOB ALICE 1.0)]}])
+    (with-applied-env
+      (expect-failure
+        "Created account prevents unauthorized transfer"
+        (f::transfer-create BOB ALICE ALICE_GUARD 1.0)))
+
+    (env-sigs
+      [ {"key": BOB_KEY
+      , "caps": [(f::TRANSFER BOB ALICE 1.0)]}])
+    (with-applied-env
+      (expect-that
+        "Created account allows authorized transfer"
+        (constantly true)
+        (f::transfer-create BOB ALICE ALICE_GUARD 1.0)))
+
+    (rollback-tx)
+    true
+  )
+
+
+  (defun transfer-tests (f:module{fungible-v2})
+    " Covers:                                        \
+    \ 1) properties on 'transfer'                    \
+    \ 2) managed capability calculus                 \
+    \ 3) precision violations                        \
+    \ Exceptions:                                    \
+    \ - empty account IDs (covered by create-account \
+    \   and transfer-create tests.)                  "
+
+    (begin-tx "transfer-tests 1")
+
+    (expect-that "Bob account creation succeeds"
+      (constantly true) ;; avoid requiring specific response
+      (f::create-account BOB BOB_GUARD))
+
+    (expect-that "Alice account creation succeeds"
+      (constantly true) ;; avoid requiring specific response
+      (f::create-account ALICE ALICE_GUARD))
+
+    (fund f BOB 1.0)
+
+    (expect-failure
+      "Cannot transfer Bob-Alice without managed capability"
+      "capability not installed" ;; text from Pact, not module
+      (f::transfer BOB ALICE 1.0))
+
+    (fund f ALICE 2.0)
+
+    (expect-failure
+      "Cannot transfer Alice-Bob without managed capability"
+      "capability not installed" ;; text from Pact, not module
+      (f::transfer ALICE BOB 2.0))
+
+    (env-sigs
+      [ { "key": BOB_KEY
+        , "caps": [(f::TRANSFER BOB ALICE 1.0)]}
+        { "key": ALICE_KEY
+        , "caps": [(f::TRANSFER ALICE BOB 2.0)]}
+      ])
+    (with-applied-env [
+
+      (expect-failure
+        "Transfer fails with negative amount"
+        (f::transfer BOB ALICE -0.1)
+      )
+
+      (expect-failure
+        "Transfer fails with 0.0 amount"
+        (f::transfer BOB ALICE 0.0)
+      )
+
+      (expect-failure
+        "Transfer fails with min precision / 10 value"
+        (f::transfer BOB ALICE
+          (/ (precision-min-value f) 10.0)))
+
+      (expect-failure
+        "Transfer fails with amount greater than cap"
+        (f::transfer BOB ALICE 10.0)
+      )
+
+      (expect-that
+        "Transfer Bob-Alice succeeds with exact cap"
+        (constantly true)
+        (f::transfer BOB ALICE 1.0))
+
+      (expect
+        "Transfer Bob-Alice: Bob balance correct"
+        0.0
+        (f::get-balance BOB))
+
+      (expect
+        "Transfer Bob-Alice: Alice balance correct"
+        3.0
+        (f::get-balance ALICE))
+
+      (expect-that
+        "Transfer Alice-Bob-1 succeeds with 1/2 cap"
+        (constantly true)
+        (f::transfer ALICE BOB 1.0))
+
+      (expect-failure
+        "Transfer Alice-Bob-2 fails for full cap"
+        (f::transfer ALICE BOB 2.0))
+
+      (expect-that
+        "Transfer Alice-Bob-2 succeeds with 1/2 cap"
+        (constantly true)
+        (f::transfer ALICE BOB 1.0))
+
+      (expect
+        "Transfer Alice-Bob: Bob balance correct"
+        2.0
+        (f::get-balance BOB))
+
+      (expect
+        "Transfer Alice-Bob: Alice balance correct"
+        1.0
+        (f::get-balance ALICE))
+
+    ])
+
+    (rollback-tx)
+
+    (begin-tx "transfer-tests-2")
+
+    (fund-create f BOB BOB_GUARD 1.0)
+    (fund-create f ALICE ALICE_GUARD 1.0)
+    (env-sigs
+      [ { "key": ALICE_KEY
+        , "caps": [(f::TRANSFER BOB ALICE 1.0)]}
+      ])
+    (with-applied-env [
+      (expect-failure
+        "Transfer fails without Bob signing"
+        (f::transfer BOB ALICE 1.0))
+    ])
+
+    (rollback-tx)
+
+
+    (begin-tx "transfer-tests-3")
+
+    (fund-create f BOB BOB_GUARD 1.0)
+    (fund-create f ALICE ALICE_GUARD 1.0)
+
+    (env-sigs
+      [ { "key": BOB_KEY
+        , "caps": [(f::TRANSFER BOB ALICE 5.0)]}
+      ])
+    (with-applied-env [
+      (expect-failure
+        "Transfer fails for insufficient funds"
+        (f::transfer BOB ALICE 5.0))
+
+      (expect-that
+        "Transfer succeeds for min precision value"
+        (constantly true)
+        (f::transfer BOB ALICE (precision-min-value f)))
+
+      (expect
+        "Transfer min precision: Bob balance correct"
+        (- 1.0 (precision-min-value f))
+        (f::get-balance BOB))
+
+      (expect
+        "Transfer min precision: Alice balance correct"
+        (+ 1.0 (precision-min-value f))
+        (f::get-balance ALICE))
+    ])
+
+    (env-sigs
+      [ { "key": BOB_KEY
+        , "caps": [(f::TRANSFER BOB BOB 1.0)]}
+      ])
+    (with-applied-env [
+      (expect-failure
+        "Transfer fails for same account"
+        (f::transfer BOB BOB 1.0))
+    ])
+
+    (rollback-tx)
+    true
+  )
+
+
+
+  (defun transfer-create-tests:bool (f:module{fungible-v2})
+    " Covers:                                        \
+    \ 1) properties on 'transfer-create'             \
+    \ 2) managed capability calculus                 \
+    \ 3) precision violations                        \
+    \ Exceptions:                                    \
+    \ - empty sender ID (covered by create-account tests) "
+
+    (begin-tx "transfer-create-tests 1")
+
+    (fund-create f ALICE ALICE_GUARD 1.0)
+
+    (env-sigs
+      [ { "key": ALICE_KEY
+        , "caps": [(f::TRANSFER ALICE "" 1.0)]}
+      ])
+    (with-applied-env [
+      (expect-failure
+        "Transfer-create fails for empty receiver account"
+        (f::transfer-create ALICE "" ALICE_GUARD 1.0))
+      ])
+
+
+    (expect-failure
+      "Cannot transfer-create Alice-Bob without managed capability"
+      "capability not installed" ;; text from Pact, not module
+      (f::transfer-create ALICE BOB BOB_GUARD 1.0))
+
+    (env-sigs
+      [ { "key": ALICE_KEY
+        , "caps": [(f::TRANSFER ALICE BOB 1.0)]}
+      ])
+    (with-applied-env [
+
+      (expect-failure
+        "Transfer-create fails with negative amount"
+        (f::transfer-create ALICE BOB BOB_GUARD -0.1)
+      )
+
+      (expect-failure
+        "Transfer-create fails with 0.0 amount"
+        (f::transfer-create ALICE BOB BOB_GUARD 0.0)
+      )
+
+      (expect-failure
+        "Transfer-create fails with min precision / 10 value"
+        (f::transfer-create ALICE BOB BOB_GUARD
+          (/ (precision-min-value f) 10.0)))
+
+      (expect-failure
+        "Transfer-create fails with amount greater than cap"
+        (f::transfer-create ALICE BOB BOB_GUARD 10.0)
+      )
+
+      (expect-that
+        "Transfer-create succeeds Alice-Bob"
+        (constantly true)
+        (f::transfer-create ALICE BOB BOB_GUARD 1.0))
+
+      (expect
+        "Transfer Alice-Bob: Bob balance correct"
+        1.0
+        (f::get-balance BOB))
+
+      (expect
+        "Transfer Alice-Bob: Alice balance correct"
+        0.0
+        (f::get-balance ALICE))
+
+    ])
+
+    (env-sigs
+      [ { "key": BOB_KEY
+        , "caps": [(f::TRANSFER BOB ALICE 0.1)]}
+      ])
+    (with-applied-env [
+
+      (expect-that
+        "Transfer-create Bob-Alice-1 succeeds with 1/4 cap"
+        (constantly true)
+        (f::transfer-create BOB ALICE ALICE_GUARD 0.025))
+
+      (expect-failure
+        "Transfer-create Bob-Alice-2 fails for full cap"
+        (f::transfer-create BOB ALICE ALICE_GUARD 0.1))
+
+      (expect-that
+        "Transfer-create Bob-Alice-2 succeeds with 1/2 cap"
+        (constantly true)
+        (f::transfer-create BOB ALICE ALICE_GUARD 0.05))
+
+      (expect
+        "Transfer-create Bob-Alice: Bob balance correct"
+        0.925
+        (f::get-balance BOB))
+
+      (expect
+        "Transfer-create Bob-Alice: Alice balance correct"
+        0.075
+        (f::get-balance ALICE))
+
+      (expect-failure
+        "Transfer-create fails with mismatched guard"
+        (f::transfer-create BOB ALICE BOB_GUARD 0.025)
+      )
+
+    ])
+
+    (rollback-tx)
+
+    (begin-tx "transfer-create-tests-2")
+
+    (fund-create f BOB BOB_GUARD 1.0)
+    (env-sigs
+      [ { "key": ALICE_KEY
+        , "caps": [(f::TRANSFER BOB ALICE 1.0)]}
+      ])
+    (with-applied-env [
+      (expect-failure
+        "Transfer-create fails without Bob signing"
+        (f::transfer-create BOB ALICE ALICE_GUARD 1.0))
+    ])
+
+    (rollback-tx)
+
+    (begin-tx "transfer-create-tests-3")
+
+    (fund-create f BOB BOB_GUARD 1.0)
+
+    (env-sigs
+      [ { "key": BOB_KEY
+        , "caps": [(f::TRANSFER BOB ALICE 5.0)]}
+      ])
+    (with-applied-env [
+      (expect-failure
+        "Transfer-create fails for insufficient funds"
+        (f::transfer-create BOB ALICE ALICE_GUARD 5.0))
+
+      (expect-that
+        "Transfer-create succeeds for min precision value"
+        (constantly true)
+        (f::transfer-create BOB ALICE ALICE_GUARD (precision-min-value f)))
+
+      (expect
+        "Transfer-create min precision: Bob balance correct"
+        (- 1.0 (precision-min-value f))
+        (f::get-balance BOB))
+
+      (expect
+        "Transfer-create min precision: Alice balance correct"
+        (precision-min-value f)
+        (f::get-balance ALICE))
+    ])
+
+    (env-sigs
+      [ { "key": BOB_KEY
+        , "caps": [(f::TRANSFER BOB BOB 1.0)]}
+      ])
+    (with-applied-env [
+      (expect-failure
+        "Transfer-create fails for same account"
+        (f::transfer-create BOB BOB BOB_GUARD 1.0))
+    ])
+
+    (rollback-tx)
+    true
+  )
+
+
+  (defun transfer-crosschain-tests:bool (f:module{fungible-v2})
+    " Covers:                                             \
+    \ 1) properties on 'transfer-crosschain'              \
+    \ 2) precision violations                             \
+    \ Exceptions:                                         \
+    \ - bad-same-sender-receiver property in fungible-v2  \
+    \   which is unsound/to be removed                    \
+    \ - empty sender ID (covered by create-account tests) "
+
+    (begin-tx "transfer-crosschain-tests 1")
+    (expect-failure
+      "Cross-chain transfer fails for unknown account"
+      (f::transfer-crosschain BOB ALICE ALICE_GUARD CHAIN_1 2.0)
+    )
+    (rollback-tx)
+
+    (begin-tx "transfer-crosschain-tests 2")
+    (fund-create f BOB BOB_GUARD 2.0)
+    (expect-failure
+      "Cross-chain transfer fails without signature"
+      (f::transfer-crosschain BOB ALICE ALICE_GUARD CHAIN_1 2.0)
+    )
+    (rollback-tx)
+
+    (begin-xchain f 3 BOB BOB_GUARD BOB_KEY 2.0)
+    (with-applied-env (with-capability (XCHAIN)
+      (expect-failure
+        "Cross-chain transfer fails with negative amount"
+        (f::transfer-crosschain BOB ALICE ALICE_GUARD CHAIN_1 -0.1))))
+    (rollback-tx)
+
+    (begin-xchain f 4 BOB BOB_GUARD BOB_KEY 2.0)
+    (with-applied-env (with-capability (XCHAIN)
+      (expect-failure
+        "Cross-chain transfer fails with 0.0 amount"
+        (f::transfer-crosschain BOB ALICE ALICE_GUARD CHAIN_1 0.0))))
+    (rollback-tx)
+
+    (begin-xchain f 5 BOB BOB_GUARD BOB_KEY 2.0)
+    (with-applied-env (with-capability (XCHAIN)
+      (expect-failure
+        "Cross-chain transfer fails with min precision / 10 value"
+        (f::transfer-crosschain BOB ALICE ALICE_GUARD CHAIN_1
+          (/ (precision-min-value f) 10.0)))))
+    (rollback-tx)
+
+    (begin-xchain f 6 BOB BOB_GUARD BOB_KEY 2.0)
+    (with-applied-env (with-capability (XCHAIN)
+      (expect-failure
+        "Cross-chain transfer fails for empty receiver"
+        (f::transfer-crosschain BOB "" ALICE_GUARD CHAIN_1 1.0))))
+    (rollback-tx)
+
+    (begin-xchain f 7 BOB BOB_GUARD BOB_KEY 2.0)
+    (with-applied-env (with-capability (XCHAIN)
+      (expect-failure
+        "Cross-chain transfer fails for insufficient funds"
+        (f::transfer-crosschain BOB ALICE ALICE_GUARD CHAIN_1 10.0))))
+    (rollback-tx)
+
+    (begin-xchain f 7 BOB BOB_GUARD BOB_KEY 2.0)
+    (with-applied-env (with-capability (XCHAIN)
+      (expect-failure
+        "Cross-chain transfer fails to same chain"
+        (f::transfer-crosschain BOB ALICE ALICE_GUARD "0" 1.0))))
+    (rollback-tx)
+
+    (begin-xchain f 8 BOB BOB_GUARD BOB_KEY 3.0)
+
+    (with-applied-env (with-capability (XCHAIN)
+
+      (expect-that
+        "Cross-chain transfer succeeds"
+        (constantly true)
+        (f::transfer-crosschain BOB ALICE ALICE_GUARD CHAIN_1 1.0))
+
+      (expect
+        "Cross-chain transfer: sender balance correct"
+        2.0 (f::get-balance BOB))
+
+      (expect-failure
+        "Cross-chain transfer: receiver not credited on source chain"
+        (f::get-balance ALICE))
+
+      (expect-failure
+        "Resumption on wrong chain fails"
+        "yield provenance" ;; from pact internals
+        (continue-pact 1))
+
+      (env-chain-data { 'chain-id: CHAIN_1 })
+      (with-applied-env [
+        (expect-that
+          "Cross-chain transfer: Resumption on correct chain succeeds"
+          (constantly true)
+          (continue-pact 1))
+
+        (expect-failure
+          "Duplicate resumption of cross-chain prevented"
+          "pact completed" ;; from pact internals
+          (continue-pact 1))
+      ])
+
+    ))
+
+    (expect
+      "Cross-chain transfer: receiver balance correct"
+      1.0 (f::get-balance ALICE))
+
+    (env-sigs
+      [ { "key": ALICE_KEY
+        , "caps": [(f::TRANSFER ALICE BOB 0.1)]}
+      ])
+    (with-applied-env
+      (expect-that
+        "Cross-chain transfer: receiver guard correct"
+        (constantly true)
+        (f::transfer ALICE BOB 0.1)))
+
+    (expect
+      "Cross-chain transfer: receiver balance correct after test tfr"
+      0.9 (f::get-balance ALICE))
+
+    (expect
+      "Cross-chain transfer: sender balance correct after test tfr"
+      2.1 (f::get-balance BOB))
+
+    (rollback-tx)
+
+    (begin-xchain f 9 BOB BOB_GUARD BOB_KEY 1.0)
+
+    (with-applied-env (with-capability (XCHAIN)
+      (expect-that
+        "Cross-chain transfer min value succeeds"
+        (constantly true)
+        (f::transfer-crosschain BOB ALICE ALICE_GUARD CHAIN_1
+          (precision-min-value f)))
+
+      (env-chain-data { 'chain-id: CHAIN_1 })
+      (with-applied-env
+        (expect-that
+          "Cross-chain transfer min value: Resumption on correct chain succeeds"
+          (constantly true)
+          (continue-pact 1)))))
+
+    (expect
+      "Cross-chain transfer min value: receiver balance correct"
+      (precision-min-value f) (f::get-balance ALICE))
+
+    (expect
+      "Cross-chain transfer min value: sender balance correct"
+      (- 1.0 (precision-min-value f)) (f::get-balance BOB))
+
+    true
+  )
+
+  (defun rotate-tests:bool
+    ( f:module{fungible-v2}
+      h:module{fungible-test-helper}
+    )
+    " Covers rotate semantics, namely that old guard is enforced \
+    \ and new guard verified to be correct."
+
+    (begin-tx "rotate-tests")
+
+    (fund-create f ALICE ALICE_GUARD 100.0)
+
+    (expect-failure
+      "rotate without setup fails"
+      (f::rotate ALICE BOB_GUARD))
+
+
+    (expect-that "pre-rotate bad key succeeds"
+      (constantly true)
+      (if (h::setup-rotate ALICE BOB_KEY) true
+        (env-sigs [{"key": BOB_KEY, "caps": [(ROTATE)]}])))
+
+    (with-applied-env (with-capability (ROTATE)
+      (expect-failure "rotate fails with bad key"
+            (f::rotate ALICE BOB_GUARD))))
+
+    (expect-that "pre-rotate succeeds"
+      (constantly true)
+      (if (h::setup-rotate ALICE ALICE_KEY) true
+        (env-sigs [{"key": ALICE_KEY, "caps": [(ROTATE)]}])))
+
+    (with-applied-env (with-capability (ROTATE)
+      (expect-that "rotate succeeds"
+        (constantly true)
+        (f::rotate ALICE BOB_GUARD))))
+
+
+    (env-sigs
+      [ { "key": ALICE_KEY
+        , "caps": [(f::TRANSFER ALICE BOB 1.0)]}
+      ])
+    (with-applied-env [
+      (expect-failure "post-rotate transfer fails with old key"
+        (f::transfer-create ALICE BOB BOB_GUARD 0.2))
+      ])
+
+
+    (env-sigs
+      [ { "key": BOB_KEY
+        , "caps": [(f::TRANSFER ALICE BOB 1.0)]}
+      ])
+    (with-applied-env [
+      (expect-that "post-rotate transfer succeeds"
+        (constantly true)
+        (f::transfer-create ALICE BOB BOB_GUARD 0.2))
+      ])
+
+    (expect
+      "sender balance correct"
+      99.8 (f::get-balance ALICE))
+
+    (expect
+      "receiver balance correct"
+      0.2 (f::get-balance BOB))
+
+    (rollback-tx)
+    true
+  )
+
+
+  (defun enforce-unit-tests:bool (f:module{fungible-v2})
+    "Strictly covers min precision only."
+    (begin-tx "enforce-unit-tests")
+
+    (expect-that "1.0 succeeds"
+      (f::enforce-unit) 1.0)
+    (expect-that "min precision succeeds"
+      (f::enforce-unit) (precision-min-value f))
+    (expect-failure "min prec / 10 fails"
+      (f::enforce-unit (/ (precision-min-value f) 10.0)))
+
+    (rollback-tx)
+    true
+  )
+)

--- a/pact-tests/pact-tests/marmalade/pact/test/ledger-test-fungible.pact
+++ b/pact-tests/pact-tests/marmalade/pact/test/ledger-test-fungible.pact
@@ -1,0 +1,195 @@
+(module ledger-test-fungible G
+  " Module for mocking an individual marmalade token \
+  \ as a standalone 'fungible-v2' for coverage by the fungible \
+  \ test. Note that when Pact gains implicit arguments for \
+  \ modrefs, this will not be needed anymore."
+  (defcap G () true)
+
+  (defconst TOKEN:string "token")
+
+  (implements fungible-v2)
+
+  (defschema entry guard:guard version:integer)
+  (deftable entries:{entry}
+    "Track GUARD and maintain VERSION for delegate guard")
+
+  (defschema caps pending:[object])
+  (deftable capstate:{caps}
+    "Singleton storage for accumulating delegate TRANSFER cap install")
+  (defconst S "SINGLETON")
+
+  (defcap TRANSFER:bool
+    ( sender:string
+      receiver:string
+      amount:decimal
+    )
+    @managed amount TRANSFER-mgr
+    (enforce-entry sender)
+    ;; managed caps are called on install, track
+    ;; for delegate install in transfer function
+    (with-default-read capstate S
+      { 'pending: [] }
+      { 'pending := caps }
+      (write capstate S
+        { 'pending: (+ caps
+          [ { 'sender: sender, 'receiver: receiver
+            , 'amount: amount } ]) })
+    )
+  )
+
+  (defun install-pending ()
+    "Install pending delegate TRANSFER caps"
+    (with-default-read capstate S
+      { 'pending: [] }
+      { 'pending := caps }
+      (write capstate S { 'pending: [] })
+      (map (install) caps)
+    )
+  )
+  (defun install (cap:object)
+    (install-capability
+      (marmalade.ledger.TRANSFER TOKEN
+        (at 'sender cap)
+        (at 'receiver cap)
+        (at 'amount cap)
+      ))
+  )
+
+  (defcap DELEGATE (account:string version:integer)
+    "Delegate of user guard to underlying token custody."
+    true)
+
+  (defun enforce-entry:integer (account:string)
+    "Enforce tracked guard and return current delegate version."
+    (let ((e (read entries account)))
+      (enforce-guard (at 'guard e))
+      (at 'version e)
+      )
+  )
+
+  (defun TRANSFER-mgr:decimal
+    ( managed:decimal
+      requested:decimal
+    )
+    "All-pass manager so underlying can be tested."
+    requested
+  )
+
+  (defun transfer:string
+    ( sender:string
+      receiver:string
+      amount:decimal
+    )
+    (with-capability (TRANSFER sender receiver amount)
+      (install-pending)
+      (with-capability
+        (DELEGATE sender (at 'version (read entries sender)))
+        (marmalade.ledger.transfer TOKEN sender receiver amount))
+    )
+
+  )
+
+  (defun transfer-create:string
+    ( sender:string
+      receiver:string
+      receiver-guard:guard
+      amount:decimal
+    )
+    (with-capability (TRANSFER sender receiver amount)
+      (install-pending)
+      (with-default-read entries receiver
+        { 'guard: receiver-guard, 'version: 0 }
+        { 'guard := g, 'version:= v }
+        (let
+          ( (del-guard
+              (if (= receiver-guard g)
+                ;; correct case, write and return current delegate
+                (let ((d (delegate-guard receiver v)))
+                  (write entries receiver { 'guard: g, 'version: v })
+                  d)
+                ;; incorrect case, pass invalid delegate to ensure enforcement
+                (delegate-guard receiver (+ 1 v)))) )
+          (with-capability (DELEGATE sender (at 'version (read entries sender)))
+            (marmalade.ledger.transfer-create
+              TOKEN sender receiver del-guard amount))))
+    )
+  )
+
+  (defpact transfer-crosschain:string
+    ( sender:string
+      receiver:string
+      receiver-guard:guard
+      target-chain:string
+      amount:decimal
+    )
+    (step (enforce false "unsupported"))
+  )
+
+  (defun get-balance:decimal
+    ( account:string )
+    (marmalade.ledger.get-balance TOKEN account)
+  )
+
+  (defun details:object{fungible-v2.account-details}
+    ( account: string )
+    (remove "id"
+      (+ { 'guard: (at 'guard (read entries account))}
+        (marmalade.ledger.details TOKEN account)))
+  )
+
+  (defun precision:integer ()
+    (marmalade.ledger.precision TOKEN)
+  )
+
+  (defun enforce-unit:bool
+    ( amount:decimal )
+    (marmalade.ledger.enforce-unit TOKEN amount)
+  )
+
+  (defun delegate-guard (account:string version:integer)
+    (create-user-guard (require-delegate account version))
+  )
+
+  (defun require-delegate (account:string version:integer)
+    (require-capability (DELEGATE account version))
+  )
+
+
+  (defun create-account:string
+    ( account:string
+      guard:guard
+    )
+    (insert entries account { 'guard: guard, 'version: 0 })
+    (marmalade.ledger.create-account TOKEN account (delegate-guard account 0))
+  )
+
+  (defun rotate:string
+    ( account:string
+      new-guard:guard
+    )
+    " Enforces tracked user guard, increments delegate version \
+    \ while calling underlying with old delegate in scope to \
+    \ enforce old guard."
+    (let*
+      ( (v (enforce-entry account))
+        (v1 (+ 1 v))
+      )
+      (write entries account
+        { 'guard: new-guard
+        , 'version: v1
+      })
+      (with-capability (DELEGATE account v)
+        (marmalade.ledger.rotate TOKEN account
+          (delegate-guard account v1)))
+    ))
+
+  (defun test-fund
+    ( account:string guard:guard amount:decimal )
+    (create-account account guard)
+    (marmalade.ledger.credit TOKEN account (delegate-guard account 0) amount)
+    true
+  )
+
+)
+(create-table entries)
+(create-table capstate)

--- a/pact-tests/pact-tests/marmalade/pact/util/fungible-util.pact
+++ b/pact-tests/pact-tests/marmalade/pact/util/fungible-util.pact
@@ -1,0 +1,42 @@
+(namespace 'util)
+
+(module fungible-util GOVERNANCE
+  (implements kip.account-protocols-v1)
+
+  (defcap GOVERNANCE ()
+    (enforce-guard (keyset-ref-guard 'util-ns-admin)))
+
+  (defun enforce-valid-amount
+    ( precision:integer
+      amount:decimal
+    )
+    (enforce (> amount 0.0) "Positive non-zero amount")
+    (enforce-precision precision amount)
+  )
+
+  (defun enforce-precision
+    ( precision:integer
+      amount:decimal
+    )
+    (enforce
+      (= (floor amount precision) amount)
+      "precision violation")
+  )
+
+  (defun enforce-valid-transfer
+    ( sender:string
+      receiver:string
+      precision:integer
+      amount:decimal)
+    (enforce (!= sender receiver)
+      "sender cannot be the receiver of a transfer")
+    (enforce-valid-amount precision amount)
+  )
+
+  (defun enforce-reserved:bool (account:string guard:guard)
+    @doc "Enforce reserved account name protocols."
+    (enforce (validate-principal guard account) "Incorrect account guard")
+    true
+  )
+
+)

--- a/pact-tests/pact-tests/marmalade/pact/util/guards1.pact
+++ b/pact-tests/pact-tests/marmalade/pact/util/guards1.pact
@@ -1,0 +1,96 @@
+;; guards1.pact
+
+(namespace 'util)
+
+(module guards1 AUTONOMOUS
+  "************************WARNING************************\
+  \ This module is currently governed by 'util-ns-admin   \
+  \ and should not be in use until the governance is      \
+  \ replaced with AUTONOMOUS, meaning that the module     \
+  \ will be non-upgradable.                               \
+  \ ******************************************************\
+  \ Functions for implementing gas guards."
+
+ (defcap AUTONOMOUS ()
+   (enforce false "Non-upgradeable"))
+
+  (defun guard-all:guard (guards:[guard])
+    "Create a guard that only succeeds if every guard in GUARDS is successfully enforced."
+    (enforce (< 0 (length guards)) "Guard list cannot be empty")
+    (create-user-guard (enforce-guard-all guards)))
+
+  (defun enforce-guard-all:bool (guards:[guard])
+    "Enforces all guards in GUARDS"
+    (map (enforce-guard) guards)
+  )
+
+  (defun guard-any:guard (guards:[guard])
+    "Create a guard that succeeds if at least one guard in GUARDS is successfully enforced."
+    (enforce (< 0 (length guards)) "Guard list cannot be empty")
+    (create-user-guard (enforce-guard-any guards)))
+
+  (defun enforce-guard-any:bool (guards:[guard])
+    "Will succeed if at least one guard in GUARDS is successfully enforced."
+    (enforce (< 0
+      (length
+        (filter
+          (= true)
+          (map (try-enforce-guard) guards))))
+      "None of the guards passed")
+  )
+
+  (defun try-enforce-guard (g:guard)
+    (try false (enforce-guard g))
+  )
+
+  (defun max-gas-notional:guard (gasNotional:decimal)
+    "Guard to enforce gas price * gas limit is smaller than or equal to GAS"
+    (create-user-guard
+      (enforce-below-or-at-gas-notional gasNotional)))
+
+  (defun enforce-below-gas-notional (gasNotional:decimal)
+    (enforce (< (chain-gas-notional) gasNotional)
+      (format "Gas Limit * Gas Price must be smaller than {}" [gasNotional])))
+
+  (defun enforce-below-or-at-gas-notional (gasNotional:decimal)
+    (enforce (<= (chain-gas-notional) gasNotional)
+      (format "Gas Limit * Gas Price must be smaller than or equal to {}" [gasNotional])))
+
+  (defun max-gas-price:guard (gasPrice:decimal)
+    "Guard to enforce gas price is smaller than or equal to GAS PRICE"
+    (create-user-guard
+      (enforce-below-or-at-gas-price gasPrice)))
+
+  (defun enforce-below-gas-price:bool (gasPrice:decimal)
+    (enforce (< (chain-gas-price) gasPrice)
+      (format "Gas Price must be smaller than {}" [gasPrice])))
+
+  (defun enforce-below-or-at-gas-price:bool (gasPrice:decimal)
+    (enforce (<= (chain-gas-price) gasPrice)
+      (format "Gas Price must be smaller than or equal to {}" [gasPrice])))
+
+  (defun max-gas-limit:guard (gasLimit:integer)
+    "Guard to enforce gas limit is smaller than or equal to GAS LIMIT"
+    (create-user-guard
+      (enforce-below-or-at-gas-limit gasLimit)))
+
+  (defun enforce-below-gas-limit:bool (gasLimit:integer)
+    (enforce (< (chain-gas-limit) gasLimit)
+      (format "Gas Limit must be smaller than {}" [gasLimit])))
+
+  (defun enforce-below-or-at-gas-limit:bool (gasLimit:integer)
+    (enforce (<= (chain-gas-limit) gasLimit)
+      (format "Gas Limit must be smaller than or equal to {}" [gasLimit])))
+
+  (defun chain-gas-price ()
+    "Return gas price from chain-data"
+    (at 'gas-price (chain-data)))
+
+  (defun chain-gas-limit ()
+    "Return gas limit from chain-data"
+    (at 'gas-limit (chain-data)))
+
+  (defun chain-gas-notional ()
+    "Return gas limit * gas price from chain-data"
+    (* (chain-gas-price) (chain-gas-limit)))
+)

--- a/pact-tests/pact-tests/marmalade/pact/yaml/README.md
+++ b/pact-tests/pact-tests/marmalade/pact/yaml/README.md
@@ -1,0 +1,89 @@
+# Marmalade - V2 Deployment
+
+## Data file
+The YAML data files includes parameters for deployment:
+
+Example for testnet:
+```yaml
+network: testnet04
+chain: 1
+marmalade_namespace: marmalade-v2
+kip_namespace: kip
+is_upgrade: false
+sender: dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e
+sender_key: dfb16b13e4032a6878fd98506b22cb0d6e5932c541e656b7ee5d69d72e6eb76e
+```
+
+## YAML transactions files
+
+The current deployment YAML files assume that only 1 signer is needed:
+  - For gas payment
+  - For namespaces unlocking
+
+Others signers can be added if needed
+
+## Transactions (JSON) files
+
+Transaction files can be generated and submitted by:
+
+```sh
+kda gen -t XXX.yaml -d data_file.yaml
+
+# Depending on your signature method
+kda sign tx.yaml --chainweaver
+# or
+kda sign tx.yaml -k key.yaml
+# or
+# ...
+
+# Then submit
+kda send tx.json
+```
+
+
+## Deployment Order / Dependencies
+
+The deployment order must be respected to fulfill all modules dependencies.
+
+* In the `kip` Namespace
+
+  0. account-protocols-v1
+
+* In the `util` Namespace
+  1. fungible-util
+
+* In the `kip` Namespace
+  2. poly-fungible-v3
+  3. updatable-uri-v1
+  4. poly-fungible-v3
+
+* In the `marmalade-v2` Namespace
+
+  5. ledger-v2
+  6. sale-v1
+  7. policy-manager
+  8. ledger
+  9. Concrete policies
+    * collection-policy-v1
+    * guard-policy-v1
+    * non-fungible-policy-v1
+    * royalty-policy-v1
+  10. policy-init **(Don't forget this one)**
+  11. util-v1
+
+Ideally, verify that each transaction has been fully mined and has succeed between each step.
+
+* In the `marmalade-sale` Namespace
+  12. conventional-auction
+  13. dutch-auction
+  14. sale-init **(Don't forget this one)**
+
+## Note about the KIP namespace
+
+Most marmalade contracts include fully qualified links to the KIP deployed interfaces.
+
+If the `token-policy-v2` and `poly-fungible-v3` are deployed in another namespace than `kip`, the links have to be manually fixed before deployment, in each Pact module.
+
+## Note about upgrading modules
+
+Don't forget to set `is_upgrade` to `true` in the YAML data file

--- a/pact-tests/pact-tests/marmalade/pact/yaml/data/mainnet-data.yaml
+++ b/pact-tests/pact-tests/marmalade/pact/yaml/data/mainnet-data.yaml
@@ -1,0 +1,20 @@
+network: mainnet01
+
+chain: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19]
+
+kip_namespace: kip
+
+marmalade_namespace: marmalade-v2
+marmalade_sale_namespace: marmalade-sale
+
+is_upgrade:
+upgrade_version_1:
+
+sender:
+sender_key:
+
+marmalade_user_key_1:
+marmalade_user_key_2:
+
+kip_ns_user_key_1:
+kip_ns_user_key_2:

--- a/pact-tests/pact-tests/marmalade/pact/yaml/data/testnet-data.yaml
+++ b/pact-tests/pact-tests/marmalade/pact/yaml/data/testnet-data.yaml
@@ -1,0 +1,20 @@
+network: testnet04
+
+chain: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19]
+
+kip_namespace: kip
+
+marmalade_namespace: marmalade-v2
+marmalade_sale_namespace: marmalade-sale
+
+is_upgrade:
+upgrade_version_1:
+
+sender:
+sender_key:
+
+marmalade_user_key_1:
+marmalade_user_key_2:
+
+kip_ns_user_key_1:
+kip_ns_user_key_2:

--- a/pact-tests/pact-tests/marmalade/pact/yaml/kip/0.account-protocols-v1.yaml
+++ b/pact-tests/pact-tests/marmalade/pact/yaml/kip/0.account-protocols-v1.yaml
@@ -1,0 +1,12 @@
+codeFile: ../kip/account-protocols-v1.pact
+signers:
+  - public: {{sender_key}}
+  - public: {{kip_ns_user_key_1}}
+  - public: {{kip_ns_user_key_2}}
+networkId: {{network}}
+publicMeta:
+  chainId: "{{chain}}"
+  sender: {{sender}}
+  gasLimit: 100000
+  gasPrice: 0.0000001
+  ttl: 600

--- a/pact-tests/pact-tests/marmalade/pact/yaml/kip/2.token-policy-v2.yaml
+++ b/pact-tests/pact-tests/marmalade/pact/yaml/kip/2.token-policy-v2.yaml
@@ -1,0 +1,14 @@
+codeFile: ../kip/token-policy-v2.pact
+signers:
+  - public: {{sender_key}}
+  - public: {{kip_ns_user_key_1}}
+  - public: {{kip_ns_user_key_2}}
+data:
+  ns: {{kip_namespace}}
+networkId: {{network}}
+publicMeta:
+  chainId: "{{chain}}"
+  sender: {{sender}}
+  gasLimit: 100000
+  gasPrice: 0.0000001
+  ttl: 100000

--- a/pact-tests/pact-tests/marmalade/pact/yaml/kip/3.updatable-uri-v1.yaml
+++ b/pact-tests/pact-tests/marmalade/pact/yaml/kip/3.updatable-uri-v1.yaml
@@ -1,0 +1,14 @@
+codeFile: ../kip/updatable-uri-policy-v1.pact
+signers:
+  - public: {{sender_key}}
+  - public: {{kip_ns_user_key_1}}
+  - public: {{kip_ns_user_key_2}}
+data:
+  ns: {{kip_namespace}}
+networkId: {{network}}
+publicMeta:
+  chainId: "{{chain}}"
+  sender: {{sender}}
+  gasLimit: 100000
+  gasPrice: 0.0000001
+  ttl: 100000

--- a/pact-tests/pact-tests/marmalade/pact/yaml/kip/4.poly-fungible-v3.yaml
+++ b/pact-tests/pact-tests/marmalade/pact/yaml/kip/4.poly-fungible-v3.yaml
@@ -1,0 +1,14 @@
+codeFile: ../kip/poly-fungible-v3.pact
+signers:
+  - public: {{sender_key}}
+  - public: {{kip_ns_user_key_1}}
+  - public: {{kip_ns_user_key_2}}
+data:
+  ns: {{kip_namespace}}
+networkId: {{network}}
+publicMeta:
+  chainId: "{{chain}}"
+  sender: {{sender}}
+  gasLimit: 100000
+  gasPrice: 0.0000001
+  ttl: 100000

--- a/pact-tests/pact-tests/marmalade/pact/yaml/marmalade-sale/12.conventional-auction.yaml
+++ b/pact-tests/pact-tests/marmalade/pact/yaml/marmalade-sale/12.conventional-auction.yaml
@@ -1,0 +1,15 @@
+codeFile: ../sale-contracts/conventional-auction/conventional-auction.pact
+signers:
+  - public: {{sender_key}}
+  - public: {{marmalade_user_key_1}}
+  - public: {{marmalade_user_key_2}}
+data:
+  ns: {{marmalade_sale_namespace}}
+  upgrade: {{is_upgrade}}
+networkId: {{network}}
+publicMeta:
+  chainId: "{{chain}}"
+  sender: {{sender}}
+  gasLimit: 100000
+  gasPrice: 0.0000001
+  ttl: 10000

--- a/pact-tests/pact-tests/marmalade/pact/yaml/marmalade-sale/13.dutch-auction.yaml
+++ b/pact-tests/pact-tests/marmalade/pact/yaml/marmalade-sale/13.dutch-auction.yaml
@@ -1,0 +1,15 @@
+codeFile: ../sale-contracts/dutch-auction/dutch-auction.pact
+signers:
+  - public: {{sender_key}}
+  - public: {{marmalade_user_key_1}}
+  - public: {{marmalade_user_key_2}}
+data:
+  ns: {{marmalade_sale_namespace}}
+  upgrade: {{is_upgrade}}
+networkId: {{network}}
+publicMeta:
+  chainId: "{{chain}}"
+  sender: {{sender}}
+  gasLimit: 100000
+  gasPrice: 0.0000001
+  ttl: 10000

--- a/pact-tests/pact-tests/marmalade/pact/yaml/marmalade-sale/14.sale-init.yaml
+++ b/pact-tests/pact-tests/marmalade/pact/yaml/marmalade-sale/14.sale-init.yaml
@@ -1,0 +1,24 @@
+codeFile: ../sale-contracts/sale-init.pact
+signers:
+  - public: {{sender_key}}
+  - public: {{marmalade_user_key_1}}
+    caps:
+    - name: marmalade-v2.policy-manager.SALE-WHITELIST
+      args: ["marmalade-sale.conventional-auction"]
+    - name: marmalade-v2.policy-manager.SALE-WHITELIST
+      args: ["marmalade-sale.dutch-auction"]
+  - public: {{marmalade_user_key_2}}
+    caps:
+    - name: marmalade-v2.policy-manager.SALE-WHITELIST
+      args: ["marmalade-sale.conventional-auction"]
+    - name: marmalade-v2.policy-manager.SALE-WHITELIST
+      args: ["marmalade-sale.dutch-auction"]
+data:
+  ns: {{marmalade_namespace}}
+networkId: {{network}}
+publicMeta:
+  chainId: "{{chain}}"
+  sender: {{sender}}
+  gasLimit: 5000
+  gasPrice: 0.0000001
+  ttl: 10000

--- a/pact-tests/pact-tests/marmalade/pact/yaml/marmalade-v2/10.policy-init.yaml
+++ b/pact-tests/pact-tests/marmalade/pact/yaml/marmalade-v2/10.policy-init.yaml
@@ -1,0 +1,14 @@
+codeFile: ../policy-manager/manager-init.pact
+signers:
+  - public: {{sender_key}}
+  - public: {{marmalade_user_key_1}}
+  - public: {{marmalade_user_key_2}}
+data:
+  ns: {{marmalade_namespace}}
+networkId: {{network}}
+publicMeta:
+  chainId: "{{chain}}"
+  sender: {{sender}}
+  gasLimit: 5000
+  gasPrice: 0.0000001
+  ttl: 10000

--- a/pact-tests/pact-tests/marmalade/pact/yaml/marmalade-v2/11.util-v1.yaml
+++ b/pact-tests/pact-tests/marmalade/pact/yaml/marmalade-v2/11.util-v1.yaml
@@ -1,0 +1,15 @@
+codeFile: ../marmalade-util/util-v1.pact
+signers:
+  - public: {{sender_key}}
+  - public: {{marmalade_user_key_1}}
+  - public: {{marmalade_user_key_2}}
+data:
+  ns: {{marmalade_namespace}}
+  upgrade: {{is_upgrade}}
+networkId: {{network}}
+publicMeta:
+  chainId: "{{chain}}"
+  sender: {{sender}}
+  gasLimit: 100000
+  gasPrice: 0.0000001
+  ttl: 10000

--- a/pact-tests/pact-tests/marmalade/pact/yaml/marmalade-v2/5.ledger-v2.interface.yaml
+++ b/pact-tests/pact-tests/marmalade/pact/yaml/marmalade-v2/5.ledger-v2.interface.yaml
@@ -1,0 +1,14 @@
+codeFile: ../ledger/ledger-v2.interface.pact
+signers:
+  - public: {{sender_key}}
+  - public: {{marmalade_user_key_1}}
+  - public: {{marmalade_user_key_2}}
+data:
+  ns: {{marmalade_namespace}}
+networkId: {{network}}
+publicMeta:
+  chainId: "{{chain}}"
+  sender: {{sender}}
+  gasLimit: 100000
+  gasPrice: 0.0000001
+  ttl: 10000

--- a/pact-tests/pact-tests/marmalade/pact/yaml/marmalade-v2/6.sale.interface.yaml
+++ b/pact-tests/pact-tests/marmalade/pact/yaml/marmalade-v2/6.sale.interface.yaml
@@ -1,0 +1,14 @@
+codeFile: ../policy-manager/sale.interface.pact
+signers:
+  - public: {{sender_key}}
+  - public: {{marmalade_user_key_1}}
+  - public: {{marmalade_user_key_2}}
+data:
+  ns: {{marmalade_namespace}}
+networkId: {{network}}
+publicMeta:
+  chainId: "{{chain}}"
+  sender: {{sender}}
+  gasLimit: 100000
+  gasPrice: 0.0000001
+  ttl: 10000

--- a/pact-tests/pact-tests/marmalade/pact/yaml/marmalade-v2/7.policy-manager.yaml
+++ b/pact-tests/pact-tests/marmalade/pact/yaml/marmalade-v2/7.policy-manager.yaml
@@ -1,0 +1,15 @@
+codeFile: ../policy-manager/policy-manager.pact
+signers:
+  - public: {{sender_key}}
+  - public: {{marmalade_user_key_1}}
+  - public: {{marmalade_user_key_2}}
+data:
+  ns: {{marmalade_namespace}}
+  upgrade: {{is_upgrade}}
+networkId: {{network}}
+publicMeta:
+  chainId: "{{chain}}"
+  sender: {{sender}}
+  gasLimit: 100000
+  gasPrice: 0.0000001
+  ttl: 10000

--- a/pact-tests/pact-tests/marmalade/pact/yaml/marmalade-v2/8.ledger.yaml
+++ b/pact-tests/pact-tests/marmalade/pact/yaml/marmalade-v2/8.ledger.yaml
@@ -1,0 +1,16 @@
+codeFile: ../ledger/ledger.pact
+signers:
+  - public: {{sender_key}}
+  - public: {{marmalade_user_key_1}}
+  - public: {{marmalade_user_key_2}}
+data:
+  ns: {{marmalade_namespace}}
+  upgrade: {{is_upgrade}}
+  upgrade_version_1: {{upgrade_version_1}}
+networkId: {{network}}
+publicMeta:
+  chainId: "{{chain}}"
+  sender: {{sender}}
+  gasLimit: 100000
+  gasPrice: 0.0000001
+  ttl: 10000

--- a/pact-tests/pact-tests/marmalade/pact/yaml/marmalade-v2/9.concrete-policies/collection-policy-v1.yaml
+++ b/pact-tests/pact-tests/marmalade/pact/yaml/marmalade-v2/9.concrete-policies/collection-policy-v1.yaml
@@ -1,0 +1,15 @@
+codeFile: ../concrete-policies/collection-policy/collection-policy-v1.pact
+signers:
+  - public: {{sender_key}}
+  - public: {{marmalade_user_key_1}}
+  - public: {{marmalade_user_key_2}}
+data:
+  ns: {{marmalade_namespace}}
+  upgrade: {{is_upgrade}}
+networkId: {{network}}
+publicMeta:
+  chainId: "{{chain}}"
+  sender: {{sender}}
+  gasLimit: 100000
+  gasPrice: 0.0000001
+  ttl: 10000

--- a/pact-tests/pact-tests/marmalade/pact/yaml/marmalade-v2/9.concrete-policies/guard-policy-v1.yaml
+++ b/pact-tests/pact-tests/marmalade/pact/yaml/marmalade-v2/9.concrete-policies/guard-policy-v1.yaml
@@ -1,0 +1,16 @@
+codeFile: ../concrete-policies/guard-policy/guard-policy-v1.pact
+signers:
+  - public: {{sender_key}}
+  - public: {{marmalade_user_key_1}}
+  - public: {{marmalade_user_key_2}}
+data:
+  ns: {{marmalade_namespace}}
+  upgrade: {{is_upgrade}}
+  upgrade_version_1: {{upgrade_version_1}}
+networkId: {{network}}
+publicMeta:
+  chainId: "{{chain}}"
+  sender: {{sender}}
+  gasLimit: 100000
+  gasPrice: 0.0000001
+  ttl: 10000

--- a/pact-tests/pact-tests/marmalade/pact/yaml/marmalade-v2/9.concrete-policies/non-fungible-policy-v1.yaml
+++ b/pact-tests/pact-tests/marmalade/pact/yaml/marmalade-v2/9.concrete-policies/non-fungible-policy-v1.yaml
@@ -1,0 +1,15 @@
+codeFile: ../concrete-policies/non-fungible-policy/non-fungible-policy-v1.pact
+signers:
+  - public: {{sender_key}}
+  - public: {{marmalade_user_key_1}}
+  - public: {{marmalade_user_key_2}}
+data:
+  ns: {{marmalade_namespace}}
+  upgrade: {{is_upgrade}}
+networkId: {{network}}
+publicMeta:
+  chainId: "{{chain}}"
+  sender: {{sender}}
+  gasLimit: 100000
+  gasPrice: 0.0000001
+  ttl: 10000

--- a/pact-tests/pact-tests/marmalade/pact/yaml/marmalade-v2/9.concrete-policies/royalty-policy-v1.yaml
+++ b/pact-tests/pact-tests/marmalade/pact/yaml/marmalade-v2/9.concrete-policies/royalty-policy-v1.yaml
@@ -1,0 +1,15 @@
+codeFile: ../concrete-policies/royalty-policy/royalty-policy-v1.pact
+signers:
+  - public: {{sender_key}}
+  - public: {{marmalade_user_key_1}}
+  - public: {{marmalade_user_key_2}}
+data:
+  ns: {{marmalade_namespace}}
+  upgrade: {{is_upgrade}}
+networkId: {{network}}
+publicMeta:
+  chainId: "{{chain}}"
+  sender: {{sender}}
+  gasLimit: 100000
+  gasPrice: 0.0000001
+  ttl: 10000

--- a/pact-tests/pact-tests/marmalade/pact/yaml/sample/add.whitelist.yaml
+++ b/pact-tests/pact-tests/marmalade/pact/yaml/sample/add.whitelist.yaml
@@ -1,0 +1,12 @@
+code: (marmalade-v2.policy-manager.add-sale-whitelist {{marmalade_sale_contract}})
+signers:
+  - public: {{sender_key}}
+  - public: {{marmalade_user_key_1}}
+  - public: {{marmalade_user_key_2}}
+networkId: {{network}}
+publicMeta:
+  chainId: "{{chain}}"
+  sender: {{sender}}
+  gasLimit: 100000
+  gasPrice: 0.0000001
+  ttl: 10000

--- a/pact-tests/pact-tests/marmalade/pact/yaml/sample/buy.royalty.yaml
+++ b/pact-tests/pact-tests/marmalade/pact/yaml/sample/buy.royalty.yaml
@@ -1,0 +1,30 @@
+
+# Assumes same fungible and marmalade account buyer
+pactTxHash: X5jiX2U9_9ktNs3jutN52kXYQiywE1S_u3WPIxv3oGw #same as sale-id. Requestkey from offer
+type: "cont"
+step: 1
+rollback: false
+signers:
+  - public: {{buyer-key}}
+    caps:
+      - name: coin.TRANSFER
+        args: ["{{buyer-account}}", "c:Z_CRfp-YeiBhSk370DUeKn9PlzVdeqq406x5-jqGnJU", 2.0] ##  "c:Z_CRfp-YeiBhSk370DUeKn9PlzVdeqq406x5-jqGnJU" is the escrow account, can be read with `(marmalade-v2.policy-manager.get-escrow-account "X5jiX2U9_9ktNs3jutN52kXYQiywE1S_u3WPIxv3oGw")`
+      - name: marmalade-v2.ledger.BUY
+        args: ["{{token-id}}", "{{seller-account}}", "{{buyer-account}}", 1.0, "X5jiX2U9_9ktNs3jutN52kXYQiywE1S_u3WPIxv3oGw" ] # last param is sale-id
+  - public: {{gas-payer-key}}
+    caps:
+      - name: coin.GAS
+        args: []
+data:
+  buyer: "{{buyer-account}}"
+  buyer-guard:
+    keys: [{{"buyer-key"}}]
+    pred: "keys-all"
+  buyer_fungible_account: "{{buyer-account}}"
+networkId: testnet04
+publicMeta:
+  chainId: "1"
+  sender: "{{gas-payer}}"
+  gasLimit: 10000
+  gasPrice: 0.0000001
+  ttl: 600

--- a/pact-tests/pact-tests/marmalade/pact/yaml/sample/create.royalty.yaml
+++ b/pact-tests/pact-tests/marmalade/pact/yaml/sample/create.royalty.yaml
@@ -1,0 +1,52 @@
+#  assumes no creator account exists, creator guard is reused to register as mint guard
+
+code: |-
+  (use marmalade-v2.ledger)
+  (use marmalade-v2.util-v1)
+
+  (coin.create-account (at 'creator (read-msg 'royalty_spec)) (at 'creator-guard (read-msg 'royalty_spec)))
+
+  (create-token
+    (create-token-id
+      {'precision: 0, 'policies: (create-policies DEFAULT_ROYALTY), 'uri: "test-uri-01"}
+      (at 'creator-guard (read-msg 'royalty_spec)) )
+    0
+    "test-uri-01"
+    (create-policies DEFAULT_ROYALTY)
+    (at 'creator-guard (read-msg 'royalty_spec))
+  )
+signers:
+  - public: {{creator-key}}
+    caps:
+      - name: marmalade-v2.ledger.CREATE-TOKEN
+        args: [ "{{token-id}}", {"pred":"keys-all","keys":["{{creator-key}}"]}]
+  - public: {{gas-payer-key}}
+    caps:
+      - name: coin.GAS
+        args: []
+data:
+  royalty_spec:
+    fungible:
+      refName:
+        namespace: null
+        name: coin
+      refSpec:
+        - namespace: null
+          name: fungible-v2
+    creator: "{{creator-account}}"
+    creator-guard:
+       keys:
+         - {{creator-key}}
+       pred: keys-all
+    royalty-rate: 0.05
+  mint_guard:
+     keys:
+       - {{creator-key}}
+     pred: keys-all
+networkId: testnet04
+publicMeta:
+  chainId: "1"
+  sender: "{{gas-payer}}"
+  gasLimit: 10000
+  gasPrice: 0.0000001
+  ttl: 600

--- a/pact-tests/pact-tests/marmalade/pact/yaml/sample/mint.royalty.yaml
+++ b/pact-tests/pact-tests/marmalade/pact/yaml/sample/mint.royalty.yaml
@@ -1,0 +1,31 @@
+# Mints marmalade token to the creator account
+code: |-
+  (marmalade-v2.ledger.mint
+    "{{token-id}}"
+    "{{creator-account}}"
+    (read-keyset 'creator-guard)
+    1.0
+  )
+signers:
+  - public: {{creator-key}}
+    caps:
+      - name: marmalade-v2.ledger.MINT
+        args: [ "{{token-id}}", "{{creator-account}}", 1.0]
+      - name: marmalade-v2.guard-policy-v1.MINT
+        args: [ "{{token-id}}", "{{creator-account}}", 1.0]
+  - public: {{gas-payer-key}}
+    caps:
+      - name: coin.GAS
+        args: []
+data:
+    creator-guard:
+       keys:
+         - {{creator-key}}
+       pred: keys-all
+networkId: testnet04
+publicMeta:
+  chainId: "1"
+  sender: "{{gas-payer}}"
+  gasLimit: 10000
+  gasPrice: 0.0000001
+  ttl: 600

--- a/pact-tests/pact-tests/marmalade/pact/yaml/sample/offer.royalty.yaml
+++ b/pact-tests/pact-tests/marmalade/pact/yaml/sample/offer.royalty.yaml
@@ -1,0 +1,40 @@
+#puts token to sale at price 2.0.
+#uses 0.0 option as timeout
+# assumes seller fungible account is the same as marmalade account
+code: |-
+  (marmalade-v2.ledger.sale
+    "{{token-id}}"
+    "{{seller-key}}"
+    1.0
+    0
+  )
+signers:
+  - public: {{seller-key}}
+    caps:
+      - name: marmalade-v2.ledger.OFFER
+        args: ["{{token-id}}", "{{seller-key}}", 1.0, {"int":0}]
+  - public: {{gas-payer-key}}
+    caps:
+      - name: coin.GAS
+        args: []
+data:
+    quote:
+      fungible:
+        refName:
+          namespace: null
+          name: coin
+        refSpec:
+          - namespace: null
+            name: fungible-v2
+      sale-price: 2.0
+      seller-fungible-account:
+        account: "{{seller-account}}"
+        guard: {"keys": ["{{seller-key}}"], "pred": "keys-all"}
+      sale-type: ""
+networkId: testnet04
+publicMeta:
+  chainId: "1"
+  sender: "{{gas-payer}}"
+  gasLimit: 10000
+  gasPrice: 0.0000001
+  ttl: 600

--- a/pact-tests/pact-tests/marmalade/pact/yaml/util/1.fungible-util.yaml
+++ b/pact-tests/pact-tests/marmalade/pact/yaml/util/1.fungible-util.yaml
@@ -1,0 +1,10 @@
+codeFile: ../util/fungible-util.pact
+signers:
+  - public: {{sender_key}}
+networkId: {{network}}
+publicMeta:
+  chainId: "{{chain}}"
+  sender: {{sender}}
+  gasLimit: 100000
+  gasPrice: 0.0000001
+  ttl: 600

--- a/pact-tests/pact-tests/marmalade/test-marmalade-v2.md
+++ b/pact-tests/pact-tests/marmalade/test-marmalade-v2.md
@@ -1,0 +1,40 @@
+# Test Marmalade V2
+
+To enable smooth migration from Marmalade V1 into Marmalade V2, V2 contracts on a test namespace on testnet for testing.
+
+## Test Namespace and Chain
+
+- Namespace: `marmalade-v2`
+- Chain ID: `1`
+
+## Interfaces
+
+- `marmalade-v2.poly-fungible-v3`
+- `marmalade-v2.token-policy-v2`
+- `marmalade-v2.policy-manager-v1`
+- `marmalade-v2.ledger-v1`
+
+## Ledger, Policy Manager, Quote Manager
+
+- `marmalade-v2.ledger`
+- `marmalade-v2.policy-manager`
+- `marmalade-v2.quote-manager`
+
+## Concrete policies
+
+- `marmalade-v2.collection-policy-v1`
+- `marmalade-v2.royalty-policy-v1`
+- `marmalade-v2.non-fungible-policy-v1`
+- `marmalade-v2.guard-policy-v1`
+
+## Example Bidding Contract
+
+- `n_9dadddb8426ba2397433bf4e6a110dab4fccead6.basic-bidding-sale`
+
+## Util
+
+- `marmalade-v2.util-v1`
+
+## Docs
+
+- [V2 README](./README.md)

--- a/tools/update-marmalade.sh
+++ b/tools/update-marmalade.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# update-marmalade.sh: Download a copy of https://github.com/kadena-io/marmalade
+# from the latest master, then extract the contents to
+# pact-tests/pact-tests/marmalade and commit them.
+
+set -eu
+[ ! -z "${DEBUG:-}" ] && set -x
+
+ROOT=$(git rev-parse --show-toplevel)
+REPO=${REPO:-kadena-io/marmalade}
+BRANCH=${BRANCH:-main}
+
+# First, make sure the repo and working copy is completely clean
+if ! git diff --quiet --exit-code; then
+  echo "Working copy is dirty; aborting"
+  exit 1
+fi
+
+# And the index, too
+if ! git diff --quiet --exit-code --cached; then
+  echo "Index is dirty; aborting"
+  exit 1
+fi
+
+# Next, get the latest commit hash. We want to put it in the commit message.
+# There's an easy one-liner
+HASH=$(curl -s -H "Accept: application/vnd.github.VERSION.sha" "https://api.github.com/repos/${REPO}/commits/${BRANCH}")
+URL="https://github.com/${REPO}/archive/${HASH}.tar.gz"
+echo "Git repo is clean; will download latest ${REPO}@${BRANCH} (${HASH})"
+
+# Delete the old marmalade dir, if needed
+if [ -d "$ROOT/pact-tests/pact-tests/marmalade" ]; then
+  echo "Removing current marmalade directory"
+  rm -rf "$ROOT/pact-tests/pact-tests/marmalade"
+fi
+
+# Then re-create it, so 'tar' can move to it and extract
+mkdir -p "$ROOT/pact-tests/pact-tests/marmalade"
+
+# Download the latest version of marmalade tarball into the dir
+echo "Downloading and extracting..."
+curl -s -L "$URL" | tar -xvz --strip-components=1 -C "$ROOT/pact-tests/pact-tests/marmalade"
+
+# Commit the changes
+echo "Committing changes..."
+git add "$ROOT/pact-tests/pact-tests/marmalade"
+git commit -m "tests: update marmalade snapshot to ${REPO}@${HASH}"


### PR DESCRIPTION
This replaces the marmalade submodule with a simple script that can be run and will automatically commit an update for you.

We've had numerous discussions about submodules recently and to keep it short: this one isn't needed and in general just causes pains. Replacing it with an occasionally-updated snapshot that exists within the repo is much better and doesn't cause so many problems (e.g. needing to constantly `git submodule update`.)

This PR is large, but only because it commits a copy of marmalade in the 3rd commit. Otherwise, it's very small, and the most important thing is the script itself, which works on my amd64/Linux machine. It should also work fine on macOS, I think.