### PR TITLE
Feat: Add use-alias for name resolution

### DIFF
--- a/gasmodel/Pact/Core/GasModel/Utils.hs
+++ b/gasmodel/Pact/Core/GasModel/Utils.hs
@@ -239,7 +239,8 @@ gmLoaded = Loaded
   {_loToplevel=mempty
   , _loNamespace=Nothing
   , _loModules=M.singleton gmModuleName gmModuleData
-  , _loAllLoaded=gmFqMap}
+  , _loAllLoaded=gmFqMap
+  , _loAlias=M.empty}
 
 prepopulateDb :: PactDb CoreBuiltin i -> GasM (PactError i) CoreBuiltin ()
 prepopulateDb pdb = do
@@ -339,6 +340,7 @@ withLoaded envVars = esLoaded .~ synthLoaded
     , _loToplevel = M.fromList [ (n, (mkGasModelFqn n, DKDefConst)) | n <- fst <$> envVars ]
     , _loNamespace = Nothing
     , _loAllLoaded = M.fromList [ (mkGasModelFqn n, DConst $ DefConst (Arg n Nothing ()) (EvaledConst v) ()) | (n, v) <- envVars ]
+    , _loAlias = M.empty
     }
 
 runNativeBenchmarkPrepared

--- a/pact-tests/gas-goldens/builtinGas.golden
+++ b/pact-tests/gas-goldens/builtinGas.golden
@@ -20,7 +20,7 @@ bind: 1300
 ceiling: 50
 chain-data: 500
 compose-capability: 60003937
-compose: 1461
+compose: 1761
 concat: 721
 cond: 2102
 contains: 231
@@ -48,10 +48,10 @@ enforce-keyset: 9816
 enforce-verifier: 10150
 enumerate: 230
 exp: 10000
-filter: 1461
+filter: 1761
 floor: 50
 fold-db: 100383631
-fold: 790
+fold: 1090
 format-time: 6041
 format: 1801
 hash: 150
@@ -78,7 +78,7 @@ not: 139
 not?: 139
 or?: 139
 pact-id: 60000268
-pairing-check: 67003094
+pairing-check: 67007074
 parse-time: 2102
 point-add: 5425
 poseidon-hash-hack-a-chain: 6393700
@@ -109,13 +109,14 @@ txlog: 160383431
 typeof-principal: 647
 typeof: 25
 update: 60516638
+use-alias: 1000
 validate-principal: 4940
-where: 1079
+where: 1229
 with-default-read: 60405981
 with-read: 60394506
 write: 60383431
 xor: 2000
 yield: 60002446
-zip: 3822
+zip: 4222
 |: 2000
 ~: 1000

--- a/pact-tests/gas-goldens/use-alias.repl
+++ b/pact-tests/gas-goldens/use-alias.repl
@@ -1,0 +1,27 @@
+(begin-tx)
+(module ns g
+  (defcap g () true)
+
+  (defun NOOP () 1)
+  )
+
+
+(define-namespace "A_fIcwIweiXXYXnKU59CNCAUoIXHXwQtB_D8xhEflLY" (create-user-guard (NOOP)) (create-user-guard (NOOP)))
+(commit-tx)
+
+(begin-tx)
+(env-data {"ns":"A_fIcwIweiXXYXnKU59CNCAUoIXHXwQtB_D8xhEflLY"})
+
+(namespace (read-string "ns"))
+(module call-me g
+  (defcap g () true)
+
+  (defun call-me () 2)
+  )
+(commit-tx)
+
+(begin-tx)
+(env-gas 0) ; reset gas
+(use-alias "A_fIcwIweiXXYXnKU59CNCAUoIXHXwQtB_D8xhEflLY" "Kadena")
+(Kadena.call-me.call-me)
+(commit-tx)

