### PR TITLE
Core: Add benchmarks for Common contracts

### DIFF
--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -122,7 +122,7 @@ main = do
   --
   -- 1 milligas = 2.5 nanoseconds
 
-  let encode = ignoreGas () . encodeRowData def ()
+  let encode = ignoreGas () . encodeRowData
 
   print "Running..."
   defaultMain
@@ -170,37 +170,37 @@ main = do
 
     -- 1700 nanos ()/ 10 chars
     , bench "row-data 1b" $ nfIO $ encode rd1b
-    
+
     -- 1954 nanos () / 1000 characters
-    , bench "row-data 2b" $ nfIO $ (ignoreGas () . encodeRowData def ()) rd2b
+    , bench "row-data 2b" $ nfIO $ (ignoreGas () . encodeRowData) rd2b
 
     -- 337 micros () / 1_000_000 characters
-    , bench "row-data 3b" $ nfIO $ (ignoreGas () . encodeRowData def ()) rd3b
+    , bench "row-data 3b" $ nfIO $ (ignoreGas () . encodeRowData) rd3b
 
     -- 144 micros (57600 milligas) : 1000 small integers
-    , bench "pact-integer-1" $ nfIO $ (ignoreGas () . encodeRowData def ()) int1
+    , bench "pact-integer-1" $ nfIO $ (ignoreGas () . encodeRowData) int1
 
     -- 190 micros (76000 milligas) : 1000 large integers (1e12).
     -- (this - pact-integer-2) / 1000 = 46 nanos per integer, when we move
     -- from 1 digit to 12 digits. Each digit adds 4 nanos, or 2 milligas.
-    , bench "pact-integer-2" $ nfIO $ (ignoreGas () . encodeRowData def ()) int2
+    , bench "pact-integer-2" $ nfIO $ (ignoreGas () . encodeRowData) int2
 
     -- 381 micros (152400 milligas) : 2000 large integers (1e12).
     -- This bench differs from pact-integer-2 by having 2000 integers instead of 1000.
     -- It takes about twice as long as pact-integer-2, validating the linear
     -- effect of integer count on encoding time.
-    , bench "pact-integer-3" $ nfIO $ (ignoreGas () . encodeRowData def ()) int3
+    , bench "pact-integer-3" $ nfIO $ (ignoreGas () . encodeRowData) int3
 
     -- 154 micros (61600 milligas) : 1000 strings of length 1
-    , bench "pact-string-1" $ nfIO $ (ignoreGas () . encodeRowData def ()) str1
+    , bench "pact-string-1" $ nfIO $ (ignoreGas () . encodeRowData) str1
 
     -- 327 micros (130800 milligas) : 1000 strings of length 1000.
     -- This bench differs from pact-string-1 by using strings of length 1000
     -- instead of strings of length 1.
     -- It takes an extra 173 micros, 173 nanos (69 milligas) per element.
     -- So the gas cost of a string is 69 milligas per 1000 characters.
-    , bench "pact-string-2" $ nfIO $ (ignoreGas () . encodeRowData def ()) str2
-    
+    , bench "pact-string-2" $ nfIO $ (ignoreGas () . encodeRowData) str2
+
     -- 652 micros. This bench differs from pact-string-2 by having twice
     -- as many elements, and it takes twice as long, as expected.
     , bench "pact-string-3" $ nfIO $ encode str3

--- a/gasmodel/Main.hs
+++ b/gasmodel/Main.hs
@@ -7,11 +7,14 @@ import qualified Criterion.Main as C
 
 import Pact.Core.GasModel.InterpreterGas as InterpreterGas
 import Pact.Core.GasModel.BuiltinsGas as BuiltinsGas
+import Pact.Core.GasModel.ContractBench as ContractBench
 
 main :: IO ()
 main = do
+  contractBenches <- ContractBench.allBenchmarks
   C.defaultMain
