### PR TITLE
Core: ADT-ize all errors

### DIFF
--- a/crypto/Pact/Core/Crypto/Pairing.hs
+++ b/crypto/Pact/Core/Crypto/Pairing.hs
@@ -402,7 +402,6 @@ data CurvePoint a
   | CurveInf
   deriving (Eq, Show)
 
--- todo: sort of scuffed, num instance?
 double :: (Field a, Num a, Eq a) => CurvePoint a -> CurvePoint a
 double CurveInf = CurveInf
 double (Point x y)

--- a/gasmodel/Pact/Core/GasModel/InterpreterGas.hs
+++ b/gasmodel/Pact/Core/GasModel/InterpreterGas.hs
@@ -370,7 +370,7 @@ gasMtWithHandlerError pdb =
     let es = defaultGasEvalState
         ps = _eeDefPactStep ee
         frame = Mt
-        value = VError "foo" ()
+        value = VError [] (UserEnforceError "foo") ()
         env = CEKEnv { _cePactDb=pdb
                     , _ceLocal=mempty
                     , _ceInCap=False

--- a/pact-lsp/Pact/Core/LanguageServer.hs
+++ b/pact-lsp/Pact/Core/LanguageServer.hs
@@ -254,7 +254,7 @@ sendDiagnostics nuri mv content = liftIO runPact >>= \case
       PEParseError{} -> "Parse"
       PEDesugarError{} -> "Desugar"
       PEExecutionError{} -> "Execution"
-      PERecoverableError{} -> "Execution"
+      PEUserRecoverableError{} -> "Execution"
 
 spanInfoToRange :: SpanInfo -> Range
 spanInfoToRange (SpanInfo sl sc el ec) = mkRange

--- a/pact-tests/Pact/Core/Test/GasGolden.hs
+++ b/pact-tests/Pact/Core/Test/GasGolden.hs
@@ -38,7 +38,7 @@ tests = do
   cases <- gasTestFiles
   pure $ testGroup "Gas Goldens"
     [ testCase "Capture all builtins" $ captureBuiltins (fst <$> cases)
-    , goldenVsStringDiff "Gas Goldens: CEK" runDiff (gasTestDir </> "builtinGas.golden") (gasGoldenTests cases interpretReplProgram)
+    , goldenVsStringDiff "Gas Goldens: CEK" runDiff (gasTestDir </> "builtinGas.golden") (gasGoldenTests cases interpretReplProgramBigStep)
     , goldenVsStringDiff "Gas Goldens: CEK smallstep" runDiff (gasTestDir </> "builtinGas.golden") (gasGoldenTests cases interpretReplProgramSmallStep)
     , goldenVsStringDiff "Gas Goldens: Direct" runDiff (gasTestDir </> "builtinGas.golden") (gasGoldenTests cases interpretReplProgramDirect)
     ]

--- a/pact-tests/Pact/Core/Test/LegacySerialiseTests.hs
+++ b/pact-tests/Pact/Core/Test/LegacySerialiseTests.hs
@@ -62,7 +62,7 @@ legacyTests = do
       Nothing -> error "Reading existing modules failed"
       Just ms -> do
         modTests <- fmap concat $ forM repl $ \r -> do
-          sequence [runTest r interpretReplProgram "CEK", runTest r interpretReplProgramDirect "Direct"]
+          sequence [runTest r interpretReplProgramBigStep "CEK", runTest r interpretReplProgramDirect "Direct"]
         pure (testGroup p modTests)
         where
         runTest r interpreter interpName = do

--- a/pact-tests/Pact/Core/Test/PersistenceTests.hs
+++ b/pact-tests/Pact/Core/Test/PersistenceTests.hs
@@ -234,7 +234,7 @@ sqliteRegression =
         evalLog <- newIORef Nothing
         ee <- defaultEvalEnv pdb replCoreBuiltinMap
         ref <- newIORef (ReplState mempty pdb def ee evalLog (SourceCode "" "") mempty mempty Nothing False)
-        Right _ <- runReplT ref (interpretReplProgram (SourceCode "test" src) (const (pure ())))
+        Right _ <- runReplT ref (interpretReplProgramBigStep (SourceCode "test" src) (const (pure ())))
         Just md <- readModule pdb (ModuleName "test" Nothing)
         pure md
 

--- a/pact-tests/Pact/Core/Test/ReplTests.hs
+++ b/pact-tests/Pact/Core/Test/ReplTests.hs
@@ -41,8 +41,8 @@ tests :: IO TestTree
 tests = do
   files <- replTestFiles
   pure $ testGroup "ReplTests"
-    [ testGroup "in-memory db:bigstep" (runFileReplTest interpretReplProgram <$> files)
-    , testGroup "sqlite db:bigstep" (runFileReplTestSqlite interpretReplProgram <$> files)
+    [ testGroup "in-memory db:bigstep" (runFileReplTest interpretReplProgramBigStep <$> files)
+    , testGroup "sqlite db:bigstep" (runFileReplTestSqlite interpretReplProgramBigStep <$> files)
     , testGroup "in-memory db:smallstep" (runFileReplTest interpretReplProgramSmallStep <$> files)
     , testGroup "sqlite db:smallstep" (runFileReplTestSqlite interpretReplProgramSmallStep <$> files)
     , testGroup "in-memory db:direct" (runFileReplTest interpretReplProgramDirect <$> files)

--- a/pact-tests/Pact/Core/Test/TestPrisms.hs
+++ b/pact-tests/Pact/Core/Test/TestPrisms.hs
@@ -10,4 +10,5 @@ makePrisms ''LexerError
 makePrisms ''ParseError
 makePrisms ''DesugarError
 makePrisms ''EvalError
+makePrisms ''UserRecoverableError
 makePrisms ''PactError

--- a/pact-tests/legacy-serial-tests/coin-v5/coin-v5.repl
+++ b/pact-tests/legacy-serial-tests/coin-v5/coin-v5.repl
@@ -421,7 +421,7 @@
   (transfer 'emily 'doug 1.0))
 
 (expect-failure "No account for will"
-  "no such read object"
+  "No value found in table coin:coin-table for key: will"
   (get-balance 'will))
 
 (test-capability (TRANSFER 'doug 'will 1.0))
@@ -485,7 +485,7 @@
 (env-data { "miner2": ["miner2"] })
 
 (expect-failure "no account for miner2"
-  "no such read object"
+  "No value found in table coin:coin-table for key: miner2"
   (get-balance 'miner2))
 
 (test-capability (COINBASE))

--- a/pact-tests/pact-tests/caps.repl
+++ b/pact-tests/pact-tests/caps.repl
@@ -814,7 +814,7 @@
 
 (expect-failure
  "cap guard fails on wrong cap"
- "Capability guard enforce failure cap not in scope"
+ "Capability not acquired"
  (test-cap-guard "A" "B"))
 
 (env-hash (hash 1))
@@ -831,7 +831,7 @@
 (cg-pact 'k2 'k2 "D" "E")
 (expect-failure
  "cap pact guard fails on wrong cap"
- "Capability guard enforce failure cap not in scope"
+ "Capability not acquired"
  (continue-pact 1))
 
 (pact-state true)
@@ -914,7 +914,7 @@
 
 (expect-failure
   "out-of-band call fails"
-  "Capability guard enforce failure cap not in scope"
+  "Capability not acquired"
   (call-op1 "hello" 2))
 (expect
    "normal case succeeds for both callees post-fork"

--- a/pact-tests/pact-tests/coin-v1.repl
+++ b/pact-tests/pact-tests/coin-v1.repl
@@ -422,7 +422,7 @@
   (transfer 'emily 'doug 1.0))
 
 (expect-failure "No account for will"
-  "no such read object"
+  "No value found in table coin:coin-table for key: will"
   (get-balance 'will))
 
 (test-capability (TRANSFER 'doug 'will 1.0))
@@ -484,7 +484,7 @@
 (env-data { "miner2": ["miner2"] })
 
 (expect-failure "no account for miner2"
-  "no such read object"
+  "No value found in table coin:coin-table for key: miner2"
   (get-balance 'miner2))
 
 (coinbase 'miner2 (read-keyset 'miner2) 1.0)

--- a/pact-tests/pact-tests/coin-v5.repl
+++ b/pact-tests/pact-tests/coin-v5.repl
@@ -435,7 +435,7 @@
   (transfer 'emily 'doug 1.0))
 
 (expect-failure "No account for will"
-  "no such read object"
+  "No value found in table coin:coin-table for key: will"
   (get-balance 'will))
 
 (test-capability (TRANSFER 'doug 'will 1.0))
@@ -499,7 +499,7 @@
 (env-data { "miner2": ["miner2"] })
 
 (expect-failure "no account for miner2"
-  "no such read object"
+  "No value found in table coin:coin-table for key: miner2"
   (get-balance 'miner2))
 
 (test-capability (COINBASE))

--- a/pact/Pact/Core/Capabilities.hs
+++ b/pact/Pact/Core/Capabilities.hs
@@ -107,8 +107,10 @@ data CapState name v
 instance (Ord name, Ord v) => Default (CapState name v) where
   def = CapState mempty mempty mempty mempty mempty
 
--- Todo: Is there a reason why module + name is
--- an unqualified
+-- | Our pact event type.
+--   Note: the name + module are isomorphic to a
+--   QualifiedName, but it is kept in this format currently for
+--   ease of legacy integration
 data PactEvent v
   = PactEvent
   { _peName :: Text
@@ -163,6 +165,9 @@ data Signer name v = Signer
  -- ^ clist for designating signature to specific caps
  } deriving (Eq, Ord, Show, Generic)
 
+instance (Pretty name, Pretty v) => Pretty (CapToken name v) where
+  pretty (CapToken qn args) =
+    pretty $ PrettyLispApp qn args
 
 instance (NFData name, NFData v) => NFData (Signer name v)
 instance (NFData name, NFData e) => NFData (CapForm name e)

--- a/pact/Pact/Core/Compile.hs
+++ b/pact/Pact/Core/Compile.hs
@@ -89,7 +89,6 @@ enforceNamespaceInstall info interpreter =
   useEvalState (esLoaded . loNamespace) >>= \case
     Just ns ->
       void $ interpretGuard interpreter info (_nsUser ns)
-      -- Eval.interpretGuard info bEnv (_nsUser ns)
     Nothing ->
       enforceRootNamespacePolicy
     where

--- a/pact/Pact/Core/DefPacts/Types.hs
+++ b/pact/Pact/Core/DefPacts/Types.hs
@@ -23,6 +23,7 @@ import Pact.Core.PactValue
 import Pact.Core.Names
 import Pact.Core.Hash
 import Pact.Core.ChainData
+import Pact.Core.Pretty
 
 data DefPactContinuation name v
   = DefPactContinuation
@@ -42,6 +43,10 @@ data Provenance = Provenance
     -- ^ a hash of current containing module
   } deriving (Eq, Show, Generic)
 
+instance Pretty Provenance where
+  pretty (Provenance (ChainId cid) mh) =
+    parens $
+      "Provenance" <+> pretty cid <+> pretty mh
 
 -- | `Yield` representing an object
 data Yield
@@ -79,3 +84,7 @@ instance NFData Yield
 instance NFData DefPactStep
 instance (NFData name, NFData v) => NFData (DefPactContinuation name v)
 instance NFData DefPactExec
+
+instance (Pretty name, Pretty v) => Pretty (DefPactContinuation name v) where
+  pretty (DefPactContinuation n v) =
+    pretty $ PrettyLispApp n v

--- a/pact/Pact/Core/Hash.hs
+++ b/pact/Pact/Core/Hash.hs
@@ -136,6 +136,9 @@ newtype ModuleHash = ModuleHash { _mhHash :: Hash }
   deriving (Eq, Ord, Show, Generic)
   deriving newtype (NFData)
 
+instance Pretty ModuleHash where
+  pretty (ModuleHash h) = pretty h
+
 placeholderHash :: ModuleHash
 placeholderHash = ModuleHash (Hash "#placeholder")
 

--- a/pact/Pact/Core/IR/ConstEval.hs
+++ b/pact/Pact/Core/IR/ConstEval.hs
@@ -42,8 +42,8 @@ evalModuleDefConsts interpreter (Module mname mgov defs blessed imports implemen
       DConst dc -> case _dcTerm dc of
         TermConst term -> do
           pv <- eval interpreter PSysOnly term
-          pv' <- maybeTCType (_dcInfo dc) pv (_argType $ _dcSpec dc)
-          pure (DConst (set dcTerm (EvaledConst pv') dc))
+          maybeTCType (_dcInfo dc) (_argType $ _dcSpec dc) pv
+          pure (DConst (set dcTerm (EvaledConst pv) dc))
         EvaledConst _ -> pure defn
       _ -> pure defn
     let dn = defName defn

--- a/pact/Pact/Core/IR/Term.hs
+++ b/pact/Pact/Core/IR/Term.hs
@@ -401,8 +401,8 @@ instance Pretty ty => Pretty (DefCap name ty b i) where
 
 instance Pretty ty => Pretty (DefSchema ty info) where
   pretty (DefSchema n schema i) =
-    let argList = [pretty arg | (Field k, t) <- M.toList schema, let arg = Arg k (Just t) i]
-    in parens $ "defschema" <+> pretty n <> (if null argList then mempty else " " <> hsep argList)
+    let argList = [Arg k (Just t) i | (Field k, t) <- M.toList schema]
+    in pretty $ PrettyLispApp ("defschema " <> n) argList
 
 instance Pretty (TableSchema name) where
   pretty (DesugaredTable pn) = pretty pn

--- a/pact/Pact/Core/Legacy/LegacyPactValue.hs
+++ b/pact/Pact/Core/Legacy/LegacyPactValue.hs
@@ -162,8 +162,7 @@ instance FromJSON (Legacy ModRef) where
   parseJSON = withObject "ModRef" $ \o ->
     fmap Legacy $
       ModRef <$> (_unLegacy <$> o .: "refName")
-        <*> (fmap _unLegacy <$> o .: "refSpec")
-        <*> pure Nothing
+        <*> (S.fromList . fmap _unLegacy <$> o .: "refSpec")
 
 instance FromJSON (Legacy PactValue) where
   parseJSON v = fmap Legacy $

--- a/pact/Pact/Core/ModRefs.hs
+++ b/pact/Pact/Core/ModRefs.hs
@@ -5,37 +5,33 @@ module Pact.Core.ModRefs
  ( ModRef(..)
  , mrModule
  , mrImplemented
- , mrRefined
  ) where
 
 import Control.Lens
 import Control.DeepSeq
 import Data.Set(Set)
 import GHC.Generics
+import qualified Data.Set as S
 
 import Pact.Core.Names
 import Pact.Core.Pretty
 
-import qualified Data.Set as S
 
 -- | Original module reference
 data ModRef
   = ModRef
   { _mrModule :: ModuleName
   -- ^ Original module
-  , _mrImplemented :: [ModuleName]
+  , _mrImplemented :: Set ModuleName
   -- ^ All implemented interfaces
-  , _mrRefined :: Maybe (Set ModuleName)
--- ^ The "Selected" interface from a type refinement
   }
   deriving (Show, Generic)
 
 instance NFData ModRef
 
 instance Pretty ModRef where
-  pretty (ModRef _mn _imp mref) = case mref of
-    Just ref -> "module" <> braces (pretty (S.toList ref))
-    Nothing -> "module<not refined>"
+  pretty (ModRef _mn imps) =
+    "module" <> braces (pretty (S.toList imps))
 
 instance Eq ModRef where
   m1 == m2 = _mrModule m1 == _mrModule m2

--- a/pact/Pact/Core/Names.hs
+++ b/pact/Pact/Core/Names.hs
@@ -144,6 +144,10 @@ data DynamicName
 
 instance NFData DynamicName
 
+instance Pretty DynamicName where
+  pretty (DynamicName dn call) =
+    pretty dn <> "::" <> pretty call
+
 data ParsedTyName
   = TQN QualifiedName
   | TBN BareName
@@ -311,6 +315,9 @@ makeLenses ''TypeName
 makeLenses ''NamedDeBruijn
 makeClassy ''NativeName
 
+instance Pretty NativeName where
+  pretty (NativeName n) = pretty n
+
 instance (Pretty b) => Pretty (OverloadedName b) where
   pretty (OverloadedName n nk) = case nk of
     OBound _ -> pretty n
@@ -362,6 +369,9 @@ newtype RowKey
   deriving (Eq, Ord, Show, NFData)
 
 makeLenses ''RowKey
+
+instance Pretty RowKey where
+  pretty (RowKey rk) = pretty rk
 
 -- | A Name reference which
 -- is always fully qualified after name resolution

--- a/pact/Pact/Core/Pretty.hs
+++ b/pact/Pact/Core/Pretty.hs
@@ -15,7 +15,7 @@ module Pact.Core.Pretty
 , bracketsSep
 , parensSep
 , bracesSep
--- , prettyList
+, PrettyLispApp(..)
 ) where
 
 import Data.Text(Text)
@@ -57,3 +57,13 @@ commaBrackets = encloseSep "[" "]" ","
 bracketsSep   = brackets . sep
 parensSep     = parens   . sep
 bracesSep     = braces   . sep
+
+data PrettyLispApp n arg
+  = PrettyLispApp
+  { _plOperator :: n
+  , _plOperands :: [arg]
+  } deriving (Show)
+
+instance (Pretty n, Pretty arg) => Pretty (PrettyLispApp n arg) where
+  pretty (PrettyLispApp n args) =
+    parens (pretty n <> if null args then mempty else space <> hsep (pretty <$> args))

--- a/pact/Pact/Core/Serialise/CBOR_V1.hs
+++ b/pact/Pact/Core/Serialise/CBOR_V1.hs
@@ -183,10 +183,9 @@ gasSerializeRowData (RowData fields) = do
       traverse_ (chargeGasMString . renderText) keys
 
     gasModRef :: ModRef -> GasM (PactError i) b ()
-    gasModRef (ModRef name implemented refined) = do
+    gasModRef (ModRef name implemented) = do
       chargeGasMString (renderText name)
       traverse_ (chargeGasMString . renderText) implemented
-      (traverse_ . traverse_) (chargeGasMString . renderText) refined
 
     chargeGasMString :: Text.Text -> GasM (PactError i) b ()
     chargeGasMString str = do
@@ -945,7 +944,7 @@ instance Serialise CoreBuiltin where
     _ -> fail "unexpected decoding"
 
 
-instance Serialise ReplBuiltins where
+instance Serialise ReplOnlyBuiltin where
   encode = encodeWord . fromIntegral . fromEnum
   decode = do
     vInd <- toEnum . fromIntegral <$> decodeWord
@@ -1004,8 +1003,8 @@ instance Serialise DefPactGuard where
   decode = DefPactGuard <$> decode <*> decode
 
 instance Serialise ModRef where
-  encode (ModRef mn imp ref) = encode mn <> encode imp <> encode ref
-  decode = ModRef <$> decode <*> decode <*> decode
+  encode (ModRef mn imp) = encode mn <> encode imp
+  decode = ModRef <$> decode <*> decode
 
 instance Serialise (CapToken FullyQualifiedName PactValue) where
   encode (CapToken n a) = encode n <> encode a

--- a/pact/Pact/Core/Serialise/LegacyPact.hs
+++ b/pact/Pact/Core/Serialise/LegacyPact.hs
@@ -430,8 +430,8 @@ fromLegacyPactValue = \case
       pure (PGuard $ GCapabilityGuard (CapabilityGuard qn args (fromLegacyPactId <$> i)))
   Legacy.PModRef (Legacy.ModRef mn mmn) -> let
     mn' = fromLegacyModuleName mn
-    imp = fmap fromLegacyModuleName (fromMaybe [] mmn)
-    in pure (PModRef $ ModRef mn' imp Nothing)
+    imp = S.fromList $ fmap fromLegacyModuleName (fromMaybe [] mmn)
+    in pure (PModRef $ ModRef mn' imp)
 
 
 fromLegacyPersistDirect
@@ -708,8 +708,8 @@ fromLegacyTerm mh = \case
 
   Legacy.TModRef (Legacy.ModRef mn mmn) -> let
     mn' = fromLegacyModuleName mn
-    imp = fmap fromLegacyModuleName (fromMaybe [] mmn)
-    in pure (InlineValue (PModRef (ModRef mn' imp Nothing)) ())
+    imp = S.fromList $ fmap fromLegacyModuleName (fromMaybe [] mmn)
+    in pure (InlineValue (PModRef (ModRef mn' imp)) ())
 
   _ -> throwError "fromLegacyTerm: invariant"
 

--- a/pact/Pact/Core/SizeOf.hs
+++ b/pact/Pact/Core/SizeOf.hs
@@ -27,7 +27,7 @@ module Pact.Core.SizeOf
   , wordSize
   , SizeOfVersion(..)
 
-  -- * SizeOf 
+  -- * SizeOf
   , countBytes
 
   ) where
@@ -386,7 +386,7 @@ instance SizeOf SpanInfo
 
 -- builtins
 instance SizeOf CoreBuiltin
-instance SizeOf ReplBuiltins
+instance SizeOf ReplOnlyBuiltin
 instance SizeOf b => SizeOf (ReplBuiltin b)
 
 

--- a/pact/Pact/Core/StableEncoding.hs
+++ b/pact/Pact/Core/StableEncoding.hs
@@ -17,7 +17,7 @@ import Data.Ratio ((%), denominator)
 import Data.ByteString (ByteString)
 import qualified Data.Text as T
 import qualified Pact.JSON.Encode as J
-import qualified Data.Set as Set
+import qualified Data.Set as S
 
 import Pact.Core.PactValue
 import Pact.Core.Literal
@@ -131,7 +131,7 @@ instance J.Encode (StableEncoding KeySetName) where
 instance J.Encode (StableEncoding KeySet) where
   build (StableEncoding (KeySet keys predFun)) =J.object
     [ "pred" J..= StableEncoding predFun
-    , "keys" J..= J.Array (Set.map StableEncoding keys) -- TODO: is this valid?
+    , "keys" J..= J.Array (S.map StableEncoding keys) -- TODO: is this valid?
     ]
   {-# INLINABLE build #-}
 
@@ -169,8 +169,8 @@ instance J.Encode (StableEncoding ModuleName) where
 
 -- | Stable encoding of `ModRef`
 instance J.Encode (StableEncoding ModRef) where
-  build (StableEncoding (ModRef mn imp _ref)) = J.object
-    [ "refSpec" J..= Just (J.Array (StableEncoding <$> imp))
+  build (StableEncoding (ModRef mn imp)) = J.object
+    [ "refSpec" J..= Just (J.Array (StableEncoding <$> S.toList imp))
     , "refName" J..= StableEncoding mn
     ]
   {-# INLINABLE build #-}

--- a/pact/Pact/Core/StackFrame.hs
+++ b/pact/Pact/Core/StackFrame.hs
@@ -47,4 +47,4 @@ instance NFData i => NFData (StackFrame i)
 
 instance Pretty (StackFrame i) where
   pretty (StackFrame sfn args _ _) =
-    parens (pretty sfn <> if null args then mempty else space <> hsep (pretty <$> args))
+    pretty $ PrettyLispApp sfn args

--- a/pact/Pact/Core/Type.hs
+++ b/pact/Pact/Core/Type.hs
@@ -227,6 +227,16 @@ data DefKind
 
 instance NFData DefKind
 
+instance Pretty DefKind where
+  pretty = \case
+    DKDefun -> "defun"
+    DKDefConst -> "defconst"
+    DKDefCap -> "defcap"
+    DKDefPact -> "defpact"
+    DKDefSchema _ -> "defscema"
+    DKDefTable -> "deftable"
+
+
 -- instance Pretty n => Pretty (Pred n) where
 --   pretty (Pred tc ty) = pretty tc <>  Pretty.angles (pretty ty)
 


### PR DESCRIPTION
This PR aims to do a few things:
- Add stack frames back to user emitted errors (via `VError` propagating frames in the CEK machine, and the `UserRecoverableError` type in the direct style)
- Fix the pretty printing of all of our errors (a longstanding TODO)
- Clean up code related to messy errors and unused error constructors
- Reevaluate what our actual "Invariant Failures" are, and turn those into an ADT as well.


Post-this PR, the repl output becomes:
```
pact>(ff 1)
(interactive):1:43: boom
 1 | (ff 1)
   |                                            ^^^^^^^^^^^^^^^^^^^^^^
  at (m.f)
  at (m.ff 1)
```

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output