--- a/pact-tests/pact-tests/use-alias.repl
+++ b/pact-tests/pact-tests/use-alias.repl
@@ -1,0 +1,58 @@
+(begin-tx)
+(module ns g
+  (defcap g () true)
+
+  (defun NOOP () 1)
+  )
+
+
+(define-namespace "A_fIcwIweiXXYXnKU59CNCAUoIXHXwQtB_D8xhEflLY" (create-user-guard (NOOP)) (create-user-guard (NOOP)))
+(commit-tx)
+
+(begin-tx)
+(env-data {"ns":"A_fIcwIweiXXYXnKU59CNCAUoIXHXwQtB_D8xhEflLY"})
+
+(namespace (read-string "ns"))
+(module call-me g
+  (defcap g () true)
+
+  (defun call-me123 ()
+    456
+  )
+
+  (defun call-me-to-fail ()
+    (enforce false "boom")
+  )
+  )
+(commit-tx)
+
+(begin-tx)
+(env-data {"ns":"A_fIcwIweiXXYXnKU59CNCAUoIXHXwQtB_D8xhEflLY"})
+;  (use-alias (read-string "ns") "boop")
+(expect
+  "use-alias works for an existing namespace"
+  "Set namespace qualifier alias"
+  (use-alias (read-string "ns") "boop"))
+(expect-failure "use-alias does not work for a non-existent namespace" (use-alias "lol" "hi"))
+
+(module caller2 g
+
+  (defcap g () true)
+
+  (defun test-call-ez:integer ()
+    (boop.call-me.call-me123)
+  )
+
+  (defun test-call-error:integer ()
+    (try 123 (boop.call-me.call-me-to-fail))
+  )
+  )
+
+
+(expect "alias works - case 1" 456 (boop.call-me.call-me123))
+(expect-failure "alias works - case 2" (boop.call-me.call-me-to-fail))
+
+(expect "alias-works: inside module, case 1" 456 (test-call-ez))
+(expect "alias-works: inside module, case 2" 123 (test-call-error))
+
+(commit-tx)

--- a/pact-tests/pact-tests/use-alias.repl
+++ b/pact-tests/pact-tests/use-alias.repl
@@ -56,3 +56,5 @@
 (expect "alias-works: inside module, case 2" 123 (test-call-error))
 
 (commit-tx)
+
+(expect-failure "alias must be a valid namespace name" (use-alias (read-string "ns") "#invalid-alias"))

--- a/pact/Pact/Core/Builtin.hs
+++ b/pact/Pact/Core/Builtin.hs
@@ -215,6 +215,7 @@ data CoreBuiltin
   | CoreIdentity
   | CoreVerifySPV
   | CoreEnforceVerifier
+  | CoreUseAlias
   deriving (Eq, Show, Ord, Bounded, Enum, Generic)
 
 instance NFData CoreBuiltin
@@ -384,6 +385,7 @@ coreBuiltinToText = \case
   CoreIdentity -> "identity"
   CoreVerifySPV -> "verify-spv"
   CoreEnforceVerifier -> "enforce-verifier"
+  CoreUseAlias -> "use-alias"
 
 -- | Our `CoreBuiltin` user-facing representation.
 -- note: `coreBuiltinToUserText` is primarily for pretty printing
@@ -532,6 +534,7 @@ coreBuiltinToUserText = \case
   CoreIdentity -> "identity"
   CoreVerifySPV -> "verify-spv"
   CoreEnforceVerifier -> "enforce-verifier"
+  CoreUseAlias -> "use-alias"
 
 instance IsBuiltin CoreBuiltin where
   builtinName = NativeName . coreBuiltinToText
@@ -683,6 +686,7 @@ instance IsBuiltin CoreBuiltin where
     CoreIdentity -> 1
     CoreVerifySPV -> 2
     CoreEnforceVerifier -> 1
+    CoreUseAlias -> 2
 
 
 coreBuiltinNames :: [Text]

--- a/pact/Pact/Core/Environment/Types.hs
+++ b/pact/Pact/Core/Environment/Types.hs
@@ -206,6 +206,7 @@ data EvalState b i
   , _esCheckRecursion :: NonEmpty RecursionCheck
     -- ^ Sequence of gas expendature events.
   , _esTraceOutput :: [PactTrace b i]
+  -- ^ The tracing output from
   } deriving (Show, Generic)
 
 instance (NFData b, NFData i) => NFData (EvalState b i)

--- a/pact/Pact/Core/Gas/TableGasModel.hs
+++ b/pact/Pact/Core/Gas/TableGasModel.hs
@@ -280,7 +280,7 @@ runTableModel = \case
     CapOpRequire cnt ->
       let mgPerCap = 100
       in MilliGas $ fromIntegral $ cnt * mgPerCap
-  GCountBytes -> MilliGas 1 
+  GCountBytes -> MilliGas 1
   where
   textCompareCost str = fromIntegral $ T.length str
   -- Running CountBytes costs 0.9 MilliGas, according to the analysis in bench/Bench.hs
@@ -554,6 +554,7 @@ nativeGasTable = MilliGas . \case
   CoreIdentity -> basicWorkGas
   CoreVerifySPV -> 100_000
   CoreEnforceVerifier -> 10_000
+  CoreUseAlias -> 1_000
 
 replNativeGasTable :: ReplBuiltin CoreBuiltin -> MilliGas
 replNativeGasTable = \case