-    [ InterpreterGas.benchmarks
+    [ contractBenches
+    , InterpreterGas.benchmarks
     , BuiltinsGas.benchmarks
     ]
 

--- a/gasmodel/Main.hs
+++ b/gasmodel/Main.hs
@@ -8,12 +8,13 @@ import qualified Criterion.Main as C
 import Pact.Core.GasModel.InterpreterGas as InterpreterGas
 import Pact.Core.GasModel.BuiltinsGas as BuiltinsGas
 import Pact.Core.GasModel.ContractBench as ContractBench
+import qualified System.Environment as Env
 
 main :: IO ()
 main = do
-  contractBenches <- ContractBench.allBenchmarks
+  v <- Env.lookupEnv "RESET_COIN_BENCH_DB"
   C.defaultMain
-    [ contractBenches
+    [ ContractBench.allBenchmarks (v == Just "1")
     , InterpreterGas.benchmarks
     , BuiltinsGas.benchmarks
     ]

--- a/gasmodel/Pact/Core/GasModel/BuiltinsGas.hs
+++ b/gasmodel/Pact/Core/GasModel/BuiltinsGas.hs
@@ -11,6 +11,7 @@ import qualified Data.Set as S
 import qualified Data.Text as T
 import qualified Data.Vector as V
 import qualified Database.SQLite3 as SQL
+import Control.Lens(over, _2)
 import Control.Monad
 import Data.Bifunctor
 import Data.Default
@@ -901,6 +902,7 @@ benchmarks = C.envWithCleanup mkPactDb cleanupPactDb $ \ ~(pdb, _db) -> do
     , not $ null benches
     ]
   where
-  mkPactDb = unsafeCreateSqlitePactDb serialisePact ":memory:"
+  mkPactDb =
+    over _2 SqliteDbNF <$> unsafeCreateSqlitePactDb serialisePact ":memory:"
 
-  cleanupPactDb (_, db) = SQL.close db
+  cleanupPactDb (_, SqliteDbNF db) = SQL.close db

--- a/gasmodel/Pact/Core/GasModel/ContractBench.hs
+++ b/gasmodel/Pact/Core/GasModel/ContractBench.hs
@@ -1,0 +1,334 @@
+
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE DataKinds #-}
+
+module Pact.Core.GasModel.ContractBench where
+
+
+import Control.Lens
+import Control.Monad
+import Criterion
+import Control.Exception
+import Data.Text(Text)
+import Data.Default
+import System.Directory
+import System.FilePath
+import NeatInterpolation (text)
+import Control.Monad.Except
+import Data.IORef
+import Data.Map.Strict(Map)
+import Data.Set(Set)
+import qualified Data.Map.Strict as M
+import qualified Data.Set as S
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import qualified Database.SQLite3.Direct as SQL
+
+import Pact.Core.Environment
+import Pact.Core.Names
+import Pact.Core.Capabilities
+import Pact.Core.PactValue
+import Pact.Core.Guards
+import Pact.Core.IR.Desugar
+import Pact.Core.IR.Eval.Runtime
+import Pact.Core.Compile
+import Pact.Core.Evaluate
+import Pact.Core.Hash
+import Pact.Core.Persistence
+import Pact.Core.Builtin
+import Pact.Core.SPV
+import qualified Pact.Core.Syntax.Parser as Lisp
+import qualified Pact.Core.Syntax.Lexer as Lisp
+import qualified Pact.Core.Syntax.LexUtils as Lisp
+import qualified Pact.Core.IR.Eval.CEK as CEK
+import qualified Pact.Core.IR.Eval.CoreBuiltin as CEK
+import qualified Pact.Core.IR.Eval.Direct.Evaluator as Direct
+import Pact.Core.Gas.TableGasModel
+import Pact.Core.Gas
+import Pact.Core.Namespace
+import Pact.Core.Serialise
+import Pact.Core.Persistence.MockPersistence
+
+import Pact.Core.Info
+import Pact.Core.Errors
+import Pact.Core.Interpreter
+import Pact.Core.Persistence.SQLite
+import Pact.Core.GasModel.Utils
+import Data.Decimal
+import Criterion.Main
+import Pact.Core.Pretty
+import qualified Data.Text.Encoding as T
+
+parseOnlyExpr :: Text -> Either PactErrorI Lisp.ParsedExpr
+parseOnlyExpr =
+  Lisp.lexer >=> Lisp.parseExpr
+
+contractsPath :: FilePath
+contractsPath = "gasmodel" </> "contracts"
+
+-- | Create a single-key keyset
+mkKs :: PublicKeyText -> PactValue
+mkKs a = PGuard $ GKeyset $ KeySet (S.singleton a) KeysAll
+
+interpretBigStep :: Interpreter CoreBuiltin SpanInfo (EvalM CoreBuiltin SpanInfo)
+interpretBigStep =
+  Interpreter runGuard runTerm
+  where
+  runTerm purity term = CEK.eval purity eEnv term
+  runGuard info g = CEK.interpretGuard info eEnv g
+  eEnv = CEK.coreBuiltinEnv @CEK.CEKBigStep
+
+interpretDirect :: Interpreter CoreBuiltin SpanInfo (EvalM CoreBuiltin SpanInfo)
+interpretDirect =
+  Interpreter runGuard runTerm
+  where
+  runTerm purity term = Direct.eval purity eEnv term
+  runGuard info g = Direct.interpretGuard info eEnv g
+  eEnv = Direct.coreBuiltinEnv
+
+
+data CoinBenchSenders
+  = CoinBenchSenderA
+  | CoinBenchSenderB
+  | CoinBenchSenderC
+  | CoinBenchSenderD
+  deriving Show
+
+getSender :: CoinBenchSenders -> String
+getSender = drop 9 . show
+
+pubKeyFromSenderRaw :: CoinBenchSenders -> Text
+pubKeyFromSenderRaw = \case
+  CoinBenchSenderA -> senderKeyA
+  CoinBenchSenderB -> senderKeyB
+  CoinBenchSenderC -> senderKeyC
+  CoinBenchSenderD -> senderKeyD
+
+kColonFromSender :: CoinBenchSenders -> Text
+kColonFromSender = ("k:" <>) . pubKeyFromSenderRaw
+
+pubKeyFromSender :: CoinBenchSenders -> PublicKeyText
+pubKeyFromSender = PublicKeyText . pubKeyFromSenderRaw
+
+coinTableName :: TableName
+coinTableName = TableName "coin-table" (ModuleName "coin" Nothing)
+
+prePopulateCoinEntries :: Default i => PactDb b i -> IO ()
+prePopulateCoinEntries pdb = forM_ [1 :: Integer .. 100_000] $ \i -> do
+  let n = renderCompactText $ pactHash $ T.encodeUtf8 $ T.pack (show i)
+  let obj = M.fromList [(Field "balance", PDecimal 100), (Field "guard", PGuard (GKeyset (KeySet (S.singleton (PublicKeyText n)) KeysAll)))]
+  ignoreGas def $ _pdbWrite pdb Write (DUserTables coinTableName) (RowKey n) (RowData obj)
+
+
+senderKeyA :: Text
+senderKeyA = T.replicate 64 "a"
+senderKeyB :: Text
+senderKeyB = T.replicate 63 "a" <> "b"
+senderKeyC :: Text
+senderKeyC = T.replicate 63 "a" <> "c"
+senderKeyD :: Text
+senderKeyD = T.replicate 63 "a" <> "d"
+
+coinInitData :: PactValue
+coinInitData = PObject $ M.fromList $
+  [ (Field "a", mkKs (pubKeyFromSender CoinBenchSenderA))
+  , (Field "b", mkKs (pubKeyFromSender CoinBenchSenderB))
+  , (Field "c", mkKs (pubKeyFromSender CoinBenchSenderC))
+  , (Field "d", mkKs (pubKeyFromSender CoinBenchSenderD))
+  ]
+
+coinInitSigners :: M.Map PublicKeyText (Set (CapToken QualifiedName PactValue))
+coinInitSigners = M.fromList $ fmap (over _1 PublicKeyText) $
+  [ (senderKeyA, mempty)
+  , (senderKeyB, mempty)
+  , (senderKeyC, mempty)
+  , (senderKeyD, mempty)
+  ]
+
+benchmarkSqliteFile :: String
+benchmarkSqliteFile = "core-benches.sqlite"
+
+transferCapFromSender :: CoinBenchSenders -> CoinBenchSenders -> Decimal -> CapToken QualifiedName PactValue
+transferCapFromSender sender receiver amount =
+  CapToken (QualifiedName "TRANSFER" (ModuleName "coin" Nothing))
+    [ PString (kColonFromSender sender)
+    , PString (kColonFromSender receiver)
+    , PDecimal amount]
+
+runPactTxFromSource
+  :: EvalEnv CoreBuiltin SpanInfo
+  -> Text
+  -> Interpreter CoreBuiltin SpanInfo (EvalM CoreBuiltin SpanInfo)
+  -> IO (Either (PactError SpanInfo) [CompileValue SpanInfo],EvalState CoreBuiltin SpanInfo)
+runPactTxFromSource ee source interpreter = runEvalM ee def $ do
+  program <- liftEither $ parseOnlyProgram source
+  traverse (interpretTopLevel interpreter) program
+
+setupBenchEvalEnv
+  :: PactDb CoreBuiltin i
+  -> Map PublicKeyText (Set (CapToken QualifiedName PactValue))
+  -> PactValue -> IO (EvalEnv CoreBuiltin i)
+setupBenchEvalEnv pdb signers mBody = do
+  gasRef <- newIORef mempty
+  pure $ EvalEnv
+    { _eeMsgSigs = signers
+    , _eeMsgVerifiers = mempty
+    , _eePactDb = pdb
+    , _eeMsgBody = mBody
+    , _eeHash = defaultPactHash
+    , _eePublicData = def
+    , _eeDefPactStep = Nothing
+    , _eeMode = Transactional
+    , _eeFlags = S.fromList [FlagEnforceKeyFormats, FlagRequireKeysetNs]
+    , _eeNatives = coreBuiltinMap
+    , _eeNamespacePolicy = SimpleNamespacePolicy
+    , _eeGasRef = gasRef
+    , _eeGasModel = tableGasModel (MilliGasLimit (MilliGas 200_000_000))
+    , _eeSPVSupport = noSPVSupport
+    }
+
+
+setupCoinTxs :: PactDb CoreBuiltin SpanInfo -> IO ()
+setupCoinTxs pdb = do
+  source <- T.readFile (contractsPath </> "coin-v5-create.pact")
+  ee <- setupBenchEvalEnv pdb coinInitSigners coinInitData
+  () <$ runPactTxFromSource ee source evalDirectInterpreter
+
+
+_run :: IO ()
+_run = do
+  pdb <- mockPactDb serialisePact_raw_spaninfo
+  setupCoinTxs pdb >>= print
+
+coinTransferTxRaw :: Text -> Text -> Text
+coinTransferTxRaw sender receiver =
+  [text| (coin.transfer "$sender" "$receiver" 200.0) |]
+
+coinTransferCreateTxRaw :: Text -> Text -> Text -> Text
+coinTransferCreateTxRaw sender receiver receiverKs =
+  [text| (coin.transfer-create "$sender" "$receiver" (read-keyset "$receiverKs") 200.0) |]
+
+getRightIO :: Exception e => Either e a -> IO a
+getRightIO = either throwIO pure
+
+resetEEGas :: EvalEnv b i -> IO ()
+resetEEGas ee =
+  writeIORef (_eeGasRef ee) mempty
+
+runCoinTransferTx
+  :: PactDb CoreBuiltin SpanInfo
+  -> CoinBenchSenders
+  -> CoinBenchSenders
+  -> Interpreter CoreBuiltin SpanInfo (EvalM CoreBuiltin SpanInfo)
+  -> String
+  -> Benchmark
+runCoinTransferTx pdb sender receiver interp interpName =
+  envWithCleanup mkTerm doRollback $ \ ~(term, ee, es) ->
+    bench title $ nfIO $ runEvalM ee es (eval interp PImpure term)
+    where
+    title =
+      "Coin transfer from "
+      <> getSender sender
+      <> " to "
+      <> getSender receiver
+      <> " using: "
+      <> interpName
+    mkTerm = do
+      ee <- setupBenchEvalEnv pdb (transferSigners sender receiver) (PObject mempty)
+      let termText = coinTransferTxRaw (kColonFromSender sender) (kColonFromSender receiver)
+      -- note, we will return this eval state, as it definitely contains the loaded coin contract here.
+      (eterm, es) <- runEvalM ee def $ do
+        t <- liftEither $ parseOnlyExpr termText
+        _dsOut <$> runDesugarTerm t
+      term <- getRightIO eterm
+      pure (term, ee, es)
+    doRollback _ = do
+      _pdbRollbackTx pdb
+      _pdbBeginTx pdb Transactional
+
+runCoinTransferTxDesugar
+  :: PactDb CoreBuiltin SpanInfo
+  -> CoinBenchSenders
+  -> CoinBenchSenders
+  -> Interpreter CoreBuiltin SpanInfo (EvalM CoreBuiltin SpanInfo)
+  -> String
+  -> Benchmark
+runCoinTransferTxDesugar pdb sender receiver interp interpName =
+  envWithCleanup mkTerm doRollback $ \ ~(term, ee) ->
+    bench title $ nfIO $ runEvalM ee def $ do
+      t <- runDesugarTerm term
+      eval interp PImpure (_dsOut t)
+    where
+    title =
+      "Coin transfer from "
+      <> getSender sender
+      <> " to "
+      <> getSender receiver
+      <> " including name resolution: "
+      <> interpName
+    mkTerm = do
+      ee <- setupBenchEvalEnv pdb (transferSigners sender receiver) (PObject mempty)
+      let termText = coinTransferTxRaw (kColonFromSender sender) (kColonFromSender receiver)
+      -- note, we will return this eval state, as it definitely contains the loaded coin contract here.
+      parsedTerm <- getRightIO $ parseOnlyExpr termText
+      pure (parsedTerm, ee)
+    doRollback _ = do
+      _pdbRollbackTx pdb
+      _pdbBeginTx pdb Transactional
+
+transferSigners :: CoinBenchSenders -> CoinBenchSenders -> Map PublicKeyText (Set (CapToken QualifiedName PactValue))
+transferSigners sender receiver =
+  M.singleton (pubKeyFromSender sender) (S.singleton (transferCapFromSender sender receiver 200.0))
+
+allBenchmarks :: IO Benchmark
+allBenchmarks = do
+  c <- doesFileExist benchmarkSqliteFile
+  when c $ removeFile benchmarkSqliteFile
+  pure $ envWithCleanup mkPactDb cleanupPactDb $ \ ~(pdb, _db) ->
+    bgroup "Coin benches"
+      [coinTransferBenches pdb]
+  where
+  coinTransferBenches pdb =
+    bgroup "transfer benchmarks"
+    [ runCoinTransferTx pdb CoinBenchSenderA CoinBenchSenderB interpretBigStep "CEK"
+    , runCoinTransferTx pdb CoinBenchSenderA CoinBenchSenderB interpretDirect "Direct"
+    , runCoinTransferTxDesugar pdb CoinBenchSenderA CoinBenchSenderB interpretBigStep "CEK"
+    , runCoinTransferTxDesugar pdb CoinBenchSenderA CoinBenchSenderB interpretDirect "Direct"
+    ]
+  mkPactDb = do
+    (pdb, db) <- unsafeCreateSqlitePactDb serialisePact_raw_spaninfo (T.pack benchmarkSqliteFile)
+    _ <- _pdbBeginTx pdb Transactional
+    _ <- setupCoinTxs pdb
+    _ <- _pdbCommitTx pdb
+    _ <- _pdbBeginTx pdb Transactional
+    prePopulateCoinEntries pdb
+    _ <- _pdbCommitTx pdb
+    _ <- _pdbBeginTx pdb Transactional
+    pure (pdb, SqliteDbNF db)
+  cleanupPactDb (pdb, SqliteDbNF db) = do
+    _pdbRollbackTx pdb
+    SQL.close db
+
+_testRunBench :: IO ()
+_testRunBench = do
+  b <- allBenchmarks
+  defaultMain [b]
+
+_testCoinTransfer :: IO ()
+_testCoinTransfer = withSqlitePactDb serialisePact_raw_spaninfo (T.pack benchmarkSqliteFile) $ \pdb -> do
+  _ <- _pdbBeginTx pdb Transactional
+  p <- setupCoinTxs pdb
+  print p
+  _ <- _pdbCommitTx pdb *> _pdbBeginTx pdb Transactional
+  ee <- setupBenchEvalEnv pdb (transferSigners CoinBenchSenderA CoinBenchSenderB) (PObject mempty)
+  let termText = coinTransferTxRaw (kColonFromSender CoinBenchSenderA) (kColonFromSender CoinBenchSenderB)
+  print termText
+  -- note, we will return this eval state, as it definitely contains the loaded coin contract here.
+  (eterm, es) <- runEvalM ee def $ do
+    t <- liftEither $ parseOnlyExpr termText
+    _dsOut <$> runDesugarTerm t
+  term <- getRightIO eterm
+  (out, _) <- runEvalM ee es (eval interpretDirect PImpure term)
+  print out

--- a/gasmodel/Pact/Core/GasModel/InterpreterGas.hs
+++ b/gasmodel/Pact/Core/GasModel/InterpreterGas.hs
@@ -54,12 +54,12 @@ benchmarks = C.envWithCleanup mkPactDb cleanupPactDb $ \ ~(pdb, _db) -> do
   C.bgroup "pact-core-term-gas" [staticExecutionBenchmarks pdb, termGas pdb, interpReturnGas pdb]
   where
   mkPactDb = do
-    tup@(pdb, _) <- unsafeCreateSqlitePactDb serialisePact ":memory:"
+    (pdb, db) <- unsafeCreateSqlitePactDb serialisePact ":memory:"
     ignoreGas def $ prepopulateDb pdb
     _ <- _pdbBeginTx pdb Transactional
-    pure tup
+    pure (pdb, SqliteDbNF db)
 
-  cleanupPactDb (_, db) = SQL.close db
+  cleanupPactDb (_, SqliteDbNF db) = SQL.close db
 
 gasVarBound :: Int -> EvalEnv CoreBuiltin () -> EvalState CoreBuiltin () -> C.Benchmark
 gasVarBound n ee es = do

--- a/gasmodel/Pact/Core/GasModel/Utils.hs
+++ b/gasmodel/Pact/Core/GasModel/Utils.hs
@@ -56,9 +56,12 @@ benchmarkEnv = coreBuiltinEnv @CEKSmallStep
 benchmarkBigStepEnv :: BuiltinEnv CEKBigStep CoreBuiltin () Eval
 benchmarkBigStepEnv = coreBuiltinEnv @CEKBigStep
 
+newtype SqliteDbNF
+  = SqliteDbNF SQL.Database
+
 -- NOTE: NECESSARY ORPHAN, otherwise we cannot simply make and
 -- cleanup sqlite pact db instances.
-instance NFData SQL.Database where
+instance NFData SqliteDbNF where
   rnf _ = ()
 
 gmSigs :: Map PublicKeyText (S.Set (CapToken QualifiedName PactValue))

--- a/gasmodel/contracts/coin-v5-create.pact
+++ b/gasmodel/contracts/coin-v5-create.pact
@@ -860,5 +860,5 @@
 (create-table allocation-table)
 (write coin-table "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {"balance":100000.0, "guard":(read-keyset "a")})
 (write coin-table "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab" {"balance":100000.0, "guard":(read-keyset "b")})
-(write coin-table "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaac" {"balance":100000.0, "guard":(read-keyset "c")})
-(write coin-table "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaad" {"balance":100000.0, "guard":(read-keyset "d")})
+;  (write coin-table "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaac" {"balance":100000.0, "guard":(read-keyset "c")})
+;  (write coin-table "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaad" {"balance":100000.0, "guard":(read-keyset "d")})

--- a/gasmodel/contracts/coin-v5-create.pact
+++ b/gasmodel/contracts/coin-v5-create.pact
@@ -1,0 +1,864 @@
+(interface fungible-xchain-v1
+
+  " This interface offers a standard capability for cross-chain \
+  \ transfers and associated events. "
+
+  (defcap TRANSFER_XCHAIN:bool
+    ( sender:string
+      receiver:string
+      amount:decimal
+      target-chain:string
+    )
+    @doc " Managed capability sealing AMOUNT for transfer \
+         \ from SENDER to RECEIVER on TARGET-CHAIN. Permits \
+         \ any number of cross-chain transfers up to AMOUNT."
+
+    @managed amount TRANSFER_XCHAIN-mgr
+    )
+
+  (defun TRANSFER_XCHAIN-mgr:decimal
+    ( managed:decimal
+      requested:decimal
+    )
+    @doc " Allows TRANSFER-XCHAIN AMOUNT to be less than or \
+         \ equal managed quantity as a one-shot, returning 0.0."
+  )
+
+  (defcap TRANSFER_XCHAIN_RECD:bool
+    ( sender:string
+      receiver:string
+      amount:decimal
+      source-chain:string
+    )
+    @doc "Event emitted on receipt of cross-chain transfer."
+    @event
+  )
+)
+
+
+(interface fungible-v2
+
+  " Standard for fungible coins and tokens as specified in KIP-0002. "
+
+   ; ----------------------------------------------------------------------
+   ; Schema
+
+   (defschema account-details
+    @doc "Schema for results of 'account' operation."
+    @model [ (invariant (!= "" sender)) ]
+
+    account:string
+    balance:decimal
+    guard:guard)
+
+
+   ; ----------------------------------------------------------------------
+   ; Caps
+
+   (defcap TRANSFER:bool
+     ( sender:string
+       receiver:string
+       amount:decimal
+     )
+     @doc " Managed capability sealing AMOUNT for transfer from SENDER to \
+          \ RECEIVER. Permits any number of transfers up to AMOUNT."
+     @managed amount TRANSFER-mgr
+     )
+
+   (defun TRANSFER-mgr:decimal
+     ( managed:decimal
+       requested:decimal
+     )
+     @doc " Manages TRANSFER AMOUNT linearly, \
+          \ such that a request for 1.0 amount on a 3.0 \
+          \ managed quantity emits updated amount 2.0."
+     )
+
+   ; ----------------------------------------------------------------------
+   ; Functionality
+
+
+  (defun transfer:string
+    ( sender:string
+      receiver:string
+      amount:decimal
+    )
+    @doc " Transfer AMOUNT between accounts SENDER and RECEIVER. \
+         \ Fails if either SENDER or RECEIVER does not exist."
+    @model [ (property (> amount 0.0))
+             (property (!= sender ""))
+             (property (!= receiver ""))
+             (property (!= sender receiver))
+           ]
+    )
+
+   (defun transfer-create:string
+     ( sender:string
+       receiver:string
+       receiver-guard:guard
+       amount:decimal
+     )
+     @doc " Transfer AMOUNT between accounts SENDER and RECEIVER. \
+          \ Fails if SENDER does not exist. If RECEIVER exists, guard \
+          \ must match existing value. If RECEIVER does not exist, \
+          \ RECEIVER account is created using RECEIVER-GUARD. \
+          \ Subject to management by TRANSFER capability."
+     @model [ (property (> amount 0.0))
+              (property (!= sender ""))
+              (property (!= receiver ""))
+              (property (!= sender receiver))
+            ]
+     )
+
+   (defpact transfer-crosschain:string
+     ( sender:string
+       receiver:string
+       receiver-guard:guard
+       target-chain:string
+       amount:decimal
+     )
+     @doc " 2-step pact to transfer AMOUNT from SENDER on current chain \
+          \ to RECEIVER on TARGET-CHAIN via SPV proof. \
+          \ TARGET-CHAIN must be different than current chain id. \
+          \ First step debits AMOUNT coins in SENDER account and yields \
+          \ RECEIVER, RECEIVER_GUARD and AMOUNT to TARGET-CHAIN. \
+          \ Second step continuation is sent into TARGET-CHAIN with proof \
+          \ obtained from the spv 'output' endpoint of Chainweb. \
+          \ Proof is validated and RECEIVER is credited with AMOUNT \
+          \ creating account with RECEIVER_GUARD as necessary."
+     @model [ (property (> amount 0.0))
+              (property (!= sender ""))
+              (property (!= receiver ""))
+              (property (!= sender receiver))
+              (property (!= target-chain ""))
+            ]
+     )
+
+   (defun get-balance:decimal
+     ( account:string )
+     " Get balance for ACCOUNT. Fails if account does not exist."
+     )
+
+   (defun details:object{account-details}
+     ( account: string )
+     " Get an object with details of ACCOUNT. \
+     \ Fails if account does not exist."
+     )
+
+   (defun precision:integer
+     ()
+     "Return the maximum allowed decimal precision."
+     )
+
+   (defun enforce-unit:bool
+     ( amount:decimal )
+     " Enforce minimum precision allowed for transactions."
+     )
+
+   (defun create-account:string
+     ( account:string
+       guard:guard
+     )
+     " Create ACCOUNT with 0.0 balance, with GUARD controlling access."
+     )
+
+   (defun rotate:string
+     ( account:string
+       new-guard:guard
+     )
+     " Rotate guard for ACCOUNT. Transaction is validated against \
+     \ existing guard before installing new guard. "
+     )
+
+)
+
+
+(module coin GOVERNANCE
+
+  @doc "'coin' represents the Kadena Coin Contract. This contract provides both the \
+  \buy/redeem gas support in the form of 'fund-tx', as well as transfer,       \
+  \credit, debit, coinbase, account creation and query, as well as SPV burn    \
+  \create. To access the coin contract, you may use its fully-qualified name,  \
+  \or issue the '(use coin)' command in the body of a module declaration."
+
+  @model
+    [ (defproperty conserves-mass
+        (= (column-delta coin-table 'balance) 0.0))
+
+      (defproperty valid-account (account:string)
+        (and
+          (>= (length account) 3)
+          (<= (length account) 256)))
+    ]
+
+  (implements fungible-v2)
+  (implements fungible-xchain-v1)
+
+  ;; coin-v2
+  (bless "ut_J_ZNkoyaPUEJhiwVeWnkSQn9JT9sQCWKdjjVVrWo")
+
+  ;; coin v3
+  (bless "1os_sLAUYvBzspn5jjawtRpJWiH1WPfhyNraeVvSIwU")
+
+  ;; coin v4
+  (bless "BjZW0T2ac6qE_I5X8GE4fal6tTqjhLTC7my0ytQSxLU")
+
+  ; --------------------------------------------------------------------------
+  ; Schemas and Tables
+
+  (defschema coin-schema
+    @doc "The coin contract token schema"
+    @model [ (invariant (>= balance 0.0)) ]
+
+    balance:decimal
+    guard:guard)
+
+  (deftable coin-table:{coin-schema})
+
+  ; --------------------------------------------------------------------------
+  ; Capabilities
+
+  (defcap GOVERNANCE ()
+    (enforce false "Enforce non-upgradeability"))
+
+  (defcap GAS ()
+    "Magic capability to protect gas buy and redeem"
+    true)
+
+  (defcap COINBASE ()
+    "Magic capability to protect miner reward"
+    true)
+
+  (defcap GENESIS ()
+    "Magic capability constraining genesis transactions"
+    true)
+
+  (defcap REMEDIATE ()
+    "Magic capability for remediation transactions"
+    true)
+
+  (defcap DEBIT (sender:string)
+    "Capability for managing debiting operations"
+    (enforce-guard (at 'guard (read coin-table sender)))
+    (enforce (!= sender "") "valid sender"))
+
+  (defcap CREDIT (receiver:string)
+    "Capability for managing crediting operations"
+    (enforce (!= receiver "") "valid receiver"))
+
+  (defcap ROTATE (account:string)
+    @doc "Autonomously managed capability for guard rotation"
+    @managed
+    true)
+
+  (defcap TRANSFER:bool
+    ( sender:string
+      receiver:string
+      amount:decimal
+    )
+    @managed amount TRANSFER-mgr
+    (enforce (!= sender receiver) "same sender and receiver")
+    (enforce-unit amount)
+    (enforce (> amount 0.0) "Positive amount")
+    (compose-capability (DEBIT sender))
+    (compose-capability (CREDIT receiver))
+  )
+
+  (defun TRANSFER-mgr:decimal
+    ( managed:decimal
+      requested:decimal
+    )
+
+    (let ((newbal (- managed requested)))
+      (enforce (>= newbal 0.0)
+        (format "TRANSFER exceeded for balance {}" [managed]))
+      newbal)
+  )
+
+  (defcap TRANSFER_XCHAIN:bool
+    ( sender:string
+      receiver:string
+      amount:decimal
+      target-chain:string
+    )
+
+    @managed amount TRANSFER_XCHAIN-mgr
+    (enforce-unit amount)
+    (enforce (> amount 0.0) "Cross-chain transfers require a positive amount")
+    (compose-capability (DEBIT sender))
+  )
+
+  (defun TRANSFER_XCHAIN-mgr:decimal
+    ( managed:decimal
+      requested:decimal
+    )
+
+    (enforce (>= managed requested)
+      (format "TRANSFER_XCHAIN exceeded for balance {}" [managed]))
+    0.0
+  )
+
+  (defcap TRANSFER_XCHAIN_RECD:bool
+    ( sender:string
+      receiver:string
+      amount:decimal
+      source-chain:string
+    )
+    @event true
+  )
+
+  ; v3 capabilities
+  (defcap RELEASE_ALLOCATION
+    ( account:string
+      amount:decimal
+    )
+    @doc "Event for allocation release, can be used for sig scoping."
+    @event true
+  )
+
+  ; --------------------------------------------------------------------------
+  ; Constants
+
+  (defconst COIN_CHARSET CHARSET_LATIN1
+    "The default coin contract character set")
+
+  (defconst MINIMUM_PRECISION 12
+    "Minimum allowed precision for coin transactions")
+
+  (defconst MINIMUM_ACCOUNT_LENGTH 3
+    "Minimum account length admissible for coin accounts")
+
+  (defconst MAXIMUM_ACCOUNT_LENGTH 256
+    "Maximum account name length admissible for coin accounts")
+
+  (defconst VALID_CHAIN_IDS (map (int-to-str 10) (enumerate 0 19))
+    "List of all valid Chainweb chain ids")
+
+  ; --------------------------------------------------------------------------
+  ; Utilities
+
+  (defun enforce-unit:bool (amount:decimal)
+    @doc "Enforce minimum precision allowed for coin transactions"
+
+    (enforce
+      (= (floor amount MINIMUM_PRECISION)
+         amount)
+      (format "Amount violates minimum precision: {}" [amount]))
+    )
+
+  (defun validate-account (account:string)
+    @doc "Enforce that an account name conforms to the coin contract \
+         \minimum and maximum length requirements, as well as the    \
+         \latin-1 character set."
+
+    (enforce
+      (is-charset COIN_CHARSET account)
+      (format
+        "Account does not conform to the coin contract charset: {}"
+        [account]))
+
+    (let ((account-length (length account)))
+
+      (enforce
+        (>= account-length MINIMUM_ACCOUNT_LENGTH)
+        (format
+          "Account name does not conform to the min length requirement: {}"
+          [account]))
+
+      (enforce
+        (<= account-length MAXIMUM_ACCOUNT_LENGTH)
+        (format
+          "Account name does not conform to the max length requirement: {}"
+          [account]))
+      )
+  )
+
+  ; --------------------------------------------------------------------------
+  ; Coin Contract
+
+  (defun gas-only ()
+    "Predicate for gas-only user guards."
+    (require-capability (GAS)))
+
+  (defun gas-guard (guard:guard)
+    "Predicate for gas + single key user guards"
+    (enforce-one
+      "Enforce either the presence of a GAS cap or keyset"
+      [ (gas-only)
+        (enforce-guard guard)
+      ]))
+
+  (defun buy-gas:string (sender:string total:decimal)
+    @doc "This function describes the main 'gas buy' operation. At this point \
+    \MINER has been chosen from the pool, and will be validated. The SENDER   \
+    \of this transaction has specified a gas limit LIMIT (maximum gas) for    \
+    \the transaction, and the price is the spot price of gas at that time.    \
+    \The gas buy will be executed prior to executing SENDER's code."
+
+    @model [ (property (> total 0.0))
+             (property (valid-account sender))
+           ]
+
+    (validate-account sender)
+
+    (enforce-unit total)
+    (enforce (> total 0.0) "gas supply must be a positive quantity")
+
+    (require-capability (GAS))
+    (with-capability (DEBIT sender)
+      (debit sender total))
+    )
+
+  (defun redeem-gas:string (miner:string miner-guard:guard sender:string total:decimal)
+    @doc "This function describes the main 'redeem gas' operation. At this    \
+    \point, the SENDER's transaction has been executed, and the gas that      \
+    \was charged has been calculated. MINER will be credited the gas cost,    \
+    \and SENDER will receive the remainder up to the limit"
+
+    @model [ (property (> total 0.0))
+             (property (valid-account sender))
+             (property (valid-account miner))
+           ]
+
+    (validate-account sender)
+    (validate-account miner)
+    (enforce-unit total)
+
+    (require-capability (GAS))
+    (let*
+      ((fee (read-decimal "fee"))
+       (refund (- total fee)))
+
+      (enforce-unit fee)
+      (enforce (>= fee 0.0)
+        "fee must be a non-negative quantity")
+
+      (enforce (>= refund 0.0)
+        "refund must be a non-negative quantity")
+
+      (emit-event (TRANSFER sender miner fee)) ;v3
+
+        ; directly update instead of credit
+      (with-capability (CREDIT sender)
+        (if (> refund 0.0)
+          (with-read coin-table sender
+            { "balance" := balance }
+            (update coin-table sender
+              { "balance": (+ balance refund) }))
+
+          "noop"))
+
+      (with-capability (CREDIT miner)
+        (if (> fee 0.0)
+          (credit miner miner-guard fee)
+          "noop"))
+      )
+
+    )
+
+  (defun create-account:string (account:string guard:guard)
+    @model [ (property (valid-account account)) ]
+
+    (validate-account account)
+    (enforce-reserved account guard)
+
+    (insert coin-table account
+      { "balance" : 0.0
+      , "guard"   : guard
+      })
+    )
+
+  (defun get-balance:decimal (account:string)
+    (with-read coin-table account
+      { "balance" := balance }
+      balance
+      )
+    )
+
+  (defun details:object{fungible-v2.account-details}
+    ( account:string )
+    (with-read coin-table account
+      { "balance" := bal
+      , "guard" := g }
+      { "account" : account
+      , "balance" : bal
+      , "guard": g })
+    )
+
+  (defun rotate:string (account:string new-guard:guard)
+    (with-capability (ROTATE account)
+      (with-read coin-table account
+        { "guard" := old-guard }
+
+        (enforce-guard old-guard)
+
+        (update coin-table account
+          { "guard" : new-guard }
+          )))
+    )
+
+
+  (defun precision:integer
+    ()
+    MINIMUM_PRECISION)
+
+  (defun transfer:string (sender:string receiver:string amount:decimal)
+    @model [ (property conserves-mass)
+             (property (> amount 0.0))
+             (property (valid-account sender))
+             (property (valid-account receiver))
+             (property (!= sender receiver)) ]
+
+    (enforce (!= sender receiver)
+      "sender cannot be the receiver of a transfer")
+
+    (validate-account sender)
+    (validate-account receiver)
+
+    (enforce (> amount 0.0)
+      "transfer amount must be positive")
+
+    (enforce-unit amount)
+
+    (with-capability (TRANSFER sender receiver amount)
+      (debit sender amount)
+      (with-read coin-table receiver
+        { "guard" := g }
+
+        (credit receiver g amount))
+      )
+    )
+
+  (defun transfer-create:string
+    ( sender:string
+      receiver:string
+      receiver-guard:guard
+      amount:decimal )
+
+    @model [ (property conserves-mass) ]
+
+    (enforce (!= sender receiver)
+      "sender cannot be the receiver of a transfer")
+
+    (validate-account sender)
+    (validate-account receiver)
+
+    (enforce (> amount 0.0)
+      "transfer amount must be positive")
+
+    (enforce-unit amount)
+
+    (with-capability (TRANSFER sender receiver amount)
+      (debit sender amount)
+      (credit receiver receiver-guard amount))
+    )
+
+  (defun coinbase:string (account:string account-guard:guard amount:decimal)
+    @doc "Internal function for the initial creation of coins.  This function \
+    \cannot be used outside of the coin contract."
+
+    @model [ (property (valid-account account))
+             (property (> amount 0.0))
+           ]
+
+    (validate-account account)
+    (enforce-unit amount)
+
+    (require-capability (COINBASE))
+    (emit-event (TRANSFER "" account amount)) ;v3
+    (with-capability (CREDIT account)
+      (credit account account-guard amount))
+    )
+
+  (defun remediate:string (account:string amount:decimal)
+    @doc "Allows for remediation transactions. This function \
+         \is protected by the REMEDIATE capability"
+    @model [ (property (valid-account account))
+             (property (> amount 0.0))
+           ]
+
+    (validate-account account)
+
+    (enforce (> amount 0.0)
+      "Remediation amount must be positive")
+
+    (enforce-unit amount)
+
+    (require-capability (REMEDIATE))
+    (emit-event (TRANSFER "" account amount)) ;v3
+    (with-read coin-table account
+      { "balance" := balance }
+
+      (enforce (<= amount balance) "Insufficient funds")
+
+      (update coin-table account
+        { "balance" : (- balance amount) }
+        ))
+    )
+
+  (defpact fund-tx (sender:string miner:string miner-guard:guard total:decimal)
+    @doc "'fund-tx' is a special pact to fund a transaction in two steps,     \
+    \with the actual transaction transpiring in the middle:                   \
+    \                                                                         \
+    \  1) A buying phase, debiting the sender for total gas and fee, yielding \
+    \     TX_MAX_CHARGE.                                                      \
+    \  2) A settlement phase, resuming TX_MAX_CHARGE, and allocating to the   \
+    \     coinbase account for used gas and fee, and sender account for bal-  \
+    \     ance (unused gas, if any)."
+
+    @model [ (property (> total 0.0))
+             (property (valid-account sender))
+             (property (valid-account miner))
+             ;(property conserves-mass) not supported yet
+           ]
+
+    (step (buy-gas sender total))
+    (step (redeem-gas miner miner-guard sender total))
+    )
+
+  (defun debit:string (account:string amount:decimal)
+    @doc "Debit AMOUNT from ACCOUNT balance"
+
+    @model [ (property (> amount 0.0))
+             (property (valid-account account))
+           ]
+
+    (validate-account account)
+
+    (enforce (> amount 0.0)
+      "debit amount must be positive")
+
+    (enforce-unit amount)
+
+    (require-capability (DEBIT account))
+    (with-read coin-table account
+      { "balance" := balance }
+
+      (enforce (<= amount balance) "Insufficient funds")
+
+      (update coin-table account
+        { "balance" : (- balance amount) }
+        ))
+    )
+
+
+  (defun credit:string (account:string guard:guard amount:decimal)
+    @doc "Credit AMOUNT to ACCOUNT balance"
+
+    @model [ (property (> amount 0.0))
+             (property (valid-account account))
+           ]
+
+    (validate-account account)
+
+    (enforce (> amount 0.0) "credit amount must be positive")
+    (enforce-unit amount)
+
+    (require-capability (CREDIT account))
+    (with-default-read coin-table account
+      { "balance" : -1.0, "guard" : guard }
+      { "balance" := balance, "guard" := retg }
+      ; we don't want to overwrite an existing guard with the user-supplied one
+      (enforce (= retg guard)
+        "account guards do not match")
+
+      (let ((is-new
+             (if (= balance -1.0)
+                 (enforce-reserved account guard)
+               false)))
+
+        (write coin-table account
+          { "balance" : (if is-new amount (+ balance amount))
+          , "guard"   : retg
+          }))
+      ))
+
+  (defun check-reserved:string (account:string)
+    " Checks ACCOUNT for reserved name and returns type if \
+    \ found or empty string. Reserved names start with a \
+    \ single char and colon, e.g. 'c:foo', which would return 'c' as type."
+    (let ((pfx (take 2 account)))
+      (if (= ":" (take -1 pfx)) (take 1 pfx) "")))
+
+  (defun enforce-reserved:bool (account:string guard:guard)
+    @doc "Enforce reserved account name protocols."
+    (if (validate-principal guard account)
+      true
+      (let ((r (check-reserved account)))
+        (if (= r "")
+          true
+          (if (= r "k")
+            (enforce false "Single-key account protocol violation")
+            (enforce false
+              (format "Reserved protocol guard violation: {}" [r]))
+            )))))
+
+
+  (defschema crosschain-schema
+    @doc "Schema for yielded value in cross-chain transfers"
+    receiver:string
+    receiver-guard:guard
+    amount:decimal
+    source-chain:string)
+
+  (defpact transfer-crosschain:string
+    ( sender:string
+      receiver:string
+      receiver-guard:guard
+      target-chain:string
+      amount:decimal )
+
+    @model [ (property (> amount 0.0))
+             (property (valid-account sender))
+             (property (valid-account receiver))
+           ]
+
+    (step
+      (with-capability
+        (TRANSFER_XCHAIN sender receiver amount target-chain)
+
+        (validate-account sender)
+        (validate-account receiver)
+
+        (enforce (!= "" target-chain) "empty target-chain")
+        (enforce (!= (at 'chain-id (chain-data)) target-chain)
+          "cannot run cross-chain transfers to the same chain")
+
+        (enforce (> amount 0.0)
+          "transfer quantity must be positive")
+
+        (enforce-unit amount)
+
+        (enforce (contains target-chain VALID_CHAIN_IDS)
+          "target chain is not a valid chainweb chain id")
+
+        ;; step 1 - debit delete-account on current chain
+        (debit sender amount)
+        (emit-event (TRANSFER sender "" amount))
+
+        (let
+          ((crosschain-details:object{crosschain-schema}
+            { "receiver" : receiver
+            , "receiver-guard" : receiver-guard
+            , "amount" : amount
+            , "source-chain" : (at 'chain-id (chain-data))
+            }))
+          (yield crosschain-details target-chain)
+          )))
+
+    (step
+      (resume
+        { "receiver" := receiver
+        , "receiver-guard" := receiver-guard
+        , "amount" := amount
+        , "source-chain" := source-chain
+        }
+
+        (emit-event (TRANSFER "" receiver amount))
+        (emit-event (TRANSFER_XCHAIN_RECD "" receiver amount source-chain))
+
+        ;; step 2 - credit create account on target chain
+        (with-capability (CREDIT receiver)
+          (credit receiver receiver-guard amount))
+        ))
+    )
+
+
+  ; --------------------------------------------------------------------------
+  ; Coin allocations
+
+  (defschema allocation-schema
+    @doc "Genesis allocation registry"
+    ;@model [ (invariant (>= balance 0.0)) ]
+
+    balance:decimal
+    date:time
+    guard:guard
+    redeemed:bool)
+
+  (deftable allocation-table:{allocation-schema})
+
+  (defun create-allocation-account
+    ( account:string
+      date:time
+      keyset-ref:string
+      amount:decimal
+    )
+
+    @doc "Add an entry to the coin allocation table. This function \
+         \also creates a corresponding empty coin contract account \
+         \of the same name and guard. Requires GENESIS capability. "
+
+    @model [ (property (valid-account account)) ]
+
+    (require-capability (GENESIS))
+
+    (validate-account account)
+    (enforce (>= amount 0.0)
+      "allocation amount must be non-negative")
+
+    (enforce-unit amount)
+
+    (let
+      ((guard:guard (keyset-ref-guard keyset-ref)))
+
+      (create-account account guard)
+
+      (insert allocation-table account
+        { "balance" : amount
+        , "date" : date
+        , "guard" : guard
+        , "redeemed" : false
+        })))
+
+  (defun release-allocation
+    ( account:string )
+
+    @doc "Release funds associated with allocation ACCOUNT into main ledger.   \
+         \ACCOUNT must already exist in main ledger. Allocation is deactivated \
+         \after release."
+    @model [ (property (valid-account account)) ]
+
+    (validate-account account)
+
+    (with-read allocation-table account
+      { "balance" := balance
+      , "date" := release-time
+      , "redeemed" := redeemed
+      , "guard" := guard
+      }
+
+      (let ((curr-time:time (at 'block-time (chain-data))))
+
+        (enforce (not redeemed)
+          "allocation funds have already been redeemed")
+
+        (enforce
+          (>= curr-time release-time)
+          (format "funds locked until {}. current time: {}" [release-time curr-time]))
+
+        (with-capability (RELEASE_ALLOCATION account balance)
+
+        (enforce-guard guard)
+
+        (with-capability (CREDIT account)
+          (emit-event (TRANSFER "" account balance))
+          (credit account guard balance)
+
+          (update allocation-table account
+            { "redeemed" : true
+            , "balance" : 0.0
+            })
+
+          "Allocation successfully released to main ledger"))
+    )))
+
+)
+
+
+(create-table coin-table)
+(create-table allocation-table)
+(write coin-table "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {"balance":100000.0, "guard":(read-keyset "a")})
+(write coin-table "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab" {"balance":100000.0, "guard":(read-keyset "b")})
+(write coin-table "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaac" {"balance":100000.0, "guard":(read-keyset "c")})
+(write coin-table "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaad" {"balance":100000.0, "guard":(read-keyset "d")})

--- a/pact-tng.cabal
+++ b/pact-tng.cabal
@@ -282,6 +282,7 @@ executable gasmodel
   other-modules:
     Pact.Core.GasModel.BuiltinsGas
     Pact.Core.GasModel.InterpreterGas
+    Pact.Core.GasModel.ContractBench
     Pact.Core.GasModel.Utils
 
   ghc-options:         -Wall -threaded -rtsopts -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints

--- a/pact-tng.cabal
+++ b/pact-tng.cabal
@@ -278,6 +278,7 @@ executable gasmodel
   build-depends:
     , pact-tng
     , criterion
+    , terminal-progress-bar
 
   other-modules:
     Pact.Core.GasModel.BuiltinsGas
@@ -356,7 +357,6 @@ test-suite core-tests
     , exceptions
     , hedgehog
     , base16-bytestring
-    , directory
     , filepath
     , lens
     , mtl

--- a/pact/Pact/Core/Compile.hs
+++ b/pact/Pact/Core/Compile.hs
@@ -14,10 +14,10 @@ module Pact.Core.Compile
  , compileDesugarOnly
  , evalTopLevel
  , CompileValue(..)
+ , parseOnlyProgram
  ) where
 
 import Control.Lens
-import Control.Monad.Except
 import Control.Monad
 import Data.Maybe(mapMaybe)
 import Data.Text(Text)
@@ -63,14 +63,14 @@ type HasCompileEnv b i m
     , SizeOf b
     )
 
-_parseOnly
+parseOnlyProgram
   :: Text -> Either PactErrorI [Lisp.TopLevel SpanInfo]
-_parseOnly source = do
-  lexed <- liftEither (Lisp.lexer source)
-  liftEither (Lisp.parseProgram lexed)
+parseOnlyProgram =
+  Lisp.lexer >=> Lisp.parseProgram
 
 _parseOnlyFile :: FilePath -> IO (Either PactErrorI [Lisp.TopLevel SpanInfo])
-_parseOnlyFile fp = _parseOnly <$> T.readFile fp
+_parseOnlyFile fp = parseOnlyProgram <$> T.readFile fp
+
 
 data CompileValue i
   = LoadedModule ModuleName ModuleHash

--- a/pact/Pact/Core/Environment/Utils.hs
+++ b/pact/Pact/Core/Environment/Utils.hs
@@ -34,7 +34,7 @@ module Pact.Core.Environment.Utils
 import Control.Lens
 import Control.Applicative((<|>))
 import Control.Monad.Except
-import Control.Exception
+import Control.Exception.Safe
 import Control.Monad.IO.Class(MonadIO(..))
 import Data.Text(Text)
 import Data.Maybe(mapMaybe)

--- a/pact/Pact/Core/Evaluate.hs
+++ b/pact/Pact/Core/Evaluate.hs
@@ -21,6 +21,8 @@ module Pact.Core.Evaluate
   , EvalBuiltinEnv
   , evalTermExec
   , allModuleExports
+  , evalDirectInterpreter
+  , evalInterpreter
   ) where
 
 import Control.Lens
@@ -57,6 +59,7 @@ import Pact.Core.IR.Desugar
 import Pact.Core.Verifiers
 import Pact.Core.Interpreter
 import qualified Pact.Core.IR.Eval.CEK as Eval
+import qualified Pact.Core.IR.Eval.Direct.Evaluator as Direct
 import qualified Pact.Core.Syntax.Lexer as Lisp
 import qualified Pact.Core.Syntax.Parser as Lisp
 import qualified Pact.Core.Syntax.ParseTree as Lisp
@@ -71,6 +74,14 @@ evalInterpreter =
   runTerm purity term = Eval.eval purity env term
   runGuard info g = Eval.interpretGuard info env g
   env = coreBuiltinEnv @Eval.CEKBigStep
+
+evalDirectInterpreter :: (Default i, Show i) => Interpreter CoreBuiltin i (EvalM CoreBuiltin i)
+evalDirectInterpreter =
+  Interpreter runGuard runTerm
+  where
+  runTerm purity term = Direct.eval purity env term
+  runGuard info g = Direct.interpretGuard info env g
+  env = Direct.coreBuiltinEnv
 
 -- | Transaction-payload related environment data.
 data MsgData = MsgData

--- a/pact/Pact/Core/IR/Eval/Direct/Evaluator.hs
+++ b/pact/Pact/Core/IR/Eval/Direct/Evaluator.hs
@@ -160,11 +160,11 @@ interpretGuard
   => i
   -> BuiltinEnv b i m
   -> Guard QualifiedName PactValue
-  -> m Bool
+  -> m PactValue
 interpretGuard info bEnv g = do
   ee <- readEnv
   let eEnv = DirectEnv mempty (_eePactDb ee) bEnv (_eeDefPactStep ee) False
-  enforceGuard info eEnv g
+  PBool <$> enforceGuard info eEnv g
 
 evalResumePact
   :: (MonadEval b i m)

--- a/pact/Pact/Core/Info.hs
+++ b/pact/Pact/Core/Info.hs
@@ -5,6 +5,7 @@ module Pact.Core.Info
 
 import Data.Default
 import GHC.Generics
+import Control.DeepSeq (NFData)
 
 data SpanInfo
   = SpanInfo
@@ -16,6 +17,8 @@ data SpanInfo
 
 instance Default SpanInfo where
   def = SpanInfo 0 0 0 0
+
+instance NFData SpanInfo
 
 -- | Combine two Span infos
 -- and spit out how far down the expression spans.

--- a/pact/Pact/Core/Repl/Compile.hs
+++ b/pact/Pact/Core/Repl/Compile.hs
@@ -146,7 +146,7 @@ interpretEvalDirect =
   evalDirect purity term =
     Direct.eval purity Direct.replBuiltinEnv term
   interpretGuardDirect info g =
-    PBool <$> Direct.interpretGuard info Direct.replBuiltinEnv g
+    Direct.interpretGuard info Direct.replBuiltinEnv g
 
 
 interpretReplProgram

--- a/pact/Pact/Core/Syntax/ParseTree.hs
+++ b/pact/Pact/Core/Syntax/ParseTree.hs
@@ -12,6 +12,7 @@ import Data.Foldable(fold)
 import Data.Text(Text)
 import Data.List.NonEmpty(NonEmpty(..))
 import Data.List(intersperse)
+import GHC.Generics
 
 import qualified Data.List.NonEmpty as NE
 
@@ -20,6 +21,7 @@ import Pact.Core.Names
 import Pact.Core.Pretty
 import Pact.Core.Type(PrimType(..))
 import Pact.Core.Guards
+import Control.DeepSeq
 
 
 data Operator
@@ -27,7 +29,9 @@ data Operator
   | OrOp
   | EnforceOp
   | EnforceOneOp
-  deriving (Show, Eq, Enum, Bounded)
+  deriving (Show, Eq, Enum, Bounded, Generic)
+
+instance NFData Operator
 
 renderOp :: Operator -> Text
 renderOp = \case
@@ -55,7 +59,9 @@ data Type
   | TyTable ParsedTyName
   | TyPolyObject
   | TyAny
-  deriving (Show, Eq)
+  deriving (Show, Eq, Generic)
+
+instance NFData Type
 
 pattern TyInt :: Type
 pattern TyInt = TyPrim PrimInt
@@ -100,14 +106,16 @@ data Arg i
   { _argName :: Text
   , _argType :: Type
   , _argInfo :: i
-  } deriving (Show, Functor)
+  } deriving (Show, Functor, Generic)
 
 data MArg i
   = MArg
   { _margName :: Text
   , _margType :: Maybe Type
   , _margInfo :: i
-  } deriving (Eq, Show, Functor)
+  } deriving (Eq, Show, Functor, Generic)
+
+instance NFData i => NFData (MArg i)
 
 defName :: Def i -> Text
 defName = \case
@@ -146,7 +154,7 @@ data Defun i
   , _dfunDocs :: Maybe Text
   , _dfunModel :: [PropertyExpr i]
   , _dfunInfo :: i
-  } deriving (Show, Functor)
+  } deriving (Show, Functor, Generic)
 
 data DefConst i
   = DefConst
@@ -155,7 +163,7 @@ data DefConst i
   , _dcTerm :: Expr i
   , _dcDocs :: Maybe Text
   , _dcInfo :: i
-  } deriving (Show, Functor)
+  } deriving (Show, Functor, Generic)
 
 data DCapMeta
   = DefEvent
@@ -172,7 +180,7 @@ data DefCap i
   , _dcapModel :: [PropertyExpr i]
   , _dcapMeta :: Maybe DCapMeta
   , _dcapInfo :: i
-  } deriving (Show, Functor)
+  } deriving (Show, Functor, Generic)
 
 data DefSchema i
   = DefSchema
@@ -181,7 +189,7 @@ data DefSchema i
   , _dscDocs :: Maybe Text
   , _dscModel :: [PropertyExpr i]
   , _dscInfo :: i
-  } deriving (Show, Functor)
+  } deriving (Show, Functor, Generic)
 
 data DefTable i
   = DefTable
@@ -189,12 +197,12 @@ data DefTable i
   , _dtSchema :: ParsedName
   , _dtDocs :: Maybe Text
   , _dtInfo :: i
-  } deriving (Show, Functor)
+  } deriving (Show, Functor, Generic)
 
 data PactStep i
   = Step (Expr i) [PropertyExpr i]
   | StepWithRollback (Expr i) (Expr i) [PropertyExpr i]