--- a/pact/Pact/Core/IR/Eval/CoreBuiltin.hs
+++ b/pact/Pact/Core/IR/Eval/CoreBuiltin.hs
@@ -1742,18 +1742,6 @@ coreDefineNamespace info b cont handler env = \case
             applyLam (C clo) [VString n, VGuard adminG] cont' handler
           _ -> throwNativeExecutionError info b $ "Fatal error: namespace manager function is not a defun"
   args -> argsError info b args
-  where
-  isValidNsFormat nsn = case T.uncons nsn of
-    Just (h, tl) ->
-      isValidNsHead h && T.all isValidNsChar tl
-    Nothing -> False
-  isValidNsHead c =
-    Char.isLatin1 c && Char.isAlpha c
-  isValidNsChar c =
-    Char.isLatin1 c && (Char.isAlphaNum c || T.elem c validSpecialChars)
-  validSpecialChars :: T.Text
-  validSpecialChars =
-    "%#+-_&$@<>=^?*!|/~"
 
 coreDescribeNamespace :: (CEKEval step b i m, MonadEval b i m) => NativeFunction step b i m
 coreDescribeNamespace info b cont handler _env = \case
@@ -1981,6 +1969,7 @@ coreUseAlias info b cont handler env = \case
     origExists <- checkNsExists (NamespaceName orig)
     unless origExists $
       throwNativeExecutionError info b "Use-alias failure: origin namespace does not exist"
+    unless (isValidNsFormat alias) $ throwNativeExecutionError info b "invalid namespace format"
     (esLoaded . loAlias) %== M.insert (NamespaceAlias alias) (NamespaceName orig)
     returnCEKValue cont handler (VString "Set namespace qualifier alias")
   args -> argsError info b args

--- a/pact/Pact/Core/IR/Eval/Direct/Evaluator.hs
+++ b/pact/Pact/Core/IR/Eval/Direct/Evaluator.hs
@@ -3196,17 +3196,6 @@ coreDefineNamespace info b env = \case
     chargeGasArgs info (GWrite nsSize)
     liftGasM info $ _pdbWrite pdb Write DNamespaces nsn ns
     return $ VString $ "Namespace defined: " <> (_namespaceName nsn)
-  isValidNsFormat nsn = case T.uncons nsn of
-    Just (h, tl) ->
-      isValidNsHead h && T.all isValidNsChar tl
-    Nothing -> False
-  isValidNsHead c =
-    Char.isLatin1 c && Char.isAlpha c
-  isValidNsChar c =
-    Char.isLatin1 c && (Char.isAlphaNum c || T.elem c validSpecialChars)
-  validSpecialChars :: T.Text
-  validSpecialChars =
-    "%#+-_&$@<>=^?*!|/~"
 
 coreDescribeNamespace :: (MonadEval b i m) => NativeFunction b i m
 coreDescribeNamespace info b _env = \case
@@ -3434,6 +3423,7 @@ coreUseAlias info b env = \case
     origExists <- checkNsExists (NamespaceName orig)
     unless origExists $
       throwNativeExecutionError info b "Use-alias failure: origin namespace does not exist"
+    unless (isValidNsFormat alias) $ throwNativeExecutionError info b "invalid namespace format"
     (esLoaded . loAlias) %== M.insert (NamespaceAlias alias) (NamespaceName orig)
     return (VString "Set namespace qualifier alias")
   args -> argsError info b args

--- a/pact/Pact/Core/IR/Term.hs
+++ b/pact/Pact/Core/IR/Term.hs
@@ -346,11 +346,11 @@ instance (Pretty name, Pretty builtin, Pretty ty) => Pretty (Term name ty builti
   pretty = \case
     Var name _ -> pretty name
     Lam ne te _ ->
-      parens ("lambda" <+> parens (fold (NE.intersperse " " (prettyLamArg <$> ne))) <+> pretty te)
+      parens ("lambda" <+> parens (fold (NE.intersperse " " (pretty <$> ne))) <+> pretty te)
     Let n te te' _ ->
       parens $ "let" <+> parens (pretty n <+> pretty te) <+> pretty te'
     App te ne _ ->
-      parens (pretty te <+> hsep (pretty <$> ne))
+      pretty (PrettyLispApp te ne)
     Sequence te te' _ ->
       parens ("seq" <+> pretty te <+> pretty te')
     Conditional o _ ->
@@ -367,14 +367,10 @@ instance (Pretty name, Pretty builtin, Pretty ty) => Pretty (Term name ty builti
     Try te te' _ ->
       parens ("try" <+> pretty te <+> pretty te')
     ObjectLit n _ ->
-      braces (hsep $ punctuate "," $ fmap (\(f, t) -> pretty f <> ":" <> pretty t) n)
+      braces (hsep $ punctuate "," $ fmap (\(f, t) -> dquotes (pretty f) <> ":" <> pretty t) n)
     InlineValue pv _ ->
       -- Note: This term is only used for back compat. with Pact < 5
       pretty pv
-    where
-    prettyTyAnn = maybe mempty ((":" <>) . pretty)
-    prettyLamArg (Arg n ty _) =
-      pretty n <> prettyTyAnn ty
 
 instance (Pretty name, Pretty builtin, Pretty ty) => Pretty (TopLevel name ty builtin info) where
   pretty = \case

--- a/pact/Pact/Core/Names.hs
+++ b/pact/Pact/Core/Names.hs
@@ -63,6 +63,7 @@ module Pact.Core.Names
  , renderParsedTyName
  , parseParsedTyName
  , parseQualifiedName
+ , NamespaceAlias(..)
  ) where
 
 import Control.Lens
@@ -79,11 +80,14 @@ import qualified Text.Megaparsec.Char as MP
 import Pact.Core.Hash
 import Pact.Core.Pretty(Pretty(..))
 
+newtype NamespaceAlias
+  = NamespaceAlias { _unNsAlias :: Text }
+  deriving (Eq, Show, Ord, Generic, NFData)
+
 -- | Newtype wrapper over bare namespaces
 newtype NamespaceName = NamespaceName { _namespaceName :: Text }
-  deriving (Eq, Ord, Show, Generic)
+  deriving (Eq, Ord, Show, Generic, NFData)
 
-instance NFData NamespaceName
 
 instance Pretty NamespaceName where
   pretty (NamespaceName n) = pretty n

--- a/pact/Pact/Core/Persistence/Types.hs
+++ b/pact/Pact/Core/Persistence/Types.hs
@@ -217,6 +217,7 @@ data Loaded b i
   -- ^ The potentially loaded current namespace
   , _loAllLoaded :: Map FullyQualifiedName (Def Name Type b i)
   -- ^ All of our fully qualified dependencies
+  , _loAlias :: Map NamespaceAlias NamespaceName
   } deriving (Show, Generic)
 
 instance (NFData b, NFData i) => NFData (Loaded b i)
@@ -224,14 +225,14 @@ instance (NFData b, NFData i) => NFData (Loaded b i)
 makeClassy ''Loaded
 
 instance Semigroup (Loaded b i) where
-  (Loaded ms tl ns al) <> (Loaded ms' tl' ns' al') =
-    Loaded (ms <> ms') (tl <> tl') (ns <|> ns') (al <> al')
+  (Loaded ms tl ns al nsl) <> (Loaded ms' tl' ns' al' nsr) =
+    Loaded (ms <> ms') (tl <> tl') (ns <|> ns') (al <> al') (nsl <> nsr)
 
 instance Monoid (Loaded b i) where
-  mempty = Loaded mempty mempty Nothing mempty
+  mempty = Loaded mempty mempty Nothing mempty mempty
 
 instance Default (Loaded b i) where
-  def = Loaded mempty mempty Nothing mempty
+  def = Loaded mempty mempty Nothing mempty mempty
 
 -- | Map the user's table name into a set of names suitable for
 --   storage in the persistence backend (prefix USER_ and the module name

--- a/pact/Pact/Core/Serialise/CBOR_V1.hs
+++ b/pact/Pact/Core/Serialise/CBOR_V1.hs
@@ -805,6 +805,7 @@ instance Serialise CoreBuiltin where
     CoreIdentity -> encodeWord 129
     CoreVerifySPV -> encodeWord 130
     CoreEnforceVerifier -> encodeWord 131
+    CoreUseAlias -> encodeWord 132
 
   decode = decodeWord >>= \case
     0 -> pure CoreAdd
@@ -941,6 +942,7 @@ instance Serialise CoreBuiltin where
     129 -> pure CoreIdentity
     130 -> pure CoreVerifySPV
     131 -> pure CoreEnforceVerifier
+    132 -> pure CoreUseAlias
     _ -> fail "unexpected decoding"
 
 


### PR DESCRIPTION
Adds `use-alias` (name not set in stone) for aliasing a namespace name into a desired identifier.

```lisp
(use-alias (read-string "ns") "boop")
(module caller2 g

  (defcap g () true)

  (defun test-call-ez:integer ()
    (boop.call-me.call-me123)
  )

  (defun test-call-error:integer ()
    (try 123 (boop.call-me.call-me-to-fail))
  )
  )


(expect "alias works - case 1" 456 (boop.call-me.call-me123))
(expect-failure "alias works - case 2" (boop.call-me.call-me-to-fail))
```

PR checklist:
* [ ] Ensure namespace format validation
* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