-  deriving (Show, Functor)
+  deriving (Show, Functor, Generic)
 
 data DefPact i
   = DefPact
@@ -205,7 +213,7 @@ data DefPact i
   , _dpDocs :: Maybe Text
   , _dpModel :: [PropertyExpr i]
   , _dpInfo :: i
-  } deriving (Show, Functor)
+  } deriving (Show, Functor, Generic)
 
 data Managed
   = AutoManaged
@@ -219,7 +227,7 @@ data Def i
   | DSchema (DefSchema i)
   | DTable (DefTable i)
   | DPact (DefPact i)
-  deriving (Show, Functor)
+  deriving (Show, Functor, Generic)
 
 data Import
   = Import
@@ -243,14 +251,14 @@ data Module i
   , _mDoc :: Maybe Text
   , _mModel :: [PropertyExpr i]
   , _mInfo :: i
-  } deriving (Show, Functor)
+  } deriving (Show, Functor, Generic)
 
 data TopLevel i
   = TLModule (Module i)
   | TLInterface (Interface i)
   | TLTerm (Expr i)
   | TLUse Import i
-  deriving (Show, Functor)
+  deriving (Show, Functor, Generic)
 
 data Interface i
   = Interface
@@ -260,7 +268,7 @@ data Interface i
   , _ifDocs :: Maybe Text
   , _ifModel :: [PropertyExpr i]
   , _ifInfo :: i
-  } deriving (Show, Functor)
+  } deriving (Show, Functor, Generic)
 
 data IfDefun i
   = IfDefun
@@ -270,7 +278,7 @@ data IfDefun i
   , _ifdDocs :: Maybe Text
   , _ifdModel :: [PropertyExpr i]
   , _ifdInfo :: i
-  } deriving (Show, Functor)
+  } deriving (Show, Functor, Generic)
 
 data IfDefCap i
   = IfDefCap
@@ -281,7 +289,7 @@ data IfDefCap i
   , _ifdcModel :: [PropertyExpr i]
   , _ifdcMeta :: Maybe DCapMeta
   , _ifdcInfo :: i
-  } deriving (Show, Functor)
+  } deriving (Show, Functor, Generic)
 
 data IfDefPact i
   = IfDefPact
@@ -291,7 +299,7 @@ data IfDefPact i
   , _ifdpDocs :: Maybe Text
   , _ifdpModel :: [PropertyExpr i]
   , _ifdpInfo :: i
-  } deriving (Show, Functor)
+  } deriving (Show, Functor, Generic)
 
 data PropKeyword
   = KwLet
@@ -325,7 +333,7 @@ data PropertyExpr i
   | PropDelim PropDelim i
   | PropSequence [PropertyExpr i] i
   | PropConstant Literal i
-  deriving (Show, Functor)
+  deriving (Show, Functor, Generic)
 
 
 -- Interface definitions may be one of:
@@ -340,7 +348,7 @@ data IfDef i
   | IfDCap (IfDefCap i)
   | IfDSchema (DefSchema i)
   | IfDPact (IfDefPact i)
-  deriving (Show, Functor)
+  deriving (Show, Functor, Generic)
 
 instance Pretty (DefConst i) where
   pretty (DefConst (MArg dcn dcty _) term _ _) =
@@ -363,7 +371,9 @@ instance Pretty (Defun i) where
 
 data Binder i =
   Binder Text (Maybe Type) (Expr i)
-  deriving (Show, Eq, Functor)
+  deriving (Show, Eq, Functor, Generic)
+
+instance NFData i => NFData (Binder i)
 
 instance Pretty (Binder i) where
   pretty (Binder ident ty e) =
@@ -372,7 +382,9 @@ instance Pretty (Binder i) where
 data CapForm i
   = WithCapability (Expr i) (Expr i)
   | CreateUserGuard ParsedName [Expr i]
-  deriving (Show, Eq, Functor)
+  deriving (Show, Eq, Functor, Generic)
+
+instance NFData i => NFData (CapForm i)
 
 data Expr i
   = Var ParsedName i
@@ -389,7 +401,9 @@ data Expr i
   | Object [(Field, Expr i)] i
   | Binding [(Field, MArg i)] [Expr i] i
   | CapabilityForm (CapForm i) i
-  deriving (Show, Eq, Functor)
+  deriving (Show, Eq, Functor, Generic)
+
+instance (NFData i) => NFData (Expr i)
 
 data ReplSpecialForm i
   = ReplLoad Text Bool i


### PR DESCRIPTION
This PR adds pact-5 benchmarks for common contracts like coin, and marmalade.

Checklist:
- [x] Coin contract setup
- [x] Coin DB pre-population
- [x] `coin.transfer` benchmarks: CEK and Direct-style
- [ ]  `coin.transfer-create` benchmarks.

TODO: Other contract benchmarks.