### PR TITLE
Add common Contract Benchmarks and Specialize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,4 @@ commands.sqlite
 cabal.project.local*
 .direnv
 .envrc
-core-benches.sqlite
+*.sqlite

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ commands.sqlite
 cabal.project.local*
 .direnv
 .envrc
+core-benches.sqlite

--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -122,7 +122,7 @@ main = do
   --
   -- 1 milligas = 2.5 nanoseconds
 
-  let encode = ignoreGas () . encodeRowData def ()
+  let encode = ignoreGas () . encodeRowData
 
   print "Running..."
   defaultMain
@@ -170,37 +170,37 @@ main = do
 
     -- 1700 nanos ()/ 10 chars
     , bench "row-data 1b" $ nfIO $ encode rd1b
-    
+
     -- 1954 nanos () / 1000 characters
-    , bench "row-data 2b" $ nfIO $ (ignoreGas () . encodeRowData def ()) rd2b
+    , bench "row-data 2b" $ nfIO $ (ignoreGas () . encodeRowData) rd2b
 
     -- 337 micros () / 1_000_000 characters
-    , bench "row-data 3b" $ nfIO $ (ignoreGas () . encodeRowData def ()) rd3b
+    , bench "row-data 3b" $ nfIO $ (ignoreGas () . encodeRowData) rd3b
 
     -- 144 micros (57600 milligas) : 1000 small integers
-    , bench "pact-integer-1" $ nfIO $ (ignoreGas () . encodeRowData def ()) int1
+    , bench "pact-integer-1" $ nfIO $ (ignoreGas () . encodeRowData) int1
 
     -- 190 micros (76000 milligas) : 1000 large integers (1e12).
     -- (this - pact-integer-2) / 1000 = 46 nanos per integer, when we move
     -- from 1 digit to 12 digits. Each digit adds 4 nanos, or 2 milligas.
-    , bench "pact-integer-2" $ nfIO $ (ignoreGas () . encodeRowData def ()) int2
+    , bench "pact-integer-2" $ nfIO $ (ignoreGas () . encodeRowData) int2
 
     -- 381 micros (152400 milligas) : 2000 large integers (1e12).
     -- This bench differs from pact-integer-2 by having 2000 integers instead of 1000.
     -- It takes about twice as long as pact-integer-2, validating the linear
     -- effect of integer count on encoding time.
-    , bench "pact-integer-3" $ nfIO $ (ignoreGas () . encodeRowData def ()) int3
+    , bench "pact-integer-3" $ nfIO $ (ignoreGas () . encodeRowData) int3
 
     -- 154 micros (61600 milligas) : 1000 strings of length 1
-    , bench "pact-string-1" $ nfIO $ (ignoreGas () . encodeRowData def ()) str1
+    , bench "pact-string-1" $ nfIO $ (ignoreGas () . encodeRowData) str1
 
     -- 327 micros (130800 milligas) : 1000 strings of length 1000.
     -- This bench differs from pact-string-1 by using strings of length 1000
     -- instead of strings of length 1.
     -- It takes an extra 173 micros, 173 nanos (69 milligas) per element.
     -- So the gas cost of a string is 69 milligas per 1000 characters.
-    , bench "pact-string-2" $ nfIO $ (ignoreGas () . encodeRowData def ()) str2
-    
+    , bench "pact-string-2" $ nfIO $ (ignoreGas () . encodeRowData) str2
+
     -- 652 micros. This bench differs from pact-string-2 by having twice
     -- as many elements, and it takes twice as long, as expected.
     , bench "pact-string-3" $ nfIO $ encode str3

--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -25,7 +25,7 @@ import qualified Data.Map as M
 
 import Pact.Core.Builtin
 import Pact.Core.Environment.Types
-import Pact.Core.Environment.Utils ((.==), useEvalState, usesEvalState)
+import Pact.Core.Environment.Utils ((.==), use, usesEvalState)
 import Pact.Core.Guards
 import Pact.Core.IR.Eval.Runtime.Types
 import Pact.Core.Persistence.MockPersistence

--- a/gasmodel/Main.hs
+++ b/gasmodel/Main.hs
@@ -9,13 +9,11 @@ import Pact.Core.GasModel.InterpreterGas as InterpreterGas
 import Pact.Core.GasModel.BuiltinsGas as BuiltinsGas
 import Pact.Core.GasModel.ContractBench as ContractBench
 import Pact.Core.GasModel.Serialization as Serialization
-import qualified System.Environment as Env
 
 main :: IO ()
 main = do
-  v <- Env.lookupEnv "RESET_COIN_BENCH_DB"
   C.defaultMain
-    [ ContractBench.allBenchmarks (v == Just "1")
+    [ ContractBench.allBenchmarks
     , InterpreterGas.benchmarks
     , BuiltinsGas.benchmarks
     , Serialization.benchmarks

--- a/gasmodel/Main.hs
+++ b/gasmodel/Main.hs
@@ -7,11 +7,14 @@ import qualified Criterion.Main as C
 
 import Pact.Core.GasModel.InterpreterGas as InterpreterGas
 import Pact.Core.GasModel.BuiltinsGas as BuiltinsGas
+import Pact.Core.GasModel.ContractBench as ContractBench
 
 main :: IO ()
 main = do
+  contractBenches <- ContractBench.allBenchmarks
   C.defaultMain
-    [ InterpreterGas.benchmarks
+    [ contractBenches
+    , InterpreterGas.benchmarks
     , BuiltinsGas.benchmarks
     ]
 

--- a/gasmodel/Main.hs
+++ b/gasmodel/Main.hs
@@ -8,14 +8,17 @@ import qualified Criterion.Main as C
 import Pact.Core.GasModel.InterpreterGas as InterpreterGas
 import Pact.Core.GasModel.BuiltinsGas as BuiltinsGas
 import Pact.Core.GasModel.ContractBench as ContractBench
+import Pact.Core.GasModel.Serialization as Serialization
+import qualified System.Environment as Env
 
 main :: IO ()
 main = do
-  contractBenches <- ContractBench.allBenchmarks
+  v <- Env.lookupEnv "RESET_COIN_BENCH_DB"
   C.defaultMain
-    [ contractBenches
+    [ ContractBench.allBenchmarks (v == Just "1")
     , InterpreterGas.benchmarks
     , BuiltinsGas.benchmarks
+    , Serialization.benchmarks
     ]
 
 

--- a/gasmodel/Pact/Core/GasModel/BuiltinsGas.hs
+++ b/gasmodel/Pact/Core/GasModel/BuiltinsGas.hs
@@ -11,6 +11,7 @@ import qualified Data.Set as S
 import qualified Data.Text as T
 import qualified Data.Vector as V
 import qualified Database.SQLite3 as SQL
+import Control.Lens(over, _2)
 import Control.Monad
 import Data.Bifunctor
 import Data.Default
@@ -909,6 +910,7 @@ benchmarks = C.envWithCleanup mkPactDb cleanupPactDb $ \ ~(pdb, _db) -> do
     , not $ null benches
     ]
   where
-  mkPactDb = unsafeCreateSqlitePactDb serialisePact ":memory:"
+  mkPactDb =
+    over _2 SqliteDbNF <$> unsafeCreateSqlitePactDb serialisePact ":memory:"
 
-  cleanupPactDb (_, db) = SQL.close db
+  cleanupPactDb (_, SqliteDbNF db) = SQL.close db

--- a/gasmodel/Pact/Core/GasModel/ContractBench.hs
+++ b/gasmodel/Pact/Core/GasModel/ContractBench.hs
@@ -13,7 +13,6 @@ import Criterion
 import Control.Exception
 import Data.Text(Text)
 import Data.Default
-import System.Directory
 import System.FilePath
 import NeatInterpolation (text)
 import Control.Monad.Except
@@ -400,8 +399,8 @@ transferSigners :: CoinBenchSenders -> CoinBenchSenders -> Map PublicKeyText (Se
 transferSigners sender receiver =
   M.singleton (pubKeyFromSender sender) (S.singleton (transferCapFromSender sender receiver 200.0))
 
-allBenchmarks :: Bool -> Benchmark
-allBenchmarks resetDb = do
+allBenchmarks :: Benchmark
+allBenchmarks = do
   env mkPactDb $ \ ~(pdb) ->
     bgroup "Pact Core Benchmarks"
       [ pureBenchmarks pdb
@@ -434,14 +433,11 @@ allBenchmarks resetDb = do
     -- , runPureBench "Let 10000" (deepLetTXRaw 10000) pdb interpretBigStep
     ]
   mkPactDb = do
-    c <- doesFileExist benchmarkSqliteFile
-    when (c && resetDb) $ removeFile benchmarkSqliteFile
     pdb <- mockPactDb serialisePact_raw_spaninfo
     _ <- _pdbBeginTx pdb Transactional
     _ <- setupCoinTxs pdb
     _ <- _pdbCommitTx pdb
     _ <- _pdbBeginTx pdb Transactional
-    when resetDb $ prePopulateCoinEntries pdb
     _ <- _pdbCommitTx pdb
     pure pdb
 

--- a/gasmodel/Pact/Core/GasModel/ContractBench.hs
+++ b/gasmodel/Pact/Core/GasModel/ContractBench.hs
@@ -1,0 +1,334 @@
+
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE DataKinds #-}
+
+module Pact.Core.GasModel.ContractBench where
+
+
+import Control.Lens
+import Control.Monad
+import Criterion
+import Control.Exception
+import Data.Text(Text)
+import Data.Default
+import System.Directory
+import System.FilePath
+import NeatInterpolation (text)
+import Control.Monad.Except
+import Data.IORef
+import Data.Map.Strict(Map)
+import Data.Set(Set)
+import qualified Data.Map.Strict as M
+import qualified Data.Set as S
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import qualified Database.SQLite3.Direct as SQL
+
+import Pact.Core.Environment
+import Pact.Core.Names
+import Pact.Core.Capabilities
+import Pact.Core.PactValue
+import Pact.Core.Guards
+import Pact.Core.IR.Desugar
+import Pact.Core.IR.Eval.Runtime
+import Pact.Core.Compile
+import Pact.Core.Evaluate
+import Pact.Core.Hash
+import Pact.Core.Persistence
+import Pact.Core.Builtin
+import Pact.Core.SPV
+import qualified Pact.Core.Syntax.Parser as Lisp
+import qualified Pact.Core.Syntax.Lexer as Lisp
+import qualified Pact.Core.Syntax.LexUtils as Lisp
+import qualified Pact.Core.IR.Eval.CEK as CEK
+import qualified Pact.Core.IR.Eval.CoreBuiltin as CEK
+import qualified Pact.Core.IR.Eval.Direct.Evaluator as Direct
+import Pact.Core.Gas.TableGasModel
+import Pact.Core.Gas
+import Pact.Core.Namespace
+import Pact.Core.Serialise
+import Pact.Core.Persistence.MockPersistence
+
+import Pact.Core.Info
+import Pact.Core.Errors
+import Pact.Core.Interpreter
+import Pact.Core.Persistence.SQLite
+import Pact.Core.GasModel.Utils
+import Data.Decimal
+import Criterion.Main
+import Pact.Core.Pretty
+import qualified Data.Text.Encoding as T
+
+parseOnlyExpr :: Text -> Either PactErrorI Lisp.ParsedExpr
+parseOnlyExpr =
+  Lisp.lexer >=> Lisp.parseExpr
+
+contractsPath :: FilePath
+contractsPath = "gasmodel" </> "contracts"
+
+-- | Create a single-key keyset
+mkKs :: PublicKeyText -> PactValue
+mkKs a = PGuard $ GKeyset $ KeySet (S.singleton a) KeysAll
+
+interpretBigStep :: Interpreter CoreBuiltin SpanInfo (EvalM CoreBuiltin SpanInfo)
+interpretBigStep =
+  Interpreter runGuard runTerm
+  where
+  runTerm purity term = CEK.eval purity eEnv term
+  runGuard info g = CEK.interpretGuard info eEnv g
+  eEnv = CEK.coreBuiltinEnv @CEK.CEKBigStep
+
+interpretDirect :: Interpreter CoreBuiltin SpanInfo (EvalM CoreBuiltin SpanInfo)
+interpretDirect =
+  Interpreter runGuard runTerm
+  where
+  runTerm purity term = Direct.eval purity eEnv term
+  runGuard info g = Direct.interpretGuard info eEnv g
+  eEnv = Direct.coreBuiltinEnv
+
+
+data CoinBenchSenders
+  = CoinBenchSenderA
+  | CoinBenchSenderB
+  | CoinBenchSenderC
+  | CoinBenchSenderD
+  deriving Show
+
+getSender :: CoinBenchSenders -> String
+getSender = drop 9 . show
+
+pubKeyFromSenderRaw :: CoinBenchSenders -> Text
+pubKeyFromSenderRaw = \case
+  CoinBenchSenderA -> senderKeyA
+  CoinBenchSenderB -> senderKeyB
+  CoinBenchSenderC -> senderKeyC
+  CoinBenchSenderD -> senderKeyD
+
+kColonFromSender :: CoinBenchSenders -> Text
+kColonFromSender = ("k:" <>) . pubKeyFromSenderRaw
+
+pubKeyFromSender :: CoinBenchSenders -> PublicKeyText
+pubKeyFromSender = PublicKeyText . pubKeyFromSenderRaw
+
+coinTableName :: TableName
+coinTableName = TableName "coin-table" (ModuleName "coin" Nothing)
+
+prePopulateCoinEntries :: Default i => PactDb b i -> IO ()
+prePopulateCoinEntries pdb = forM_ [1 :: Integer .. 100_000] $ \i -> do
+  let n = renderCompactText $ pactHash $ T.encodeUtf8 $ T.pack (show i)
+  let obj = M.fromList [(Field "balance", PDecimal 100), (Field "guard", PGuard (GKeyset (KeySet (S.singleton (PublicKeyText n)) KeysAll)))]
+  ignoreGas def $ _pdbWrite pdb Write (DUserTables coinTableName) (RowKey n) (RowData obj)
+
+
+senderKeyA :: Text
+senderKeyA = T.replicate 64 "a"
+senderKeyB :: Text
+senderKeyB = T.replicate 63 "a" <> "b"
+senderKeyC :: Text
+senderKeyC = T.replicate 63 "a" <> "c"
+senderKeyD :: Text
+senderKeyD = T.replicate 63 "a" <> "d"
+
+coinInitData :: PactValue
+coinInitData = PObject $ M.fromList $
+  [ (Field "a", mkKs (pubKeyFromSender CoinBenchSenderA))
+  , (Field "b", mkKs (pubKeyFromSender CoinBenchSenderB))
+  , (Field "c", mkKs (pubKeyFromSender CoinBenchSenderC))
+  , (Field "d", mkKs (pubKeyFromSender CoinBenchSenderD))
+  ]
+
+coinInitSigners :: M.Map PublicKeyText (Set (CapToken QualifiedName PactValue))
+coinInitSigners = M.fromList $ fmap (over _1 PublicKeyText) $
+  [ (senderKeyA, mempty)
+  , (senderKeyB, mempty)
+  , (senderKeyC, mempty)
+  , (senderKeyD, mempty)
+  ]
+
+benchmarkSqliteFile :: String
+benchmarkSqliteFile = "core-benches.sqlite"
+
+transferCapFromSender :: CoinBenchSenders -> CoinBenchSenders -> Decimal -> CapToken QualifiedName PactValue
+transferCapFromSender sender receiver amount =
+  CapToken (QualifiedName "TRANSFER" (ModuleName "coin" Nothing))
+    [ PString (kColonFromSender sender)
+    , PString (kColonFromSender receiver)
+    , PDecimal amount]
+
+runPactTxFromSource
+  :: EvalEnv CoreBuiltin SpanInfo
+  -> Text
+  -> Interpreter CoreBuiltin SpanInfo (EvalM CoreBuiltin SpanInfo)
+  -> IO (Either (PactError SpanInfo) [CompileValue SpanInfo],EvalState CoreBuiltin SpanInfo)
+runPactTxFromSource ee source interpreter = runEvalM ee def $ do
+  program <- liftEither $ parseOnlyProgram source
+  traverse (interpretTopLevel interpreter) program
+
+setupBenchEvalEnv
+  :: PactDb CoreBuiltin i
+  -> Map PublicKeyText (Set (CapToken QualifiedName PactValue))
+  -> PactValue -> IO (EvalEnv CoreBuiltin i)
+setupBenchEvalEnv pdb signers mBody = do
+  gasRef <- newIORef mempty
+  pure $ EvalEnv
+    { _eeMsgSigs = signers
+    , _eeMsgVerifiers = mempty
+    , _eePactDb = pdb
+    , _eeMsgBody = mBody
+    , _eeHash = defaultPactHash
+    , _eePublicData = def
+    , _eeDefPactStep = Nothing
+    , _eeMode = Transactional
+    , _eeFlags = S.fromList [FlagEnforceKeyFormats, FlagRequireKeysetNs]
+    , _eeNatives = coreBuiltinMap
+    , _eeNamespacePolicy = SimpleNamespacePolicy
+    , _eeGasRef = gasRef
+    , _eeGasModel = tableGasModel (MilliGasLimit (MilliGas 200_000_000))
+    , _eeSPVSupport = noSPVSupport
+    }
+
+
+setupCoinTxs :: PactDb CoreBuiltin SpanInfo -> IO ()
+setupCoinTxs pdb = do
+  source <- T.readFile (contractsPath </> "coin-v5-create.pact")
+  ee <- setupBenchEvalEnv pdb coinInitSigners coinInitData
+  () <$ runPactTxFromSource ee source evalDirectInterpreter
+
+
+_run :: IO ()
+_run = do
+  pdb <- mockPactDb serialisePact_raw_spaninfo
+  setupCoinTxs pdb >>= print
+
+coinTransferTxRaw :: Text -> Text -> Text
+coinTransferTxRaw sender receiver =
+  [text| (coin.transfer "$sender" "$receiver" 200.0) |]
+
+coinTransferCreateTxRaw :: Text -> Text -> Text -> Text
+coinTransferCreateTxRaw sender receiver receiverKs =
+  [text| (coin.transfer-create "$sender" "$receiver" (read-keyset "$receiverKs") 200.0) |]
+
+getRightIO :: Exception e => Either e a -> IO a
+getRightIO = either throwIO pure
+
+resetEEGas :: EvalEnv b i -> IO ()
+resetEEGas ee =
+  writeIORef (_eeGasRef ee) mempty
+
+runCoinTransferTx
+  :: PactDb CoreBuiltin SpanInfo
+  -> CoinBenchSenders
+  -> CoinBenchSenders
+  -> Interpreter CoreBuiltin SpanInfo (EvalM CoreBuiltin SpanInfo)
+  -> String
+  -> Benchmark
+runCoinTransferTx pdb sender receiver interp interpName =
+  envWithCleanup mkTerm doRollback $ \ ~(term, ee, es) ->
+    bench title $ nfIO $ runEvalM ee es (eval interp PImpure term)
+    where
+    title =
+      "Coin transfer from "
+      <> getSender sender
+      <> " to "
+      <> getSender receiver
+      <> " using: "
+      <> interpName
+    mkTerm = do
+      ee <- setupBenchEvalEnv pdb (transferSigners sender receiver) (PObject mempty)
+      let termText = coinTransferTxRaw (kColonFromSender sender) (kColonFromSender receiver)
+      -- note, we will return this eval state, as it definitely contains the loaded coin contract here.
+      (eterm, es) <- runEvalM ee def $ do
+        t <- liftEither $ parseOnlyExpr termText
+        _dsOut <$> runDesugarTerm t
+      term <- getRightIO eterm
+      pure (term, ee, es)
+    doRollback _ = do
+      _pdbRollbackTx pdb
+      _pdbBeginTx pdb Transactional
+
+runCoinTransferTxDesugar
+  :: PactDb CoreBuiltin SpanInfo
+  -> CoinBenchSenders
+  -> CoinBenchSenders
+  -> Interpreter CoreBuiltin SpanInfo (EvalM CoreBuiltin SpanInfo)
+  -> String
+  -> Benchmark
+runCoinTransferTxDesugar pdb sender receiver interp interpName =
+  envWithCleanup mkTerm doRollback $ \ ~(term, ee) ->
+    bench title $ nfIO $ runEvalM ee def $ do
+      t <- runDesugarTerm term
+      eval interp PImpure (_dsOut t)
+    where
+    title =
+      "Coin transfer from "
+      <> getSender sender
+      <> " to "
+      <> getSender receiver
+      <> " including name resolution: "
+      <> interpName
+    mkTerm = do
+      ee <- setupBenchEvalEnv pdb (transferSigners sender receiver) (PObject mempty)
+      let termText = coinTransferTxRaw (kColonFromSender sender) (kColonFromSender receiver)
+      -- note, we will return this eval state, as it definitely contains the loaded coin contract here.
+      parsedTerm <- getRightIO $ parseOnlyExpr termText
+      pure (parsedTerm, ee)
+    doRollback _ = do
+      _pdbRollbackTx pdb
+      _pdbBeginTx pdb Transactional
+
+transferSigners :: CoinBenchSenders -> CoinBenchSenders -> Map PublicKeyText (Set (CapToken QualifiedName PactValue))
+transferSigners sender receiver =
+  M.singleton (pubKeyFromSender sender) (S.singleton (transferCapFromSender sender receiver 200.0))
+
+allBenchmarks :: IO Benchmark
+allBenchmarks = do
+  c <- doesFileExist benchmarkSqliteFile
+  when c $ removeFile benchmarkSqliteFile
+  pure $ envWithCleanup mkPactDb cleanupPactDb $ \ ~(pdb, _db) ->
+    bgroup "Coin benches"
+      [coinTransferBenches pdb]
+  where
+  coinTransferBenches pdb =
+    bgroup "transfer benchmarks"
+    [ runCoinTransferTx pdb CoinBenchSenderA CoinBenchSenderB interpretBigStep "CEK"
+    , runCoinTransferTx pdb CoinBenchSenderA CoinBenchSenderB interpretDirect "Direct"
+    , runCoinTransferTxDesugar pdb CoinBenchSenderA CoinBenchSenderB interpretBigStep "CEK"
+    , runCoinTransferTxDesugar pdb CoinBenchSenderA CoinBenchSenderB interpretDirect "Direct"
+    ]
+  mkPactDb = do
+    (pdb, db) <- unsafeCreateSqlitePactDb serialisePact_raw_spaninfo (T.pack benchmarkSqliteFile)
+    _ <- _pdbBeginTx pdb Transactional
+    _ <- setupCoinTxs pdb
+    _ <- _pdbCommitTx pdb
+    _ <- _pdbBeginTx pdb Transactional
+    prePopulateCoinEntries pdb
+    _ <- _pdbCommitTx pdb
+    _ <- _pdbBeginTx pdb Transactional
+    pure (pdb, SqliteDbNF db)
+  cleanupPactDb (pdb, SqliteDbNF db) = do
+    _pdbRollbackTx pdb
+    SQL.close db
+
+_testRunBench :: IO ()
+_testRunBench = do
+  b <- allBenchmarks
+  defaultMain [b]
+
+_testCoinTransfer :: IO ()
+_testCoinTransfer = withSqlitePactDb serialisePact_raw_spaninfo (T.pack benchmarkSqliteFile) $ \pdb -> do
+  _ <- _pdbBeginTx pdb Transactional
+  p <- setupCoinTxs pdb
+  print p
+  _ <- _pdbCommitTx pdb *> _pdbBeginTx pdb Transactional
+  ee <- setupBenchEvalEnv pdb (transferSigners CoinBenchSenderA CoinBenchSenderB) (PObject mempty)
+  let termText = coinTransferTxRaw (kColonFromSender CoinBenchSenderA) (kColonFromSender CoinBenchSenderB)
+  print termText
+  -- note, we will return this eval state, as it definitely contains the loaded coin contract here.
+  (eterm, es) <- runEvalM ee def $ do
+    t <- liftEither $ parseOnlyExpr termText
+    _dsOut <$> runDesugarTerm t
+  term <- getRightIO eterm
+  (out, _) <- runEvalM ee es (eval interpretDirect PImpure term)
+  print out

--- a/gasmodel/Pact/Core/GasModel/InterpreterGas.hs
+++ b/gasmodel/Pact/Core/GasModel/InterpreterGas.hs
@@ -54,12 +54,12 @@ benchmarks = C.envWithCleanup mkPactDb cleanupPactDb $ \ ~(pdb, _db) -> do
   C.bgroup "pact-core-term-gas" [staticExecutionBenchmarks pdb, termGas pdb, interpReturnGas pdb]
   where
   mkPactDb = do
-    tup@(pdb, _) <- unsafeCreateSqlitePactDb serialisePact ":memory:"
+    (pdb, db) <- unsafeCreateSqlitePactDb serialisePact ":memory:"
     ignoreGas def $ prepopulateDb pdb
     _ <- _pdbBeginTx pdb Transactional
-    pure tup
+    pure (pdb, SqliteDbNF db)
 
-  cleanupPactDb (_, db) = SQL.close db
+  cleanupPactDb (_, SqliteDbNF db) = SQL.close db
 
 gasVarBound :: Int -> EvalEnv CoreBuiltin () -> EvalState CoreBuiltin () -> C.Benchmark
 gasVarBound n ee es = do

--- a/gasmodel/Pact/Core/GasModel/InterpreterGas.hs
+++ b/gasmodel/Pact/Core/GasModel/InterpreterGas.hs
@@ -5,21 +5,14 @@
 module Pact.Core.GasModel.InterpreterGas(benchmarks) where
 
 import Control.Lens
--- import Control.Monad
 import Control.Monad.IO.Class
 import Data.Default
--- import Data.Functor(void)
--- import Data.Bifunctor(bimap)
--- import Criterion.Types(Report)
 import qualified Data.RAList as RA
 import qualified Data.List.NonEmpty as NE
 import qualified Criterion as C
--- import qualified Criterion.Report as C
--- import qualified Criterion.Analysis as C
 import qualified Data.Text as T
 import qualified Data.Set as S
 import qualified Data.Map.Strict as M
-import qualified Database.SQLite3 as SQL
 
 import Pact.Core.Builtin
 import Pact.Core.Environment
@@ -45,21 +38,22 @@ import Pact.Core.GasModel.Utils
 runEvalDropState
   :: EvalEnv b i
   -> EvalState b i
-  -> EvalM b i a
+  -> EvalM ExecRuntime b i a
   -> IO (Either (PactError i) a)
-runEvalDropState ee es = fmap fst . runEvalM ee es
+runEvalDropState ee es = fmap fst . runEvalM (ExecEnv ee) es
 
 benchmarks :: C.Benchmark
-benchmarks = C.envWithCleanup mkPactDb cleanupPactDb $ \ ~(pdb, _db) -> do
-  C.bgroup "pact-core-term-gas" [staticExecutionBenchmarks pdb, termGas pdb, interpReturnGas pdb]
+benchmarks = C.envWithCleanup mkPactDb cleanupPactDb $ \ ~(pdb, _, _) -> do
+  C.bgroup "TermEvalGasCEK" [staticExecutionBenchmarks pdb, termGas pdb, interpReturnGas pdb]
   where
   mkPactDb = do
-    (pdb, db) <- unsafeCreateSqlitePactDb serialisePact ":memory:"
+    (pdb, db, cache) <- unsafeCreateSqlitePactDb serialisePact ":memory:"
     ignoreGas def $ prepopulateDb pdb
     _ <- _pdbBeginTx pdb Transactional
-    pure (pdb, SqliteDbNF db)
+    pure (pdb, NoNf db, NoNf cache)
 
-  cleanupPactDb (_, SqliteDbNF db) = SQL.close db
+  cleanupPactDb (_, NoNf db, NoNf cache) =
+    unsafeCloseSqlitePactDb db cache
 
 gasVarBound :: Int -> EvalEnv CoreBuiltin () -> EvalState CoreBuiltin () -> C.Benchmark
 gasVarBound n ee es = do
@@ -117,7 +111,7 @@ letGas =
   let letBind = Let (Arg "_" Nothing ()) unitConst unitConst ()
   in simpleTermGas letBind "Let Node"
 
-constantExample :: CoreTerm -> CEKValue CEKSmallStep CoreBuiltin () Eval
+constantExample :: CoreTerm -> CEKValue ExecRuntime CEKSmallStep CoreBuiltin ()
 constantExample (Constant LUnit ()) = VPactValue (PLiteral LUnit)
 constantExample _ = error "boom"
 

--- a/gasmodel/Pact/Core/GasModel/Serialization.hs
+++ b/gasmodel/Pact/Core/GasModel/Serialization.hs
@@ -1,0 +1,44 @@
+module Pact.Core.GasModel.Serialization
+  (benchmarks) where
+
+import Criterion(Benchmark)
+import qualified Data.Map.Strict as M
+import qualified Data.Set as S
+import qualified Data.Text as T
+import qualified Criterion as C
+
+import Pact.Core.Names
+import Pact.Core.PactValue
+import Pact.Core.Guards
+import Pact.Core.StableEncoding
+
+import Pact.Core.Persistence.Types
+import Pact.Core.Serialise.CBOR_V1 (encodeRowDataNoGas, encodeRowData)
+import Pact.Core.Gas (ignoreGas)
+
+benchmarks :: Benchmark
+benchmarks = C.bgroup "Encode/Decode benchmarks"
+  [ benchJSONEncodeRowData
+  , benchCBOREncodeRowData
+  , benchCBOREncodeRowDataGas ]
+
+accountBalancePV :: RowData
+accountBalancePV =
+  RowData $
+  M.fromList
+  [ (Field "balance", PDecimal 100)
+  , (Field "guard", PGuard (GKeyset (KeySet (S.singleton (PublicKeyText n)) KeysAll)))]
+  where
+  n = T.replicate 64 "a"
+
+benchJSONEncodeRowData :: Benchmark
+benchJSONEncodeRowData =
+  C.bench "encode row data json" (C.nf encodeStable accountBalancePV)
+
+benchCBOREncodeRowData :: Benchmark
+benchCBOREncodeRowData =
+  C.bench "encode row data cbor" (C.nf encodeRowDataNoGas accountBalancePV)
+
+benchCBOREncodeRowDataGas :: Benchmark
+benchCBOREncodeRowDataGas =
+  C.bench "encode row data cbor - gassed" (C.nfIO (ignoreGas () $ encodeRowData accountBalancePV))

--- a/gasmodel/Pact/Core/GasModel/Utils.hs
+++ b/gasmodel/Pact/Core/GasModel/Utils.hs
@@ -17,7 +17,6 @@ import qualified Criterion as C
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
-import qualified Database.SQLite3 as SQL
 
 
 import Pact.Core.Builtin
@@ -38,30 +37,31 @@ import Pact.Core.Hash
 import Pact.Core.Guards
 import Pact.Core.Evaluate
 import Pact.Core.Namespace
-import Pact.Core.IR.Eval.CEK.Types
+import Pact.Core.IR.Eval.CEK.Types hiding (Eval)
 import qualified Pact.Core.IR.Eval.CEK as Eval
 
 type CoreDb = PactDb CoreBuiltin ()
-type MachineResult = CEKReturn CoreBuiltin () Eval
+type MachineResult = CEKReturn ExecRuntime CoreBuiltin ()
 type ApplyContToVEnv =
   ( EvalEnv CoreBuiltin ()
   , EvalState CoreBuiltin ()
-  , Cont CEKSmallStep CoreBuiltin () Eval
-  , CEKErrorHandler CEKSmallStep CoreBuiltin () Eval
-  , CEKValue CEKSmallStep CoreBuiltin () Eval)
+  , Cont ExecRuntime CEKSmallStep CoreBuiltin ()
+  , CEKErrorHandler ExecRuntime CEKSmallStep CoreBuiltin ()
+  , CEKValue ExecRuntime CEKSmallStep CoreBuiltin ())
 
-benchmarkEnv :: BuiltinEnv CEKSmallStep CoreBuiltin () Eval
-benchmarkEnv = coreBuiltinEnv @CEKSmallStep
+benchmarkEnv :: BuiltinEnv ExecRuntime CEKSmallStep CoreBuiltin ()
+benchmarkEnv = coreBuiltinEnv @ExecRuntime @CEKSmallStep
 
-benchmarkBigStepEnv :: BuiltinEnv CEKBigStep CoreBuiltin () Eval
-benchmarkBigStepEnv = coreBuiltinEnv @CEKBigStep
+benchmarkBigStepEnv :: BuiltinEnv ExecRuntime CEKBigStep CoreBuiltin ()
+benchmarkBigStepEnv = coreBuiltinEnv @ExecRuntime @CEKBigStep
 
-newtype SqliteDbNF
-  = SqliteDbNF SQL.Database
+newtype NoNF a
+  = NoNf a
+  deriving (Eq, Show)
 
 -- NOTE: NECESSARY ORPHAN, otherwise we cannot simply make and
 -- cleanup sqlite pact db instances.
-instance NFData SqliteDbNF where
+instance NFData (NoNF a) where
   rnf _ = ()
 
 gmSigs :: Map PublicKeyText (S.Set (CapToken QualifiedName PactValue))
@@ -261,7 +261,7 @@ evaluateN
   -> Text
   -> Int
   -> IO (Either (PactError ()) MachineResult, EvalState CoreBuiltin ())
-evaluateN evalEnv es source nSteps = runEvalM evalEnv es $ do
+evaluateN evalEnv es source nSteps = runEvalM (ExecEnv evalEnv) es $ do
   term <- compileTerm source
   let pdb = _eePactDb evalEnv
       ps = _eeDefPactStep evalEnv
@@ -308,7 +308,7 @@ runCompileTerm
   -> BenchEvalState
   -> Text
   -> IO (Either (PactError ()) CoreTerm, EvalState CoreBuiltin ())
-runCompileTerm es ee = runEvalM es ee . compileTerm
+runCompileTerm ee es = runEvalM (ExecEnv ee) es . compileTerm
 
 runNativeBenchmark'
   :: (BenchEvalEnv -> IO BenchEvalEnv)
@@ -318,7 +318,7 @@ runNativeBenchmark'
   -> Text
   -> C.Benchmark
 runNativeBenchmark' envMod stMod pdb title src = C.env mkEnv $ \ ~(term, es, ee) ->
-  C.bench title $ C.nfAppIO (fmap (ensureNonError . fst) . runEvalM ee es . Eval.eval PImpure benchmarkBigStepEnv) term
+  C.bench title $ C.nfAppIO (fmap (ensureNonError . fst) . runEvalM (ExecEnv ee) es . Eval.eval PImpure benchmarkBigStepEnv) term
   where
   ensureNonError = either (error . show) id
   mkEnv = do
@@ -406,7 +406,7 @@ ignoreWrites :: PactDb b i -> PactDb b i
 ignoreWrites pdb = pdb { _pdbWrite = \_ _ _ _ -> pure () }
 
 -- Closures
-unitClosureNullary :: CEKEnv step CoreBuiltin () m -> Closure step CoreBuiltin () m
+unitClosureNullary :: CEKEnv ExecRuntime step CoreBuiltin () -> Closure ExecRuntime step CoreBuiltin ()
 unitClosureNullary env
   = Closure
   { _cloFqName = FullyQualifiedName (ModuleName "foomodule" Nothing) "foo" placeholderHash
@@ -418,7 +418,7 @@ unitClosureNullary env
   , _cloInfo = ()}
 
 
-unitClosureUnary :: CEKEnv step CoreBuiltin () m -> Closure step CoreBuiltin () m
+unitClosureUnary :: CEKEnv ExecRuntime step CoreBuiltin () -> Closure ExecRuntime step CoreBuiltin ()
 unitClosureUnary env
   = Closure
   { _cloFqName = FullyQualifiedName (ModuleName "foomodule" Nothing) "foo" placeholderHash
@@ -429,7 +429,7 @@ unitClosureUnary env
   , _cloEnv = env
   , _cloInfo = ()}
 
-unitClosureBinary :: CEKEnv step CoreBuiltin () m -> Closure step CoreBuiltin () m
+unitClosureBinary :: CEKEnv ExecRuntime step CoreBuiltin () -> Closure ExecRuntime step CoreBuiltin ()
 unitClosureBinary env
   = Closure
   { _cloFqName = FullyQualifiedName (ModuleName "foomodule" Nothing) "foo" placeholderHash
@@ -441,7 +441,7 @@ unitClosureBinary env
   , _cloInfo = ()}
 
 
-boolClosureUnary :: Bool -> CEKEnv step b () m -> Closure step b () m
+boolClosureUnary :: Bool -> CEKEnv e step b () -> Closure e step b ()
 boolClosureUnary b env
   = Closure
   { _cloFqName = FullyQualifiedName (ModuleName "foomodule" Nothing) "foo" placeholderHash
@@ -452,7 +452,7 @@ boolClosureUnary b env
   , _cloEnv = env
   , _cloInfo = ()}
 
-boolClosureBinary :: Bool -> CEKEnv step b () m -> Closure step b () m
+boolClosureBinary :: Bool -> CEKEnv e step b () -> Closure e step b ()
 boolClosureBinary b env
   = Closure
   { _cloFqName = FullyQualifiedName (ModuleName "foomodule" Nothing) "foo" placeholderHash
@@ -463,7 +463,7 @@ boolClosureBinary b env
   , _cloEnv = env
   , _cloInfo = ()}
 
-intClosureBinary :: Integer -> CEKEnv step b () m -> Closure step b () m
+intClosureBinary :: Integer -> CEKEnv e step b () -> Closure e step b ()
 intClosureBinary b env
   = Closure
   { _cloFqName = FullyQualifiedName (ModuleName "foomodule" Nothing) "foo" placeholderHash

--- a/gasmodel/Pact/Core/GasModel/Utils.hs
+++ b/gasmodel/Pact/Core/GasModel/Utils.hs
@@ -59,8 +59,6 @@ newtype NoNF a
   = NoNf a
   deriving (Eq, Show)
 
--- NOTE: NECESSARY ORPHAN, otherwise we cannot simply make and
--- cleanup sqlite pact db instances.
 instance NFData (NoNF a) where
   rnf _ = ()
 

--- a/gasmodel/Pact/Core/GasModel/Utils.hs
+++ b/gasmodel/Pact/Core/GasModel/Utils.hs
@@ -56,9 +56,12 @@ benchmarkEnv = coreBuiltinEnv @CEKSmallStep
 benchmarkBigStepEnv :: BuiltinEnv CEKBigStep CoreBuiltin () Eval
 benchmarkBigStepEnv = coreBuiltinEnv @CEKBigStep
 
+newtype SqliteDbNF
+  = SqliteDbNF SQL.Database
+
 -- NOTE: NECESSARY ORPHAN, otherwise we cannot simply make and
 -- cleanup sqlite pact db instances.
-instance NFData SQL.Database where
+instance NFData SqliteDbNF where
   rnf _ = ()
 
 gmSigs :: Map PublicKeyText (S.Set (CapToken QualifiedName PactValue))

--- a/gasmodel/contracts/coin-v5-create.pact
+++ b/gasmodel/contracts/coin-v5-create.pact
@@ -858,7 +858,7 @@
 
 (create-table coin-table)
 (create-table allocation-table)
-(write coin-table "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {"balance":100000.0, "guard":(read-keyset "a")})
-(write coin-table "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab" {"balance":100000.0, "guard":(read-keyset "b")})
-(write coin-table "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaac" {"balance":100000.0, "guard":(read-keyset "c")})
-(write coin-table "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaad" {"balance":100000.0, "guard":(read-keyset "d")})
+(write coin-table "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {"balance":100000000.0, "guard":(read-keyset "a")})
+(write coin-table "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab" {"balance":100000000.0, "guard":(read-keyset "b")})
+;  (write coin-table "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaac" {"balance":100000.0, "guard":(read-keyset "c")})
+;  (write coin-table "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaad" {"balance":100000.0, "guard":(read-keyset "d")})

--- a/gasmodel/contracts/coin-v5-create.pact
+++ b/gasmodel/contracts/coin-v5-create.pact
@@ -1,0 +1,864 @@
+(interface fungible-xchain-v1
+
+  " This interface offers a standard capability for cross-chain \
+  \ transfers and associated events. "
+
+  (defcap TRANSFER_XCHAIN:bool
+    ( sender:string
+      receiver:string
+      amount:decimal
+      target-chain:string
+    )
+    @doc " Managed capability sealing AMOUNT for transfer \
+         \ from SENDER to RECEIVER on TARGET-CHAIN. Permits \
+         \ any number of cross-chain transfers up to AMOUNT."
+
+    @managed amount TRANSFER_XCHAIN-mgr
+    )
+
+  (defun TRANSFER_XCHAIN-mgr:decimal
+    ( managed:decimal
+      requested:decimal
+    )
+    @doc " Allows TRANSFER-XCHAIN AMOUNT to be less than or \
+         \ equal managed quantity as a one-shot, returning 0.0."
+  )
+
+  (defcap TRANSFER_XCHAIN_RECD:bool
+    ( sender:string
+      receiver:string
+      amount:decimal
+      source-chain:string
+    )
+    @doc "Event emitted on receipt of cross-chain transfer."
+    @event
+  )
+)
+
+
+(interface fungible-v2
+
+  " Standard for fungible coins and tokens as specified in KIP-0002. "
+
+   ; ----------------------------------------------------------------------
+   ; Schema
+
+   (defschema account-details
+    @doc "Schema for results of 'account' operation."
+    @model [ (invariant (!= "" sender)) ]
+
+    account:string
+    balance:decimal
+    guard:guard)
+
+
+   ; ----------------------------------------------------------------------
+   ; Caps
+
+   (defcap TRANSFER:bool
+     ( sender:string
+       receiver:string
+       amount:decimal
+     )
+     @doc " Managed capability sealing AMOUNT for transfer from SENDER to \
+          \ RECEIVER. Permits any number of transfers up to AMOUNT."
+     @managed amount TRANSFER-mgr
+     )
+
+   (defun TRANSFER-mgr:decimal
+     ( managed:decimal
+       requested:decimal
+     )
+     @doc " Manages TRANSFER AMOUNT linearly, \
+          \ such that a request for 1.0 amount on a 3.0 \
+          \ managed quantity emits updated amount 2.0."
+     )
+
+   ; ----------------------------------------------------------------------
+   ; Functionality
+
+
+  (defun transfer:string
+    ( sender:string
+      receiver:string
+      amount:decimal
+    )
+    @doc " Transfer AMOUNT between accounts SENDER and RECEIVER. \
+         \ Fails if either SENDER or RECEIVER does not exist."
+    @model [ (property (> amount 0.0))
+             (property (!= sender ""))
+             (property (!= receiver ""))
+             (property (!= sender receiver))
+           ]
+    )
+
+   (defun transfer-create:string
+     ( sender:string
+       receiver:string
+       receiver-guard:guard
+       amount:decimal
+     )
+     @doc " Transfer AMOUNT between accounts SENDER and RECEIVER. \
+          \ Fails if SENDER does not exist. If RECEIVER exists, guard \
+          \ must match existing value. If RECEIVER does not exist, \
+          \ RECEIVER account is created using RECEIVER-GUARD. \
+          \ Subject to management by TRANSFER capability."
+     @model [ (property (> amount 0.0))
+              (property (!= sender ""))
+              (property (!= receiver ""))
+              (property (!= sender receiver))
+            ]
+     )
+
+   (defpact transfer-crosschain:string
+     ( sender:string
+       receiver:string
+       receiver-guard:guard
+       target-chain:string
+       amount:decimal
+     )
+     @doc " 2-step pact to transfer AMOUNT from SENDER on current chain \
+          \ to RECEIVER on TARGET-CHAIN via SPV proof. \
+          \ TARGET-CHAIN must be different than current chain id. \
+          \ First step debits AMOUNT coins in SENDER account and yields \
+          \ RECEIVER, RECEIVER_GUARD and AMOUNT to TARGET-CHAIN. \
+          \ Second step continuation is sent into TARGET-CHAIN with proof \
+          \ obtained from the spv 'output' endpoint of Chainweb. \
+          \ Proof is validated and RECEIVER is credited with AMOUNT \
+          \ creating account with RECEIVER_GUARD as necessary."
+     @model [ (property (> amount 0.0))
+              (property (!= sender ""))
+              (property (!= receiver ""))
+              (property (!= sender receiver))
+              (property (!= target-chain ""))
+            ]
+     )
+
+   (defun get-balance:decimal
+     ( account:string )
+     " Get balance for ACCOUNT. Fails if account does not exist."
+     )
+
+   (defun details:object{account-details}
+     ( account: string )
+     " Get an object with details of ACCOUNT. \
+     \ Fails if account does not exist."
+     )
+
+   (defun precision:integer
+     ()
+     "Return the maximum allowed decimal precision."
+     )
+
+   (defun enforce-unit:bool
+     ( amount:decimal )
+     " Enforce minimum precision allowed for transactions."
+     )
+
+   (defun create-account:string
+     ( account:string
+       guard:guard
+     )
+     " Create ACCOUNT with 0.0 balance, with GUARD controlling access."
+     )
+
+   (defun rotate:string
+     ( account:string
+       new-guard:guard
+     )
+     " Rotate guard for ACCOUNT. Transaction is validated against \
+     \ existing guard before installing new guard. "
+     )
+
+)
+
+
+(module coin GOVERNANCE
+
+  @doc "'coin' represents the Kadena Coin Contract. This contract provides both the \
+  \buy/redeem gas support in the form of 'fund-tx', as well as transfer,       \
+  \credit, debit, coinbase, account creation and query, as well as SPV burn    \
+  \create. To access the coin contract, you may use its fully-qualified name,  \
+  \or issue the '(use coin)' command in the body of a module declaration."
+
+  @model
+    [ (defproperty conserves-mass
+        (= (column-delta coin-table 'balance) 0.0))
+
+      (defproperty valid-account (account:string)
+        (and
+          (>= (length account) 3)
+          (<= (length account) 256)))
+    ]
+
+  (implements fungible-v2)
+  (implements fungible-xchain-v1)
+
+  ;; coin-v2
+  (bless "ut_J_ZNkoyaPUEJhiwVeWnkSQn9JT9sQCWKdjjVVrWo")
+
+  ;; coin v3
+  (bless "1os_sLAUYvBzspn5jjawtRpJWiH1WPfhyNraeVvSIwU")
+
+  ;; coin v4
+  (bless "BjZW0T2ac6qE_I5X8GE4fal6tTqjhLTC7my0ytQSxLU")
+
+  ; --------------------------------------------------------------------------
+  ; Schemas and Tables
+
+  (defschema coin-schema
+    @doc "The coin contract token schema"
+    @model [ (invariant (>= balance 0.0)) ]
+
+    balance:decimal
+    guard:guard)
+
+  (deftable coin-table:{coin-schema})
+
+  ; --------------------------------------------------------------------------
+  ; Capabilities
+
+  (defcap GOVERNANCE ()
+    (enforce false "Enforce non-upgradeability"))
+
+  (defcap GAS ()
+    "Magic capability to protect gas buy and redeem"
+    true)
+
+  (defcap COINBASE ()
+    "Magic capability to protect miner reward"
+    true)
+
+  (defcap GENESIS ()
+    "Magic capability constraining genesis transactions"
+    true)
+
+  (defcap REMEDIATE ()
+    "Magic capability for remediation transactions"
+    true)
+
+  (defcap DEBIT (sender:string)
+    "Capability for managing debiting operations"
+    (enforce-guard (at 'guard (read coin-table sender)))
+    (enforce (!= sender "") "valid sender"))
+
+  (defcap CREDIT (receiver:string)
+    "Capability for managing crediting operations"
+    (enforce (!= receiver "") "valid receiver"))
+
+  (defcap ROTATE (account:string)
+    @doc "Autonomously managed capability for guard rotation"
+    @managed
+    true)
+
+  (defcap TRANSFER:bool
+    ( sender:string
+      receiver:string
+      amount:decimal
+    )
+    @managed amount TRANSFER-mgr
+    (enforce (!= sender receiver) "same sender and receiver")
+    (enforce-unit amount)
+    (enforce (> amount 0.0) "Positive amount")
+    (compose-capability (DEBIT sender))
+    (compose-capability (CREDIT receiver))
+  )
+
+  (defun TRANSFER-mgr:decimal
+    ( managed:decimal
+      requested:decimal
+    )
+
+    (let ((newbal (- managed requested)))
+      (enforce (>= newbal 0.0)
+        (format "TRANSFER exceeded for balance {}" [managed]))
+      newbal)
+  )
+
+  (defcap TRANSFER_XCHAIN:bool
+    ( sender:string
+      receiver:string
+      amount:decimal
+      target-chain:string
+    )
+
+    @managed amount TRANSFER_XCHAIN-mgr
+    (enforce-unit amount)
+    (enforce (> amount 0.0) "Cross-chain transfers require a positive amount")
+    (compose-capability (DEBIT sender))
+  )
+
+  (defun TRANSFER_XCHAIN-mgr:decimal
+    ( managed:decimal
+      requested:decimal
+    )
+
+    (enforce (>= managed requested)
+      (format "TRANSFER_XCHAIN exceeded for balance {}" [managed]))
+    0.0
+  )
+
+  (defcap TRANSFER_XCHAIN_RECD:bool
+    ( sender:string
+      receiver:string
+      amount:decimal
+      source-chain:string
+    )
+    @event true
+  )
+
+  ; v3 capabilities
+  (defcap RELEASE_ALLOCATION
+    ( account:string
+      amount:decimal
+    )
+    @doc "Event for allocation release, can be used for sig scoping."
+    @event true
+  )
+
+  ; --------------------------------------------------------------------------
+  ; Constants
+
+  (defconst COIN_CHARSET CHARSET_LATIN1
+    "The default coin contract character set")
+
+  (defconst MINIMUM_PRECISION 12
+    "Minimum allowed precision for coin transactions")
+
+  (defconst MINIMUM_ACCOUNT_LENGTH 3
+    "Minimum account length admissible for coin accounts")
+
+  (defconst MAXIMUM_ACCOUNT_LENGTH 256
+    "Maximum account name length admissible for coin accounts")
+
+  (defconst VALID_CHAIN_IDS (map (int-to-str 10) (enumerate 0 19))
+    "List of all valid Chainweb chain ids")
+
+  ; --------------------------------------------------------------------------
+  ; Utilities
+
+  (defun enforce-unit:bool (amount:decimal)
+    @doc "Enforce minimum precision allowed for coin transactions"
+
+    (enforce
+      (= (floor amount MINIMUM_PRECISION)
+         amount)
+      (format "Amount violates minimum precision: {}" [amount]))
+    )
+
+  (defun validate-account (account:string)
+    @doc "Enforce that an account name conforms to the coin contract \
+         \minimum and maximum length requirements, as well as the    \
+         \latin-1 character set."
+
+    (enforce
+      (is-charset COIN_CHARSET account)
+      (format
+        "Account does not conform to the coin contract charset: {}"
+        [account]))
+
+    (let ((account-length (length account)))
+
+      (enforce
+        (>= account-length MINIMUM_ACCOUNT_LENGTH)
+        (format
+          "Account name does not conform to the min length requirement: {}"
+          [account]))
+
+      (enforce
+        (<= account-length MAXIMUM_ACCOUNT_LENGTH)
+        (format
+          "Account name does not conform to the max length requirement: {}"
+          [account]))
+      )
+  )
+
+  ; --------------------------------------------------------------------------
+  ; Coin Contract
+
+  (defun gas-only ()
+    "Predicate for gas-only user guards."
+    (require-capability (GAS)))
+
+  (defun gas-guard (guard:guard)
+    "Predicate for gas + single key user guards"
+    (enforce-one
+      "Enforce either the presence of a GAS cap or keyset"
+      [ (gas-only)
+        (enforce-guard guard)
+      ]))
+
+  (defun buy-gas:string (sender:string total:decimal)
+    @doc "This function describes the main 'gas buy' operation. At this point \
+    \MINER has been chosen from the pool, and will be validated. The SENDER   \
+    \of this transaction has specified a gas limit LIMIT (maximum gas) for    \
+    \the transaction, and the price is the spot price of gas at that time.    \
+    \The gas buy will be executed prior to executing SENDER's code."
+
+    @model [ (property (> total 0.0))
+             (property (valid-account sender))
+           ]
+
+    (validate-account sender)
+
+    (enforce-unit total)
+    (enforce (> total 0.0) "gas supply must be a positive quantity")
+
+    (require-capability (GAS))
+    (with-capability (DEBIT sender)
+      (debit sender total))
+    )
+
+  (defun redeem-gas:string (miner:string miner-guard:guard sender:string total:decimal)
+    @doc "This function describes the main 'redeem gas' operation. At this    \
+    \point, the SENDER's transaction has been executed, and the gas that      \
+    \was charged has been calculated. MINER will be credited the gas cost,    \
+    \and SENDER will receive the remainder up to the limit"
+
+    @model [ (property (> total 0.0))
+             (property (valid-account sender))
+             (property (valid-account miner))
+           ]
+
+    (validate-account sender)
+    (validate-account miner)
+    (enforce-unit total)
+
+    (require-capability (GAS))
+    (let*
+      ((fee (read-decimal "fee"))
+       (refund (- total fee)))
+
+      (enforce-unit fee)
+      (enforce (>= fee 0.0)
+        "fee must be a non-negative quantity")
+
+      (enforce (>= refund 0.0)
+        "refund must be a non-negative quantity")
+
+      (emit-event (TRANSFER sender miner fee)) ;v3
+
+        ; directly update instead of credit
+      (with-capability (CREDIT sender)
+        (if (> refund 0.0)
+          (with-read coin-table sender
+            { "balance" := balance }
+            (update coin-table sender
+              { "balance": (+ balance refund) }))
+
+          "noop"))
+
+      (with-capability (CREDIT miner)
+        (if (> fee 0.0)
+          (credit miner miner-guard fee)
+          "noop"))
+      )
+
+    )
+
+  (defun create-account:string (account:string guard:guard)
+    @model [ (property (valid-account account)) ]
+
+    (validate-account account)
+    (enforce-reserved account guard)
+
+    (insert coin-table account
+      { "balance" : 0.0
+      , "guard"   : guard
+      })
+    )
+
+  (defun get-balance:decimal (account:string)
+    (with-read coin-table account
+      { "balance" := balance }
+      balance
+      )
+    )
+
+  (defun details:object{fungible-v2.account-details}
+    ( account:string )
+    (with-read coin-table account
+      { "balance" := bal
+      , "guard" := g }
+      { "account" : account
+      , "balance" : bal
+      , "guard": g })
+    )
+
+  (defun rotate:string (account:string new-guard:guard)
+    (with-capability (ROTATE account)
+      (with-read coin-table account
+        { "guard" := old-guard }
+
+        (enforce-guard old-guard)
+
+        (update coin-table account
+          { "guard" : new-guard }
+          )))
+    )
+
+
+  (defun precision:integer
+    ()
+    MINIMUM_PRECISION)
+
+  (defun transfer:string (sender:string receiver:string amount:decimal)
+    @model [ (property conserves-mass)
+             (property (> amount 0.0))
+             (property (valid-account sender))
+             (property (valid-account receiver))
+             (property (!= sender receiver)) ]
+
+    (enforce (!= sender receiver)
+      "sender cannot be the receiver of a transfer")
+
+    (validate-account sender)
+    (validate-account receiver)
+
+    (enforce (> amount 0.0)
+      "transfer amount must be positive")
+
+    (enforce-unit amount)
+
+    (with-capability (TRANSFER sender receiver amount)
+      (debit sender amount)
+      (with-read coin-table receiver
+        { "guard" := g }
+
+        (credit receiver g amount))
+      )
+    )
+
+  (defun transfer-create:string
+    ( sender:string
+      receiver:string
+      receiver-guard:guard
+      amount:decimal )
+
+    @model [ (property conserves-mass) ]
+
+    (enforce (!= sender receiver)
+      "sender cannot be the receiver of a transfer")
+
+    (validate-account sender)
+    (validate-account receiver)
+
+    (enforce (> amount 0.0)
+      "transfer amount must be positive")
+
+    (enforce-unit amount)
+
+    (with-capability (TRANSFER sender receiver amount)
+      (debit sender amount)
+      (credit receiver receiver-guard amount))
+    )
+
+  (defun coinbase:string (account:string account-guard:guard amount:decimal)
+    @doc "Internal function for the initial creation of coins.  This function \
+    \cannot be used outside of the coin contract."
+
+    @model [ (property (valid-account account))
+             (property (> amount 0.0))
+           ]
+
+    (validate-account account)
+    (enforce-unit amount)
+
+    (require-capability (COINBASE))
+    (emit-event (TRANSFER "" account amount)) ;v3
+    (with-capability (CREDIT account)
+      (credit account account-guard amount))
+    )
+
+  (defun remediate:string (account:string amount:decimal)
+    @doc "Allows for remediation transactions. This function \
+         \is protected by the REMEDIATE capability"
+    @model [ (property (valid-account account))
+             (property (> amount 0.0))
+           ]
+
+    (validate-account account)
+
+    (enforce (> amount 0.0)
+      "Remediation amount must be positive")
+
+    (enforce-unit amount)
+
+    (require-capability (REMEDIATE))
+    (emit-event (TRANSFER "" account amount)) ;v3
+    (with-read coin-table account
+      { "balance" := balance }
+
+      (enforce (<= amount balance) "Insufficient funds")
+
+      (update coin-table account
+        { "balance" : (- balance amount) }
+        ))
+    )
+
+  (defpact fund-tx (sender:string miner:string miner-guard:guard total:decimal)
+    @doc "'fund-tx' is a special pact to fund a transaction in two steps,     \
+    \with the actual transaction transpiring in the middle:                   \
+    \                                                                         \
+    \  1) A buying phase, debiting the sender for total gas and fee, yielding \
+    \     TX_MAX_CHARGE.                                                      \
+    \  2) A settlement phase, resuming TX_MAX_CHARGE, and allocating to the   \
+    \     coinbase account for used gas and fee, and sender account for bal-  \
+    \     ance (unused gas, if any)."
+
+    @model [ (property (> total 0.0))
+             (property (valid-account sender))
+             (property (valid-account miner))
+             ;(property conserves-mass) not supported yet
+           ]
+
+    (step (buy-gas sender total))
+    (step (redeem-gas miner miner-guard sender total))
+    )
+
+  (defun debit:string (account:string amount:decimal)
+    @doc "Debit AMOUNT from ACCOUNT balance"
+
+    @model [ (property (> amount 0.0))
+             (property (valid-account account))
+           ]
+
+    (validate-account account)
+
+    (enforce (> amount 0.0)
+      "debit amount must be positive")
+
+    (enforce-unit amount)
+
+    (require-capability (DEBIT account))
+    (with-read coin-table account
+      { "balance" := balance }
+
+      (enforce (<= amount balance) "Insufficient funds")
+
+      (update coin-table account
+        { "balance" : (- balance amount) }
+        ))
+    )
+
+
+  (defun credit:string (account:string guard:guard amount:decimal)
+    @doc "Credit AMOUNT to ACCOUNT balance"
+
+    @model [ (property (> amount 0.0))
+             (property (valid-account account))
+           ]
+
+    (validate-account account)
+
+    (enforce (> amount 0.0) "credit amount must be positive")
+    (enforce-unit amount)
+
+    (require-capability (CREDIT account))
+    (with-default-read coin-table account
+      { "balance" : -1.0, "guard" : guard }
+      { "balance" := balance, "guard" := retg }
+      ; we don't want to overwrite an existing guard with the user-supplied one
+      (enforce (= retg guard)
+        "account guards do not match")
+
+      (let ((is-new
+             (if (= balance -1.0)
+                 (enforce-reserved account guard)
+               false)))
+
+        (write coin-table account
+          { "balance" : (if is-new amount (+ balance amount))
+          , "guard"   : retg
+          }))
+      ))
+
+  (defun check-reserved:string (account:string)
+    " Checks ACCOUNT for reserved name and returns type if \
+    \ found or empty string. Reserved names start with a \
+    \ single char and colon, e.g. 'c:foo', which would return 'c' as type."
+    (let ((pfx (take 2 account)))
+      (if (= ":" (take -1 pfx)) (take 1 pfx) "")))
+
+  (defun enforce-reserved:bool (account:string guard:guard)
+    @doc "Enforce reserved account name protocols."
+    (if (validate-principal guard account)
+      true
+      (let ((r (check-reserved account)))
+        (if (= r "")
+          true
+          (if (= r "k")
+            (enforce false "Single-key account protocol violation")
+            (enforce false
+              (format "Reserved protocol guard violation: {}" [r]))
+            )))))
+
+
+  (defschema crosschain-schema
+    @doc "Schema for yielded value in cross-chain transfers"
+    receiver:string
+    receiver-guard:guard
+    amount:decimal
+    source-chain:string)
+
+  (defpact transfer-crosschain:string
+    ( sender:string
+      receiver:string
+      receiver-guard:guard
+      target-chain:string
+      amount:decimal )
+
+    @model [ (property (> amount 0.0))
+             (property (valid-account sender))
+             (property (valid-account receiver))
+           ]
+
+    (step
+      (with-capability
+        (TRANSFER_XCHAIN sender receiver amount target-chain)
+
+        (validate-account sender)
+        (validate-account receiver)
+
+        (enforce (!= "" target-chain) "empty target-chain")
+        (enforce (!= (at 'chain-id (chain-data)) target-chain)
+          "cannot run cross-chain transfers to the same chain")
+
+        (enforce (> amount 0.0)
+          "transfer quantity must be positive")
+
+        (enforce-unit amount)
+
+        (enforce (contains target-chain VALID_CHAIN_IDS)
+          "target chain is not a valid chainweb chain id")
+
+        ;; step 1 - debit delete-account on current chain
+        (debit sender amount)
+        (emit-event (TRANSFER sender "" amount))
+
+        (let
+          ((crosschain-details:object{crosschain-schema}
+            { "receiver" : receiver
+            , "receiver-guard" : receiver-guard
+            , "amount" : amount
+            , "source-chain" : (at 'chain-id (chain-data))
+            }))
+          (yield crosschain-details target-chain)
+          )))
+
+    (step
+      (resume
+        { "receiver" := receiver
+        , "receiver-guard" := receiver-guard
+        , "amount" := amount
+        , "source-chain" := source-chain
+        }
+
+        (emit-event (TRANSFER "" receiver amount))
+        (emit-event (TRANSFER_XCHAIN_RECD "" receiver amount source-chain))
+
+        ;; step 2 - credit create account on target chain
+        (with-capability (CREDIT receiver)
+          (credit receiver receiver-guard amount))
+        ))
+    )
+
+
+  ; --------------------------------------------------------------------------
+  ; Coin allocations
+
+  (defschema allocation-schema
+    @doc "Genesis allocation registry"
+    ;@model [ (invariant (>= balance 0.0)) ]
+
+    balance:decimal
+    date:time
+    guard:guard
+    redeemed:bool)
+
+  (deftable allocation-table:{allocation-schema})
+
+  (defun create-allocation-account
+    ( account:string
+      date:time
+      keyset-ref:string
+      amount:decimal
+    )
+
+    @doc "Add an entry to the coin allocation table. This function \
+         \also creates a corresponding empty coin contract account \
+         \of the same name and guard. Requires GENESIS capability. "
+
+    @model [ (property (valid-account account)) ]
+
+    (require-capability (GENESIS))
+
+    (validate-account account)
+    (enforce (>= amount 0.0)
+      "allocation amount must be non-negative")
+
+    (enforce-unit amount)
+
+    (let
+      ((guard:guard (keyset-ref-guard keyset-ref)))
+
+      (create-account account guard)
+
+      (insert allocation-table account
+        { "balance" : amount
+        , "date" : date
+        , "guard" : guard
+        , "redeemed" : false
+        })))
+
+  (defun release-allocation
+    ( account:string )
+
+    @doc "Release funds associated with allocation ACCOUNT into main ledger.   \
+         \ACCOUNT must already exist in main ledger. Allocation is deactivated \
+         \after release."
+    @model [ (property (valid-account account)) ]
+
+    (validate-account account)
+
+    (with-read allocation-table account
+      { "balance" := balance
+      , "date" := release-time
+      , "redeemed" := redeemed
+      , "guard" := guard
+      }
+
+      (let ((curr-time:time (at 'block-time (chain-data))))
+
+        (enforce (not redeemed)
+          "allocation funds have already been redeemed")
+
+        (enforce
+          (>= curr-time release-time)
+          (format "funds locked until {}. current time: {}" [release-time curr-time]))
+
+        (with-capability (RELEASE_ALLOCATION account balance)
+
+        (enforce-guard guard)
+
+        (with-capability (CREDIT account)
+          (emit-event (TRANSFER "" account balance))
+          (credit account guard balance)
+
+          (update allocation-table account
+            { "redeemed" : true
+            , "balance" : 0.0
+            })
+
+          "Allocation successfully released to main ledger"))
+    )))
+
+)
+
+
+(create-table coin-table)
+(create-table allocation-table)
+(write coin-table "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {"balance":100000.0, "guard":(read-keyset "a")})
+(write coin-table "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab" {"balance":100000.0, "guard":(read-keyset "b")})
+(write coin-table "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaac" {"balance":100000.0, "guard":(read-keyset "c")})
+(write coin-table "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaad" {"balance":100000.0, "guard":(read-keyset "d")})

--- a/pact-lsp/Pact/Core/LanguageServer.hs
+++ b/pact-lsp/Pact/Core/LanguageServer.hs
@@ -23,7 +23,6 @@ import Control.Monad.IO.Class
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.IORef
-import Data.Default
 import System.FilePath
 
 import Pact.Core.Persistence.MockPersistence
@@ -54,7 +53,6 @@ import Pact.Core.LanguageServer.Renaming
 import Pact.Core.Repl.BuiltinDocs
 import Pact.Core.Repl.UserDocs
 import Pact.Core.Names
-import Pact.Core.Interpreter
 import qualified Pact.Core.IR.ModuleHashing as MHash
 import qualified Pact.Core.IR.ConstEval as ConstEval
 import qualified Pact.Core.Repl.Compile as Repl
@@ -215,8 +213,6 @@ sendDiagnostics nuri mv content = liftIO runPact >>= \case
         src = SourceCode (takeFileName file) content
         rstate = ReplState
           { _replFlags = mempty
-          , _replEvalState = def
-          , _replPactDb = pdb
           , _replEvalLog = gasLog
           , _replCurrSource = src
           , _replEvalEnv = ee
@@ -344,7 +340,7 @@ documentRenameRequestHandler = requestHandler SMethod_TextDocumentRename $ \req 
         resp (Right (InL we))
 
 processFile
-  :: Interpreter ReplCoreBuiltin SpanInfo (ReplM ReplCoreBuiltin)
+  :: Repl.ReplInterpreter
   -> SourceCode
   -> ReplM ReplCoreBuiltin [EvalTopLevel ReplCoreBuiltin SpanInfo]
 processFile replEnv (SourceCode _ source) = do

--- a/pact-tests/Pact/Core/Gen/Serialise.hs
+++ b/pact-tests/Pact/Core/Gen/Serialise.hs
@@ -161,6 +161,10 @@ typeGen :: Gen Type
 typeGen = Gen.recursive Gen.choice
  [ TyPrim <$> tyPrimGen
  , TyModRef <$> Gen.set (Range.linear 0 10) moduleNameGen
+ , pure TyAny
+ , pure TyCapToken
+ , pure TyAnyList
+ , pure TyAnyObject
  ]
  [ TyList <$> typeGen
  , TyObject <$> schemaGen

--- a/pact-tests/Pact/Core/Test/GasGolden.hs
+++ b/pact-tests/Pact/Core/Test/GasGolden.hs
@@ -5,7 +5,6 @@ module Pact.Core.Test.GasGolden
   ) where
 
 import Control.Monad
-import Data.Default
 import Data.IORef
 import Data.Maybe
 import Data.Text (Text)
@@ -118,8 +117,6 @@ runGasTest file interpret = do
   let source = SourceCode file src
   let rstate = ReplState
             { _replFlags = mempty
-            , _replEvalState = def
-            , _replPactDb = pdb
             , _replEvalLog = gasLog
             , _replCurrSource = source
             , _replEvalEnv = ee'

--- a/pact-tests/Pact/Core/Test/LegacySerialiseTests.hs
+++ b/pact-tests/Pact/Core/Test/LegacySerialiseTests.hs
@@ -20,14 +20,12 @@ import Pact.Core.Test.ReplTests
 import Pact.Core.Persistence
 import Pact.Core.Persistence.MockPersistence
 import Pact.Core.Serialise
-import Pact.Core.Builtin
 import Data.Foldable
 import Control.Lens
 import Pact.Core.Repl.Compile
 import Data.Default
 
 import Pact.Core.Gas
-import Pact.Core.IR.Term
 
 tests :: IO TestTree
 tests = testGroup "Legacy Repl Tests" <$> legacyTests
@@ -84,16 +82,4 @@ legacyTests = do
   toModuleData p fp =
     decodeModuleData <$> BS.readFile (legacyTestDir </> p </> fp)
 
-  -- Boilerplate for lifting `CoreBuiltin` into `ReplCoreBuiltin`
-  -- Note: this is only used in this test.
-  liftReplBuiltin :: ModuleData CoreBuiltin a -> ModuleData ReplCoreBuiltin a
-  liftReplBuiltin = \case
-    ModuleData em ed -> let
-      defs' = over (traverseDefTerm . termBuiltin) RBuiltinWrap <$> _mDefs em
-      ed' = over (traverseDefTerm . termBuiltin) RBuiltinWrap <$> ed
-      in ModuleData (em{_mDefs = defs'}) ed'
-    InterfaceData im ed -> let
-      ifdefs = over (traverseIfDefTerm . termBuiltin) RBuiltinWrap <$> _ifDefns im
-      ed' = over (traverseDefTerm . termBuiltin) RBuiltinWrap <$> ed
-      in InterfaceData (im{_ifDefns = ifdefs}) ed'
 

--- a/pact-tests/Pact/Core/Test/ReplTests.hs
+++ b/pact-tests/Pact/Core/Test/ReplTests.hs
@@ -10,7 +10,6 @@ import Test.Tasty.HUnit
 
 import Control.Monad(when)
 import Data.IORef
-import Data.Default
 import Data.Foldable(traverse_)
 import System.Directory
 import System.FilePath
@@ -85,8 +84,6 @@ runReplTest (ReplSourceDir path) pdb file src interp = do
   let source = SourceCode (path </> file) src
   let rstate = ReplState
             { _replFlags = mempty
-            , _replEvalState = def
-            , _replPactDb = pdb
             , _replEvalLog = gasLog
             , _replCurrSource = source
             , _replEvalEnv = ee

--- a/pact-tests/Pact/Core/Test/SizeOfTests.hs
+++ b/pact-tests/Pact/Core/Test/SizeOfTests.hs
@@ -20,7 +20,6 @@ import Pact.Core.Errors
 import Pact.Core.Environment.Types
 import Pact.Core.PactValue
 import Pact.Core.Serialise
-import Pact.Core.IR.Eval.Runtime.Types (runEvalM)
 
 tests :: TestTree
 tests = testGroup "SizeOfTests" $
@@ -45,7 +44,7 @@ getSize version value = do
   pdb <- mockPactDb serialisePact_repl_spaninfo
   ee <- defaultEvalEnv pdb replCoreBuiltinMap
   let es = def
-  (v, _state) <- liftIO $ runEvalM ee es (sizeOf version value)
+  (v, _state) <- liftIO $ runEvalM (ExecEnv ee) es (sizeOf def version value)
   return v
 
 sizeOfSmallObject :: SizeOfVersion -> Bytes -> TestTree

--- a/pact-tests/Pact/Core/Test/StaticErrorTests.hs
+++ b/pact-tests/Pact/Core/Test/StaticErrorTests.hs
@@ -10,7 +10,6 @@ import qualified Data.Text as T
 import Control.Lens
 import Data.IORef
 import Data.Text (Text)
-import Data.Default
 import NeatInterpolation (text)
 
 import Pact.Core.Builtin
@@ -42,8 +41,6 @@ runStaticTest label src interp predicate = do
   let source = SourceCode label src
       rstate = ReplState
             { _replFlags = mempty
-            , _replEvalState = def
-            , _replPactDb = pdb
             , _replEvalLog = gasLog
             , _replCurrSource = source
             , _replEvalEnv = ee

--- a/pact-tng.cabal
+++ b/pact-tng.cabal
@@ -282,6 +282,7 @@ executable gasmodel
   other-modules:
     Pact.Core.GasModel.BuiltinsGas
     Pact.Core.GasModel.InterpreterGas
+    Pact.Core.GasModel.ContractBench
     Pact.Core.GasModel.Utils
 
   ghc-options:         -Wall -threaded -rtsopts -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints

--- a/pact-tng.cabal
+++ b/pact-tng.cabal
@@ -278,12 +278,36 @@ executable gasmodel
   build-depends:
     , pact-tng
     , criterion
+    , terminal-progress-bar
 
   other-modules:
     Pact.Core.GasModel.BuiltinsGas
     Pact.Core.GasModel.InterpreterGas
     Pact.Core.GasModel.ContractBench
+    Pact.Core.GasModel.Serialization
     Pact.Core.GasModel.Utils
+
+  ghc-options:         -Wall -threaded -rtsopts -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
+  ghc-prof-options:    -fprof-auto -fprof-auto-calls
+  default-language:    Haskell2010
+
+executable profile-tx
+  import: pact-common
+  hs-source-dirs: profile-tx
+
+  main-is: ProfileTx.hs
+
+  build-depends:
+    , pact-tng
+    , criterion
+    , terminal-progress-bar
+
+  other-modules:
+    -- Pact.Core.GasModel.BuiltinsGas
+    -- Pact.Core.GasModel.InterpreterGas
+    -- Pact.Core.GasModel.ContractBench
+    -- Pact.Core.GasModel.Serialization
+    -- Pact.Core.GasModel.Utils
 
   ghc-options:         -Wall -threaded -rtsopts -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
   ghc-prof-options:    -fprof-auto -fprof-auto-calls
@@ -320,7 +344,7 @@ benchmark bench
     , text
     , deepseq
     , pact-time
-  ghc-options: -WAll -threaded -rtsopts "-with-rtsopts=-N"
+  ghc-options: -Wall -threaded -rtsopts "-with-rtsopts=-N"
   hs-source-dirs: bench
   default-language: Haskell2010
 
@@ -356,7 +380,6 @@ test-suite core-tests
     , exceptions
     , hedgehog
     , base16-bytestring
-    , directory
     , filepath
     , lens
     , mtl

--- a/pact/Pact/Core/Compile.hs
+++ b/pact/Pact/Core/Compile.hs
@@ -14,10 +14,10 @@ module Pact.Core.Compile
  , compileDesugarOnly
  , evalTopLevel
  , CompileValue(..)
+ , parseOnlyProgram
  ) where
 
 import Control.Lens
-import Control.Monad.Except
 import Control.Monad
 import Data.Maybe(mapMaybe)
 import Data.Text(Text)
@@ -63,14 +63,14 @@ type HasCompileEnv b i m
     , SizeOf b
     )
 
-_parseOnly
+parseOnlyProgram
   :: Text -> Either PactErrorI [Lisp.TopLevel SpanInfo]
-_parseOnly source = do
-  lexed <- liftEither (Lisp.lexer source)
-  liftEither (Lisp.parseProgram lexed)
+parseOnlyProgram =
+  Lisp.lexer >=> Lisp.parseProgram
 
 _parseOnlyFile :: FilePath -> IO (Either PactErrorI [Lisp.TopLevel SpanInfo])
-_parseOnlyFile fp = _parseOnly <$> T.readFile fp
+_parseOnlyFile fp = parseOnlyProgram <$> T.readFile fp
+
 
 data CompileValue i
   = LoadedModule ModuleName ModuleHash

--- a/pact/Pact/Core/Compile.hs
+++ b/pact/Pact/Core/Compile.hs
@@ -53,12 +53,10 @@ import qualified Pact.Core.Syntax.ParseTree as Lisp
 import Pact.Core.Gas
 import Pact.Core.SizeOf
 
-type HasCompileEnv b i m
-  = ( MonadEval b i m
-    , DesugarBuiltin b
+type HasCompileEnv b i
+  = (DesugarBuiltin b
     , Pretty b
     , IsBuiltin b
-    , PhaseDebug b i m
     , SizeOf i
     , SizeOf b
     )
@@ -81,12 +79,11 @@ data CompileValue i
 
 
 enforceNamespaceInstall
-  :: (HasCompileEnv b i m)
-  => i
-  -> Interpreter b i m
-  -> m ()
+  :: i
+  -> Interpreter e b i
+  -> EvalM e b i ()
 enforceNamespaceInstall info interpreter =
-  useEvalState (esLoaded . loNamespace) >>= \case
+  use (esLoaded . loNamespace) >>= \case
     Just ns ->
       void $ interpretGuard interpreter info (_nsUser ns)
     Nothing ->
@@ -98,19 +95,15 @@ enforceNamespaceInstall info interpreter =
         throwExecutionError info (NamespaceInstallError "cannot install in root namespace")
     allowRoot SimpleNamespacePolicy = True
     allowRoot (SmartNamespacePolicy ar _) = ar
-{-# SPECIALIZE enforceNamespaceInstall
-  :: ()
-  -> Interpreter CoreBuiltin () Eval
-  -> Eval ()  #-}
 
 -- | Evaluate module governance
 evalModuleGovernance
-  :: (HasCompileEnv b i m)
-  => Interpreter b i m
+  :: (HasCompileEnv b i)
+  => Interpreter e b i
   -> Lisp.TopLevel i
-  -> m ()
+  -> EvalM e b i ()
 evalModuleGovernance interpreter tl = do
-  lo <- useEvalState esLoaded
+  lo <- use esLoaded
   pdb <- viewEvalEnv eePactDb
   case tl of
     Lisp.TLModule m -> do
@@ -126,7 +119,7 @@ evalModuleGovernance interpreter tl = do
                   term = App (Builtin (liftCoreBuiltin CoreEnforceGuard) info) (pure ksrg) info
               void $ eval interpreter PImpure term
             CapGov (FQName fqn) -> do
-              hasModAdmin <- usesEvalState (esCaps . csModuleAdmin) (S.member mname)
+              hasModAdmin <- uses (esCaps . csModuleAdmin) (S.member mname)
               if hasModAdmin then pure ()
               else do
                 -- check whether we already have module admin.
@@ -135,9 +128,9 @@ evalModuleGovernance interpreter tl = do
                     withCapApp = App (Var (fqnToName fqn) info) [] info
                     term = CapabilityForm (WithCapability withCapApp cgBody) info
                 void $ eval interpreter PImpure term
-                esCaps . csModuleAdmin %== S.insert mname
+                esCaps . csModuleAdmin %= S.insert mname
           -- | Restore the state to pre-module admin acquisition
-          esLoaded .== lo
+          esLoaded .= lo
         Nothing -> enforceNamespaceInstall info interpreter
     Lisp.TLInterface iface -> do
       let info = Lisp._ifInfo iface
@@ -148,17 +141,14 @@ evalModuleGovernance interpreter tl = do
         Just _ ->
           throwExecutionError info  (CannotUpgradeInterface ifn)
     _ -> pure ()
-{-# SPECIALIZE evalModuleGovernance
-  :: Interpreter CoreBuiltin () Eval
-  -> Lisp.TopLevel ()
-  -> Eval ()  #-}
+
 
 compileDesugarOnly
-  :: forall b i m
-  .  (HasCompileEnv b i m)
-  => Interpreter b i m
+  :: forall e b i
+  .  (HasCompileEnv b i)
+  => Interpreter e b i
   -> Lisp.TopLevel i
-  -> m (EvalTopLevel b i, S.Set ModuleName)
+  -> EvalM e b i (EvalTopLevel b i, S.Set ModuleName)
 compileDesugarOnly interpreter tl = do
   evalModuleGovernance interpreter tl
   -- Todo: pretty instance for modules and all of toplevel
@@ -170,11 +160,11 @@ compileDesugarOnly interpreter tl = do
   pure (tlFinal, deps)
 
 interpretTopLevel
-  :: forall b i m
-  .  (HasCompileEnv b i m)
-  => Interpreter b i m
+  :: forall e b i
+  .  (HasCompileEnv b i)
+  => Interpreter e b i
   -> Lisp.TopLevel i
-  -> m (CompileValue i)
+  -> EvalM e b i (CompileValue i)
 interpretTopLevel interpreter tl = do
   evalModuleGovernance interpreter tl
   -- Todo: pretty instance for modules and all of toplevel
@@ -184,20 +174,16 @@ interpretTopLevel interpreter tl = do
   let tlFinal = MHash.hashTopLevel constEvaled
   debugPrint DPDesugar ds
   evalTopLevel interpreter tlFinal deps
-{-# SPECIALIZE interpretTopLevel
-  :: Interpreter CoreBuiltin () Eval
-  -> Lisp.TopLevel ()
-  -> Eval (CompileValue ())  #-}
 
 evalTopLevel
-  :: forall b i m
-  .  (HasCompileEnv b i m)
-  => Interpreter b i m
+  :: forall e b i
+  .  (HasCompileEnv b i)
+  => Interpreter e b i
   -> EvalTopLevel b i
   -> S.Set ModuleName
-  -> m (CompileValue i)
+  -> EvalM e b i (CompileValue i)
 evalTopLevel interpreter tlFinal deps = do
-  lo0 <- useEvalState esLoaded
+  lo0 <- use esLoaded
   pdb <- viewEvalEnv eePactDb
   case tlFinal of
     TLModule m -> do
@@ -214,7 +200,7 @@ evalTopLevel interpreter tlFinal deps = do
         CapGov _ -> pure ()
       let deps' = M.filterWithKey (\k _ -> S.member (_fqModule k) deps) (_loAllLoaded lo0)
           mdata = ModuleData m deps'
-      mSize <- sizeOf SizeOfV0 m
+      mSize <- sizeOf (_mInfo m) SizeOfV0 m
       chargeGasArgs (_mInfo m) (GModuleMemory mSize)
       writeModule (_mInfo m) pdb Write (view mName m) mdata
       let fqDeps = toFqDep (_mName m) (_mHash m) <$> _mDefs m
@@ -224,13 +210,13 @@ evalTopLevel interpreter tlFinal deps = do
             over loModules (M.insert (_mName m) mdata) .
             over loAllLoaded (M.union newLoaded) .
             over loToplevel (M.union newTopLevel)
-      esLoaded %== loadNewModule
-      esCaps . csModuleAdmin %== S.union (S.singleton (_mName m))
+      esLoaded %= loadNewModule
+      esCaps . csModuleAdmin %= S.union (S.singleton (_mName m))
       pure (LoadedModule (_mName m) (_mHash m))
     TLInterface iface -> do
       let deps' = M.filterWithKey (\k _ -> S.member (_fqModule k) deps) (_loAllLoaded lo0)
           mdata = InterfaceData iface deps'
-      ifaceSize <- sizeOf SizeOfV0 iface
+      ifaceSize <- sizeOf (_ifInfo iface) SizeOfV0 iface
       chargeGasArgs (_ifInfo iface) (GModuleMemory ifaceSize)
       writeModule (_ifInfo iface) pdb Write (view ifName iface) mdata
       let fqDeps = toFqDep (_ifName iface) (_ifHash iface)
@@ -243,13 +229,8 @@ evalTopLevel interpreter tlFinal deps = do
             over loModules (M.insert (_ifName iface) mdata) .
             over loAllLoaded (M.union newLoaded) .
             over loToplevel (M.union newTopLevel)
-      esLoaded %== loadNewModule
+      esLoaded %= loadNewModule
       pure (LoadedInterface (view ifName iface) (view ifHash iface))
     TLTerm term -> (`InterpretValue` (view termInfo term)) <$> eval interpreter PImpure term
     TLUse imp _ -> pure (LoadedImports imp)
-{-# SPECIALIZE evalTopLevel
-  :: Interpreter CoreBuiltin () Eval
-  -> EvalTopLevel CoreBuiltin ()
-  -> S.Set ModuleName
-  -> Eval (CompileValue ())  #-}
 {-# INLINE evalTopLevel #-}

--- a/pact/Pact/Core/Environment/Types.hs
+++ b/pact/Pact/Core/Environment/Types.hs
@@ -37,14 +37,11 @@ module Pact.Core.Environment.Types
  , cdBlockTime, cdPrevBlockHash
  , cdSender, cdGasLimit, cdGasPrice
  , EvalState(..)
---  , HasEvalState(..)
  , StackFrame(..)
  , StackFunctionType(..)
  , flagRep
  , flagReps
  , ExecutionFlag(..)
---  , MonadEvalEnv(..)
---  , MonadEvalState(..)
  , defaultEvalEnv
  , GasLogEntry(..)
  , RecursionCheck(..)
@@ -264,15 +261,6 @@ makeLenses ''EvalState
 instance HasLoaded (EvalState b i) b i where
   loaded = esLoaded
 
--- class (Monad m) => MonadEvalEnv b i m | m -> b, m -> i where
---   readEnv :: m (EvalEnv b i)
-
--- -- | Our monad mirroring `EvalState` for our evaluation state
--- class Monad m => MonadEvalState b i m | m -> b, m -> i where
---   getEvalState :: m (EvalState b i)
---   putEvalState :: EvalState b i -> m ()
---   modifyEvalState :: (EvalState b i -> EvalState b i) -> m ()
-
 -- | A default evaluation environment meant for
 --   uses such as the repl
 defaultEvalEnv :: PactDb b i -> M.Map Text b -> IO (EvalEnv b i)
@@ -299,8 +287,6 @@ defaultEvalEnv pdb m = do
 data ReplState b
   = ReplState
   { _replFlags :: Set ReplDebugFlag
-  -- , _replPactDb :: PactDb b SpanInfo
-  -- , _replEvalState :: EvalState b SpanInfo
   , _replEvalEnv :: EvalEnv b SpanInfo
   , _replEvalLog :: IORef (Maybe [(Text, Gas)])
   , _replCurrSource :: SourceCode

--- a/pact/Pact/Core/Environment/Utils.hs
+++ b/pact/Pact/Core/Environment/Utils.hs
@@ -8,10 +8,7 @@
 
 
 module Pact.Core.Environment.Utils
- ( setEvalState
- , (%==), useEvalState, usesEvalState
- , (.==)
- , viewEvalEnv
+ ( viewEvalEnv
  , viewsEvalEnv
  , getModuleData
  , getModule
@@ -32,9 +29,11 @@ module Pact.Core.Environment.Utils
  ) where
 
 import Control.Lens
+import Data.IORef
 import Control.Applicative((<|>))
 import Control.Monad.Except
 import Control.Exception.Safe
+import Control.Monad.Reader hiding (MonadIO(..))
 import Control.Monad.IO.Class(MonadIO(..))
 import Data.Text(Text)
 import Data.Maybe(mapMaybe)
@@ -53,28 +52,18 @@ import Pact.Core.Capabilities
 import Pact.Core.PactValue
 import Pact.Core.Builtin
 
-viewEvalEnv :: (MonadEvalEnv b i m) => Lens' (EvalEnv b i) s -> m s
-viewEvalEnv l = view l <$> readEnv
 
-viewsEvalEnv :: (MonadEvalEnv b i m) => Lens' (EvalEnv b i) s -> (s -> a) -> m a
-viewsEvalEnv f l = views f l <$> readEnv
+viewEvalEnv :: Lens' (EvalEnv b i) s -> EvalM e b i s
+viewEvalEnv l = ask >>= \case
+  ExecEnv e -> pure (view l e)
+  ReplEnv r ->
+     view (replEvalEnv . l) <$> liftIO (readIORef r)
 
-setEvalState :: (MonadEvalState b i m) => Traversal' (EvalState b i) s -> s -> m ()
-setEvalState l s = modifyEvalState (set l s)
-
-(.==) :: (MonadEvalState b i m) => Traversal' (EvalState b i) s -> s -> m ()
-l .== s = modifyEvalState (set l s)
-
-(%==) :: (MonadEvalState b i m) => Traversal' (EvalState b i) s -> (s -> s) -> m ()
-l %== f = modifyEvalState (over l f)
-
-infix 4 %==, .==
-
-useEvalState :: (MonadEvalState b i m) => Lens' (EvalState b i) s -> m s
-useEvalState l = view l <$> getEvalState
-
-usesEvalState :: (MonadEvalState b i m) => Lens' (EvalState b i) s -> (s -> s') -> m s'
-usesEvalState l f = views l f <$> getEvalState
+viewsEvalEnv :: Lens' (EvalEnv b i) s -> (s -> a) -> EvalM e b i a
+viewsEvalEnv l f = ask >>= \case
+  ExecEnv e -> pure (views l f e)
+  ReplEnv r ->
+     views (replEvalEnv . l) f <$> liftIO (readIORef r)
 
 toFqDep :: ModuleName -> ModuleHash -> Def name t b i -> (FullyQualifiedName, Def name t b i)
 toFqDep modName mhash defn =
@@ -92,36 +81,36 @@ allModuleExports = \case
     in allNewDeps <> deps
 
 liftDbFunction
-  :: (MonadEvalState b i m, MonadError (PactError i) m, MonadIO m)
-  => i
+  :: i
   -> IO a
-  -> m a
+  -> EvalM e b i a
 liftDbFunction info action = do
   liftIO (try action) >>= \case
     Left dbopErr -> throwExecutionError info (DbOpFailure dbopErr)
     Right e -> pure e
 
-throwUserRecoverableError :: (MonadError (PactError info) m, MonadEvalState b info m) => info -> UserRecoverableError -> m a
+throwUserRecoverableError :: i -> UserRecoverableError -> EvalM e b i a
 throwUserRecoverableError i err = do
-  st <- useEvalState esStack
+  st <- use esStack
   throwUserRecoverableError' i st err
 
-throwUserRecoverableError' :: MonadError (PactError info) m => info -> [StackFrame info] -> UserRecoverableError -> m a
+throwUserRecoverableError' :: i -> [StackFrame i] -> UserRecoverableError -> EvalM e b i a
 throwUserRecoverableError' info stack err = throwError (PEUserRecoverableError err stack info)
 
-throwExecutionError :: (MonadEvalState b i m, MonadError (PactError i) m) => i -> EvalError -> m a
+throwExecutionError :: i -> EvalError -> EvalM e b i a
 throwExecutionError i e = do
-  st <- useEvalState esStack
+  st <- use esStack
   throwError (PEExecutionError e st i)
 
-throwNativeExecutionError :: (MonadEvalState b i m, MonadError (PactError i) m, IsBuiltin b) => i -> b -> Text -> m a
+throwNativeExecutionError :: IsBuiltin b => i -> b -> Text -> EvalM e b i a
 throwNativeExecutionError info b msg =
   throwExecutionError info (NativeExecutionError (builtinName b) msg)
 
+
 -- | lookupModuleData for only modules
-lookupModule :: (MonadEval b i m) => i -> PactDb b i -> ModuleName -> m (Maybe (EvalModule b i))
+lookupModule :: i -> PactDb b i -> ModuleName -> EvalM e b i (Maybe (EvalModule b i))
 lookupModule info pdb mn =
- useEvalState (esLoaded . loModules . at mn) >>= \case
+ use (esLoaded . loModules . at mn) >>= \case
    Just (ModuleData md _) -> pure (Just md)
    Just (InterfaceData _ _) ->
     throwExecutionError info (ExpectedModule mn)
@@ -129,48 +118,48 @@ lookupModule info pdb mn =
     liftDbFunction info (_pdbRead pdb DModules mn) >>= \case
       Just mdata@(ModuleData md deps) -> do
         let newLoaded = M.fromList $ toFqDep mn (_mHash md) <$> _mDefs md
-        (esLoaded . loAllLoaded) %== M.union newLoaded . M.union deps
-        (esLoaded . loModules) %== M.insert mn mdata
+        (esLoaded . loAllLoaded) %= M.union newLoaded . M.union deps
+        (esLoaded . loModules) %= M.insert mn mdata
         pure (Just md)
       Just (InterfaceData _ _) ->
         throwExecutionError info (ExpectedModule mn)
       Nothing -> pure Nothing
 
 -- | lookupModuleData modules and interfaces
-lookupModuleData :: (MonadEval b i m) => i -> PactDb b i -> ModuleName -> m (Maybe (ModuleData b i))
+lookupModuleData :: i -> PactDb b i -> ModuleName -> EvalM e b i (Maybe (ModuleData b i))
 lookupModuleData info pdb mn =
- useEvalState (esLoaded . loModules . at mn) >>= \case
+ use (esLoaded . loModules . at mn) >>= \case
    Just md -> pure (Just md)
    Nothing -> do
     liftDbFunction info (_pdbRead pdb DModules mn) >>= \case
       Just mdata@(ModuleData md deps) -> do
         let newLoaded = M.fromList $ toFqDep mn (_mHash md) <$> _mDefs md
-        (esLoaded . loAllLoaded) %== M.union newLoaded . M.union deps
-        (esLoaded . loModules) %== M.insert mn mdata
+        (esLoaded . loAllLoaded) %= M.union newLoaded . M.union deps
+        (esLoaded . loModules) %= M.insert mn mdata
         pure (Just mdata)
       Just mdata@(InterfaceData iface deps) -> do
         let ifDefs = mapMaybe ifDefToDef (_ifDefns iface)
         let newLoaded = M.fromList $ toFqDep mn (_ifHash iface) <$> ifDefs
-        (esLoaded . loAllLoaded) %== M.union newLoaded . M.union deps
-        (esLoaded . loModules) %== M.insert mn mdata
+        (esLoaded . loAllLoaded) %= M.union newLoaded . M.union deps
+        (esLoaded . loModules) %= M.insert mn mdata
         pure (Just mdata)
       Nothing -> pure Nothing
 
 
 -- | getModuleData, but only for modules, no interfaces
-getModule :: (MonadEval b i m) => i -> PactDb b i -> ModuleName -> m (EvalModule b i)
+getModule :: i -> PactDb b i -> ModuleName -> EvalM e b i (EvalModule b i)
 getModule info pdb mn = lookupModule info pdb mn >>= \case
   Just md -> pure md
   Nothing -> throwExecutionError info (ModuleDoesNotExist mn)
 
 -- | Get or load a module or interface based on the module name
-getModuleData :: (MonadEval b i m) => i -> PactDb b i -> ModuleName -> m (ModuleData b i)
+getModuleData :: i -> PactDb b i -> ModuleName -> EvalM e b i (ModuleData b i)
 getModuleData info pdb mn = lookupModuleData info pdb mn >>= \case
   Just md -> pure md
   Nothing -> throwExecutionError info (ModuleDoesNotExist mn)
 
 -- | Returns a module member, but only for modules, no interfaces
-getModuleMember :: (MonadEval b i m) => i -> PactDb b i -> QualifiedName -> m (EvalDef b i)
+getModuleMember :: i -> PactDb b i -> QualifiedName -> EvalM e b i (EvalDef b i)
 getModuleMember info pdb (QualifiedName qn mn) = do
   md <- getModule info pdb mn
   case findDefInModule qn md of
@@ -179,7 +168,7 @@ getModuleMember info pdb (QualifiedName qn mn) = do
       let fqn = FullyQualifiedName mn qn (_mHash md)
       throwExecutionError info (ModuleMemberDoesNotExist fqn)
 
-getModuleMemberWithHash :: (MonadEval b i m) => i -> PactDb b i -> QualifiedName -> m (EvalDef b i, ModuleHash)
+getModuleMemberWithHash :: i -> PactDb b i -> QualifiedName -> EvalM e b i (EvalDef b i, ModuleHash)
 getModuleMemberWithHash info pdb (QualifiedName qn mn) = do
   md <- getModule info pdb mn
   case findDefInModule qn md of
@@ -189,29 +178,27 @@ getModuleMemberWithHash info pdb (QualifiedName qn mn) = do
       throwExecutionError info (ModuleMemberDoesNotExist fqn)
 
 
-mangleNamespace :: (MonadEvalState b i m) => ModuleName -> m ModuleName
+mangleNamespace :: ModuleName -> EvalM e b i ModuleName
 mangleNamespace mn@(ModuleName mnraw ns) =
-  useEvalState (esLoaded . loNamespace) >>= \case
+  use (esLoaded . loNamespace) >>= \case
     Nothing -> pure mn
     Just (Namespace currNs _ _) -> pure (ModuleName mnraw (ns <|> Just currNs))
 
 getAllStackCaps
-  :: (MonadEval b i m)
-  => m (S.Set (CapToken QualifiedName PactValue))
+  :: EvalM e b i (S.Set (CapToken QualifiedName PactValue))
 getAllStackCaps = do
-  S.fromList . concatMap capToList <$> useEvalState (esCaps . csSlots)
+  S.fromList . concatMap capToList <$> use (esCaps . csSlots)
   where
   capToList (CapSlot c cs) = c:cs
 
 -- Todo: capautonomous
 checkSigCaps
-  :: (MonadEval b i m)
-  => M.Map PublicKeyText (S.Set (CapToken QualifiedName PactValue))
-  -> m (M.Map PublicKeyText (S.Set (CapToken QualifiedName PactValue)))
+  :: M.Map PublicKeyText (S.Set (CapToken QualifiedName PactValue))
+  -> EvalM e b i (M.Map PublicKeyText (S.Set (CapToken QualifiedName PactValue)))
 checkSigCaps sigs = do
-  capsBeingEvaluated <- useEvalState (esCaps . csCapsBeingEvaluated)
+  capsBeingEvaluated <- use (esCaps . csCapsBeingEvaluated)
   granted <- if S.null capsBeingEvaluated then getAllStackCaps else pure capsBeingEvaluated
-  autos <- useEvalState (esCaps . csAutonomous)
+  autos <- use (esCaps . csAutonomous)
   -- Pretty much, what this means is:
   -- if you installed a capability from code (using `install-capability`)
   -- then we disable unscoped sigs. Why?

--- a/pact/Pact/Core/Environment/Utils.hs
+++ b/pact/Pact/Core/Environment/Utils.hs
@@ -34,7 +34,7 @@ module Pact.Core.Environment.Utils
 import Control.Lens
 import Control.Applicative((<|>))
 import Control.Monad.Except
-import Control.Exception
+import Control.Exception.Safe
 import Control.Monad.IO.Class(MonadIO(..))
 import Data.Text(Text)
 import Data.Maybe(mapMaybe)

--- a/pact/Pact/Core/Errors.hs
+++ b/pact/Pact/Core/Errors.hs
@@ -697,6 +697,7 @@ instance Exception EvalError
 
 data DbOpException
   = WriteException
+  | RowReadDecodeFailure Text
   | RowFoundException TableName RowKey
   | NoRowFound TableName RowKey
   | NoSuchTable TableName
@@ -715,6 +716,8 @@ instance Pretty DbOpException where
   pretty = \case
     WriteException ->
       "Error found while writing value"
+    RowReadDecodeFailure rk ->
+      "Failed to deserialize but found value at key:" <> pretty rk
     RowFoundException tn rk ->
       "Value already found while in Insert mode in table" <+> pretty tn <+> "at key" <+> dquotes (pretty rk)
     NoRowFound tn rk ->

--- a/pact/Pact/Core/Evaluate.hs
+++ b/pact/Pact/Core/Evaluate.hs
@@ -21,6 +21,8 @@ module Pact.Core.Evaluate
   , EvalBuiltinEnv
   , evalTermExec
   , allModuleExports
+  , evalDirectInterpreter
+  , evalInterpreter
   ) where
 
 import Control.Lens
@@ -57,6 +59,7 @@ import Pact.Core.IR.Desugar
 import Pact.Core.Verifiers
 import Pact.Core.Interpreter
 import qualified Pact.Core.IR.Eval.CEK as Eval
+import qualified Pact.Core.IR.Eval.Direct.Evaluator as Direct
 import qualified Pact.Core.Syntax.Lexer as Lisp
 import qualified Pact.Core.Syntax.Parser as Lisp
 import qualified Pact.Core.Syntax.ParseTree as Lisp
@@ -71,6 +74,14 @@ evalInterpreter =
   runTerm purity term = Eval.eval purity env term
   runGuard info g = Eval.interpretGuard info env g
   env = coreBuiltinEnv @Eval.CEKBigStep
+
+evalDirectInterpreter :: (Default i, Show i) => Interpreter CoreBuiltin i (EvalM CoreBuiltin i)
+evalDirectInterpreter =
+  Interpreter runGuard runTerm
+  where
+  runTerm purity term = Direct.eval purity env term
+  runGuard info g = Direct.interpretGuard info env g
+  env = Direct.coreBuiltinEnv
 
 -- | Transaction-payload related environment data.
 data MsgData = MsgData

--- a/pact/Pact/Core/Gas/Types.hs
+++ b/pact/Pact/Core/Gas/Types.hs
@@ -65,6 +65,7 @@ import Data.Text (Text)
 import GHC.Generics
 
 import Pact.Core.Pretty
+import Pact.Core.Names (FullyQualifiedName)
 
 -- | Gas in pact-core, represented as an unsigned
 -- integer, units will go in terms of 1e3 = 2ns
@@ -212,7 +213,7 @@ data GasArgs
   -- ^ Cost of integer operations
   | GMakeList !Integer !Word64
   -- ^ Cost of creating a list of `n` elements + some memory overhead per elem
-  | GAApplyLam Text !Int
+  | GAApplyLam (Maybe FullyQualifiedName) !Int
   -- ^ Cost of function application
   | GAZKArgs !ZKArg
   -- ^ Cost of ZK function

--- a/pact/Pact/Core/Guards.hs
+++ b/pact/Pact/Core/Guards.hs
@@ -82,6 +82,9 @@ renderKeySetName :: KeySetName -> Text
 renderKeySetName (KeySetName n Nothing) = n
 renderKeySetName (KeySetName n (Just ns)) = _namespaceName ns <> "." <> n
 
+-- | A parser for our keyset name format
+-- <namespace>.keyset
+-- as well as for our legacy format (any string)
 keysetNameParser :: Parser KeySetName
 keysetNameParser = qualified <|> withoutNs
   where
@@ -91,6 +94,8 @@ keysetNameParser = qualified <|> withoutNs
       pure $ KeySetName kn (Just ns)
     withoutNs = do
       t <- takeText
+      -- NOTE: this condition cannot be commented out for any reason
+      -- it will impact principal parsing by allowing parsing the empty string
       guard $ not $ T.null t
       pure $ KeySetName t Nothing
 

--- a/pact/Pact/Core/IR/Eval/CEK.hs
+++ b/pact/Pact/Core/IR/Eval/CEK.hs
@@ -546,7 +546,6 @@ resumePact i cont handler env crossChainContinuation = viewEvalEnv eeDefPactStep
 
         resumeDefPactExec ccExec
       where
-        --resumeDefPactExec :: CEKEval e step b i, MonadEval b i m => DefPactExec -> EvalM e b i (CEKEvalResult e step b i)
         resumeDefPactExec pe = do
           when (_psDefPactId ps /= _peDefPactId pe) $
             throwExecutionError i (DefPactIdMismatch (_psDefPactId ps) (_peDefPactId pe))    -- TODO check with multichain
@@ -1772,13 +1771,6 @@ eval purity benv term = do
         VPactValue pv -> pure pv
         _ ->
           throwExecutionError (view termInfo term) (EvalError "Evaluation did not reduce to a value")
--- {-# SPECIALIZE eval
---    :: (Default i, Show i)
---    => Purity
---    -> BuiltinEnv CEKBigStep CoreBuiltin i (EvalM CoreBuiltin i)
---    -> EvalTerm CoreBuiltin i
---    -> EvalM CoreBuiltin i PactValue
---     #-}
 
 interpretGuard
   :: forall e step b i
@@ -1798,12 +1790,6 @@ interpretGuard info bEnv g = do
         VPactValue pv -> pure pv
         _ ->
           throwExecutionError info (EvalError "Evaluation did not reduce to a value")
-{-# SPECIALIZE interpretGuard
-   :: ()
-   -> CoreBuiltinEnv
-   -> Guard QualifiedName PactValue
-   -> Eval PactValue
-    #-}
 
 evalResumePact
   :: forall e step b i
@@ -1824,12 +1810,6 @@ evalResumePact info bEnv mdpe = do
         VPactValue pv -> pure pv
         _ ->
           throwExecutionError info (EvalError "Evaluation did not reduce to a value")
-{-# SPECIALIZE evalResumePact
-   :: ()
-   -> CoreBuiltinEnv
-   -> Maybe DefPactExec
-   -> Eval PactValue
-    #-}
 
 
 evaluateTermSmallStep

--- a/pact/Pact/Core/IR/Eval/CEK/Types.hs
+++ b/pact/Pact/Core/IR/Eval/CEK/Types.hs
@@ -333,7 +333,7 @@ data NativeFn (e :: RuntimeMode) (step :: CEKStepKind) (b :: K.Type) (i :: K.Typ
   { _native :: !b
   , _nativeEnv :: !(CEKEnv e step b i)
   , _nativeFn :: !(NativeFunction e step b i)
-  , _nativeArity :: {-# UNPACK #-} !Int
+  , _nativeArity :: !Int
   , _nativeLoc :: !i
   } deriving (Generic)
 
@@ -347,7 +347,7 @@ data PartialNativeFn (e :: RuntimeMode) (step :: CEKStepKind) (b :: K.Type) (i :
   { _pNative :: !b
   , _pNativeEnv :: !(CEKEnv e step b i)
   , _pNativeFn :: !(NativeFunction e step b i)
-  , _pNativeArity :: {-# UNPACK #-} !Int
+  , _pNativeArity :: !Int
   , _pNativeAppliedArgs :: ![CEKValue e step b i]
   , _pNativeLoc :: !i
   } deriving (Generic)
@@ -474,7 +474,7 @@ data Cont (e :: RuntimeMode) (step :: CEKStepKind) (b :: K.Type) (i :: K.Type)
   -- ^ Continuation for the current object field being evaluated, and the already evaluated pairs
   | CapInvokeC (CEKEnv e step b i) i (CapCont e step b i) (Cont e step b i)
   -- ^ Frame for control flow around argument reduction to with-capability and create-user-guard
-  | CapBodyC (CEKEnv e step b i) i {-# UNPACK #-} !(CapBodyState b i) (Cont e step b i)
+  | CapBodyC (CEKEnv e step b i) i !(CapBodyState b i) (Cont e step b i)
   -- ^ CapBodyC includes
   --  - what to do after the cap body (pop it, or compose it)
   --  - Is it a user managed cap? If so, include the body token

--- a/pact/Pact/Core/IR/Eval/CEK/Types.hs
+++ b/pact/Pact/Core/IR/Eval/CEK/Types.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE StrictData #-}
 
 module Pact.Core.IR.Eval.CEK.Types
  ( CEKTLEnv
@@ -76,7 +77,6 @@ module Pact.Core.IR.Eval.CEK.Types
  , ClosureType(..)
  , ErrorState(..)
  , BuiltinCont(..)
---  , CEKEval(..)
  , CEKReturn(..)
  , CEKEvalResult
  , CEKStepKind(..)
@@ -127,34 +127,34 @@ import Pact.Core.IR.Eval.Runtime.Types
 import qualified Pact.Core.Pretty as P
 
 
-data CEKReturn b i m
-  = CEKEvaluateTerm (Cont CEKSmallStep b i m) (CEKErrorHandler CEKSmallStep b i m) (CEKEnv CEKSmallStep b i m) (EvalTerm b i)
-  | CEKReturn (Cont CEKSmallStep b i m) (CEKErrorHandler CEKSmallStep b i m) (EvalResult CEKSmallStep b i m)
+data CEKReturn e b i
+  = CEKEvaluateTerm (Cont e CEKSmallStep b i) (CEKErrorHandler e CEKSmallStep b i) (CEKEnv e CEKSmallStep b i) (EvalTerm b i)
+  | CEKReturn (Cont e CEKSmallStep b i) (CEKErrorHandler e CEKSmallStep b i) (EvalResult e CEKSmallStep b i)
   deriving (Show, Generic)
 
-instance (NFData b, NFData i) => NFData (CEKReturn b i m)
+instance (NFData b, NFData i) => NFData (CEKReturn e b i)
 
 -- | The top level env map
 type CEKTLEnv b i = Map FullyQualifiedName (EvalDef b i)
 
 -- | Locally bound variables
-data CEKEnv (step :: CEKStepKind) (b :: K.Type) (i :: K.Type) (m :: K.Type -> K.Type)
+data CEKEnv (e :: RuntimeMode) (step :: CEKStepKind) (b :: K.Type) (i :: K.Type)
   = CEKEnv
-  { _ceLocal :: RAList (CEKValue step b i m)
+  { _ceLocal :: RAList (CEKValue e step b i)
   , _cePactDb :: PactDb b i
-  , _ceBuiltins :: BuiltinEnv step b i m
+  , _ceBuiltins :: BuiltinEnv e step b i
   , _ceDefPactStep :: Maybe DefPactStep
   , _ceInCap :: Bool }
   deriving (Generic)
 
-instance (NFData b, NFData i) => NFData (CEKEnv step b i m)
+instance (NFData b, NFData i) => NFData (CEKEnv e step b i)
 
-instance (Show i, Show b) => Show (CEKEnv step b i m) where
+instance (Show i, Show b) => Show (CEKEnv e step b i) where
   show (CEKEnv e _ _ _ _) = show e
 
 -- | List of builtins
-type BuiltinEnv (step :: CEKStepKind) (b :: K.Type) (i :: K.Type) (m :: K.Type -> K.Type)
-  = i -> b -> CEKEnv step b i m -> NativeFn step b i m
+type BuiltinEnv (e :: RuntimeMode) (step :: CEKStepKind) (b :: K.Type) (i :: K.Type)
+  = i -> b -> CEKEnv e step b i -> NativeFn e step b i
 
 
 data ClosureType i
@@ -164,59 +164,59 @@ data ClosureType i
 
 instance NFData i => NFData (ClosureType i)
 
-data Closure (step :: CEKStepKind) (b :: K.Type) (i :: K.Type) (m :: K.Type -> K.Type)
+data Closure (e :: RuntimeMode) (step :: CEKStepKind) (b :: K.Type) (i :: K.Type)
   = Closure
   { _cloFqName :: !FullyQualifiedName
   , _cloTypes :: !(ClosureType i)
   , _cloArity :: !Int
   , _cloTerm :: !(EvalTerm b i)
   , _cloRType :: !(Maybe Type)
-  , _cloEnv :: !(CEKEnv step b i m)
+  , _cloEnv :: !(CEKEnv e step b i)
   , _cloInfo :: i
   } deriving (Show, Generic)
 
-instance (NFData b, NFData i) => NFData (Closure step b i m)
+instance (NFData b, NFData i) => NFData (Closure e step b i)
 
 -- | A closure coming from a lambda application with its accompanying environment capturing args,
 -- but is not partially applied
-data LamClosure (step :: CEKStepKind) (b :: K.Type) (i :: K.Type) (m :: K.Type -> K.Type)
+data LamClosure (e :: RuntimeMode) (step :: CEKStepKind) (b :: K.Type) (i :: K.Type)
   = LamClosure
   { _lcloTypes :: !(ClosureType i)
   , _lcloArity :: !Int
   , _lcloTerm :: !(EvalTerm b i)
   , _lcloRType :: !(Maybe Type)
-  , _lcloEnv :: !(CEKEnv step b i m)
+  , _lcloEnv :: !(CEKEnv e step b i)
   , _lcloInfo :: i
   } deriving (Show, Generic)
 
-instance (NFData b, NFData i) => NFData (LamClosure step b i m)
+instance (NFData b, NFData i) => NFData (LamClosure e step b i)
 
 -- | A partially applied function because we don't allow
 -- them to be applied at the lhs of an app since pact historically hasn't had partial closures.
 -- This is a bit annoying to deal with but helps preserve semantics
-data PartialClosure (step :: CEKStepKind) (b :: K.Type) (i :: K.Type) (m :: K.Type -> K.Type)
+data PartialClosure (e :: RuntimeMode) (step :: CEKStepKind) (b :: K.Type) (i :: K.Type)
   = PartialClosure
   { _pcloFrame :: !(Maybe (StackFrame i))
   , _pcloTypes :: !(NonEmpty (Arg Type i))
   , _pcloArity :: !Int
   , _pcloTerm :: !(EvalTerm b i)
   , _pcloRType :: !(Maybe Type)
-  , _pcloEnv :: !(CEKEnv step b i m)
+  , _pcloEnv :: !(CEKEnv e step b i)
   , _pcloInfo :: i
   } deriving (Show, Generic)
 
-instance (NFData b, NFData i) => NFData (PartialClosure step b i m)
+instance (NFData b, NFData i) => NFData (PartialClosure e step b i)
 
-data DefPactClosure (step :: CEKStepKind) (b :: K.Type) (i :: K.Type) (m :: K.Type -> K.Type)
+data DefPactClosure (e :: RuntimeMode) (step :: CEKStepKind) (b :: K.Type) (i :: K.Type)
   = DefPactClosure
   { _pactcloFQN :: !FullyQualifiedName
   , _pactcloTypes :: !(ClosureType i)
   , _pactcloArity :: !Int
-  , _pactEnv :: !(CEKEnv step b i m)
+  , _pactEnv :: !(CEKEnv e step b i)
   , _pactcloInfo :: i
   } deriving (Show, Generic)
 
-instance (NFData b, NFData i) => NFData (DefPactClosure step b i m)
+instance (NFData b, NFData i) => NFData (DefPactClosure e step b i)
 
 data CapTokenClosure i
   = CapTokenClosure
@@ -228,134 +228,134 @@ data CapTokenClosure i
 
 instance NFData i => NFData (CapTokenClosure i)
 
-data CanApply (step :: CEKStepKind) (b :: K.Type) (i :: K.Type) (m :: K.Type -> K.Type)
-  = C {-# UNPACK #-} !(Closure step b i m)
-  | LC {-# UNPACK #-} !(LamClosure step b i m)
-  | PC {-# UNPACK #-} !(PartialClosure step b i m)
-  | N {-# UNPACK #-} !(NativeFn step b i m)
-  | PN {-# UNPACK #-} !(PartialNativeFn step b i m)
-  | DPC {-# UNPACK #-} !(DefPactClosure step b i m)
-  | CT {-# UNPACK #-} !(CapTokenClosure i)
+data CanApply (e :: RuntimeMode) (step :: CEKStepKind) (b :: K.Type) (i :: K.Type)
+  = C !(Closure e step b i)
+  | N !(NativeFn e step b i)
+  | CT !(CapTokenClosure i)
+  | LC !(LamClosure e step b i)
+  | PC !(PartialClosure e step b i)
+  | PN !(PartialNativeFn e step b i)
+  | DPC !(DefPactClosure e step b i)
   deriving (Show, Generic)
 
-instance (NFData b, NFData i) => NFData (CanApply step b i m)
+instance (NFData b, NFData i) => NFData (CanApply e step b i)
 
 
 -- | The type of our semantic runtime values
-data CEKValue (step :: CEKStepKind) (b :: K.Type) (i :: K.Type) (m :: K.Type -> K.Type)
+data CEKValue (e :: RuntimeMode) (step :: CEKStepKind) (b :: K.Type) (i :: K.Type)
   = VPactValue !PactValue
   -- ^ PactValue(s), which contain no terms
   | VTable !TableValue
   -- ^ Table references, which despite being a syntactic
   -- value with
-  | VClosure  !(CanApply step b i m)
+  | VClosure  !(CanApply e step b i)
   -- ^ Closures, which may contain terms
   deriving (Generic)
 
-instance (NFData b, NFData i) => NFData (CEKValue step b i m)
+instance (NFData b, NFData i) => NFData (CEKValue e step b i)
 
-instance Show (CEKValue step b i m) where
+instance Show (CEKValue e step b i) where
   show = \case
     VPactValue pv -> show pv
     VTable vt -> "table" <> show (_tvName vt)
     VClosure _ -> "closure<>"
 
-pattern VLiteral :: Literal -> CEKValue step b i m
+pattern VLiteral :: Literal -> CEKValue e step b i
 pattern VLiteral lit = VPactValue (PLiteral lit)
 
-pattern VString :: Text -> CEKValue step b i m
+pattern VString :: Text -> CEKValue e step b i
 pattern VString txt = VLiteral (LString txt)
 
-pattern VInteger :: Integer -> CEKValue step b i m
+pattern VInteger :: Integer -> CEKValue e step b i
 pattern VInteger txt = VLiteral (LInteger txt)
 
-pattern VUnit :: CEKValue step b i m
+pattern VUnit :: CEKValue e step b i
 pattern VUnit = VLiteral LUnit
 
-pattern VBool :: Bool -> CEKValue step b i m
+pattern VBool :: Bool -> CEKValue e step b i
 pattern VBool b = VLiteral (LBool b)
 
-pattern VDecimal :: Decimal -> CEKValue step b i m
+pattern VDecimal :: Decimal -> CEKValue e step b i
 pattern VDecimal d = VLiteral (LDecimal d)
 
-pattern VGuard :: Guard QualifiedName PactValue -> CEKValue step b i m
+pattern VGuard :: Guard QualifiedName PactValue -> CEKValue e step b i
 pattern VGuard g = VPactValue (PGuard g)
 
-pattern VList :: Vector PactValue -> CEKValue step b i m
+pattern VList :: Vector PactValue -> CEKValue e step b i
 pattern VList p = VPactValue (PList p)
 
-pattern VTime :: UTCTime -> CEKValue step b i m
+pattern VTime :: UTCTime -> CEKValue e step b i
 pattern VTime p = VPactValue (PTime p)
 
-pattern VObject :: Map Field PactValue -> CEKValue step b i m
+pattern VObject :: Map Field PactValue -> CEKValue e step b i
 pattern VObject o = VPactValue (PObject o)
 
-pattern VModRef :: ModRef -> CEKValue step b i m
+pattern VModRef :: ModRef -> CEKValue e step b i
 pattern VModRef mn = VPactValue (PModRef mn)
 
-pattern VCapToken :: CapToken FullyQualifiedName PactValue -> CEKValue step b i m
+pattern VCapToken :: CapToken FullyQualifiedName PactValue -> CEKValue e step b i
 pattern VCapToken ct = VPactValue (PCapToken ct)
 
-pattern VNative :: NativeFn step b i m -> CEKValue step b i m
+pattern VNative :: NativeFn e step b i -> CEKValue e step b i
 pattern VNative clo = VClosure (N clo)
 
-pattern VPartialNative :: PartialNativeFn step b i m -> CEKValue step b i m
+pattern VPartialNative :: PartialNativeFn e step b i -> CEKValue e step b i
 pattern VPartialNative clo = VClosure (PN clo)
 
-pattern VDefClosure :: Closure step b i m -> CEKValue step b i m
+pattern VDefClosure :: Closure e step b i -> CEKValue e step b i
 pattern VDefClosure clo = VClosure (C clo)
 
-pattern VLamClosure :: LamClosure step b i m -> CEKValue step b i m
+pattern VLamClosure :: LamClosure e step b i -> CEKValue e step b i
 pattern VLamClosure clo = VClosure (LC clo)
 
-pattern VPartialClosure :: PartialClosure step b i m -> CEKValue step b i m
+pattern VPartialClosure :: PartialClosure e step b i -> CEKValue e step b i
 pattern VPartialClosure clo = VClosure (PC clo)
 
-pattern VDefPactClosure :: DefPactClosure step b i m -> CEKValue step b i m
+pattern VDefPactClosure :: DefPactClosure e step b i -> CEKValue e step b i
 pattern VDefPactClosure clo = VClosure (DPC clo)
 
 -- | Result of an evaluation step, either a CEK value or an error.
-data EvalResult (step :: CEKStepKind) (b :: K.Type) (i :: K.Type) (m :: K.Type -> K.Type)
-  = EvalValue (CEKValue step b i m)
+data EvalResult (e :: RuntimeMode) (step :: CEKStepKind) (b :: K.Type) (i :: K.Type)
+  = EvalValue (CEKValue e step b i)
   | VError [StackFrame i] UserRecoverableError i
   deriving (Show, Generic)
 
-instance (NFData b, NFData i) => NFData (EvalResult step b i m)
+instance (NFData b, NFData i) => NFData (EvalResult e step b i)
 
 
 
 
-type NativeFunction (step :: CEKStepKind) (b :: K.Type) (i :: K.Type) (m :: K.Type -> K.Type)
-  = i -> b -> Cont step b i m -> CEKErrorHandler step b i m -> CEKEnv step b i m -> [CEKValue step b i m] -> m (CEKEvalResult step b i m)
+type NativeFunction (e :: RuntimeMode) (step :: CEKStepKind) (b :: K.Type) (i :: K.Type)
+  = i -> b -> Cont e step b i -> CEKErrorHandler e step b i -> CEKEnv e step b i -> [CEKValue e step b i] -> EvalM e b i (CEKEvalResult e step b i)
 
-data NativeFn (step :: CEKStepKind) (b :: K.Type) (i :: K.Type) (m :: K.Type -> K.Type)
+data NativeFn (e :: RuntimeMode) (step :: CEKStepKind) (b :: K.Type) (i :: K.Type)
   = NativeFn
   { _native :: !b
-  , _nativeEnv :: !(CEKEnv step b i m)
-  , _nativeFn :: !(NativeFunction step b i m)
+  , _nativeEnv :: !(CEKEnv e step b i)
+  , _nativeFn :: !(NativeFunction e step b i)
   , _nativeArity :: {-# UNPACK #-} !Int
   , _nativeLoc :: !i
   } deriving (Generic)
 
-instance (NFData b, NFData i) => NFData (NativeFn step b i m)
+instance (NFData b, NFData i) => NFData (NativeFn e step b i)
 
 -- | A partially applied native because we don't allow
 -- them to be applied at the lhs of an app since pact historically hasn't had partial closures.
 -- This is a bit annoying to deal with but helps preserve semantics
-data PartialNativeFn (step :: CEKStepKind) (b :: K.Type) (i :: K.Type) (m :: K.Type -> K.Type)
+data PartialNativeFn (e :: RuntimeMode) (step :: CEKStepKind) (b :: K.Type) (i :: K.Type)
   = PartialNativeFn
   { _pNative :: !b
-  , _pNativeEnv :: !(CEKEnv step b i m)
-  , _pNativeFn :: !(NativeFunction step b i m)
+  , _pNativeEnv :: !(CEKEnv e step b i)
+  , _pNativeFn :: !(NativeFunction e step b i)
   , _pNativeArity :: {-# UNPACK #-} !Int
-  , _pNativeAppliedArgs :: ![CEKValue step b i m]
+  , _pNativeAppliedArgs :: ![CEKValue e step b i]
   , _pNativeLoc :: !i
   } deriving (Generic)
 
-instance (NFData b, NFData i) => NFData (PartialNativeFn step b i m)
+instance (NFData b, NFData i) => NFData (PartialNativeFn e step b i)
 
 -- | Continuation Frames that handle conditional argument returns in a lazy manner.
-data CondCont (step :: CEKStepKind) (b :: K.Type) (i :: K.Type) (m :: K.Type -> K.Type)
+data CondCont (e :: RuntimeMode) (step :: CEKStepKind) (b :: K.Type) (i :: K.Type)
   = AndC (EvalTerm b i)
   -- ^ <term to evaluate in the True case>
   | OrC (EvalTerm b i)
@@ -366,39 +366,39 @@ data CondCont (step :: CEKStepKind) (b :: K.Type) (i :: K.Type) (m :: K.Type -> 
   -- ^ <error string term>
   | EnforceOneC
   -- ^ <error string term> [<enforceable term>]
-  | FilterC (CanApply step b i m) PactValue [PactValue] [PactValue]
+  | FilterC (CanApply e step b i) PactValue [PactValue] [PactValue]
   -- ^ {filtering closure} <current focused value> <remaining> <accumulator>
-  | AndQC (CanApply step b i m) PactValue
+  | AndQC (CanApply e step b i) PactValue
   -- ^ {bool comparison closure} <original value>
-  | OrQC (CanApply step b i m) PactValue
+  | OrQC (CanApply e step b i) PactValue
   -- ^ {bool comparison closure} <original value>
   | NotQC
   -- ^ Nada
   deriving (Show, Generic)
 
-data BuiltinCont (step :: CEKStepKind) (b :: K.Type) (i :: K.Type) (m :: K.Type -> K.Type)
-  = MapC (CanApply step b i m) [PactValue] [PactValue]
+data BuiltinCont (e :: RuntimeMode) (step :: CEKStepKind) (b :: K.Type) (i :: K.Type)
+  = MapC (CanApply e step b i) [PactValue] [PactValue]
   -- ^ {closure} {remaining} {accum}
-  | FoldC (CanApply step b i m) [PactValue]
+  | FoldC (CanApply e step b i) [PactValue]
   -- ^ {closure} {accum} {rest}
-  | ZipC (CanApply step b i m) ([PactValue],[PactValue]) [PactValue]
+  | ZipC (CanApply e step b i) ([PactValue],[PactValue]) [PactValue]
   -- ^ <zip closure> <lists to zip> <accumulator>
-  | PreSelectC TableValue (CanApply step b i m) (Maybe [Field])
+  | PreSelectC TableValue (CanApply e step b i) (Maybe [Field])
   -- ^ <table> <select filter closure> <filter fields>*
-  | PreFoldDbC TableValue (CanApply step b i m) (CanApply step b i m)
+  | PreFoldDbC TableValue (CanApply e step b i) (CanApply e step b i)
   -- ^ <table> <select filter closure> <accumulator closure>
-  | SelectC TableValue (CanApply step b i m) (ObjectData PactValue) [RowKey] [ObjectData PactValue] (Maybe [Field])
+  | SelectC TableValue (CanApply e step b i) (ObjectData PactValue) [RowKey] [ObjectData PactValue] (Maybe [Field])
   -- ^ <table> <filter closure> <current value> <remaining keys> <accumulator> <fields>
-  | FoldDbFilterC TableValue (CanApply step b i m) (CanApply step b i m) (RowKey, ObjectData PactValue) [RowKey] [(RowKey, PactValue)]
+  | FoldDbFilterC TableValue (CanApply e step b i) (CanApply e step b i) (RowKey, ObjectData PactValue) [RowKey] [(RowKey, PactValue)]
   -- ^ <table> <filter closure> <accum closure> <current k/v pair in focus> <remaining keys> <accumulator>
-  | FoldDbMapC TableValue (CanApply step b i m) [(RowKey, PactValue)] [PactValue]
+  | FoldDbMapC TableValue (CanApply e step b i) [(RowKey, PactValue)] [PactValue]
   -- ^ <table> <accum closure> <remaining pairs> <accumulator>
   | ReadC TableValue RowKey
   -- ^ <table> <key to read>
   | WriteC TableValue WriteType RowKey (ObjectData PactValue)
   -- ^ <table> <write type> <key to write> <value to write>
    -- ^ <table> <key to read> <closure to apply afterwards>
-  | WithDefaultReadC TableValue RowKey (ObjectData PactValue) (CanApply step b i m)
+  | WithDefaultReadC TableValue RowKey (ObjectData PactValue) (CanApply e step b i)
   -- ^ <table> <key to read> <default value> <closure to apply afterwards>
   | KeysC TableValue
   -- ^ Table to apply `keys` to
@@ -422,9 +422,9 @@ data BuiltinCont (step :: CEKStepKind) (b :: K.Type) (i :: K.Type) (m :: K.Type 
 
 
 -- | Control flow around Capability special forms, in particular cap token forms
-data CapCont (step :: CEKStepKind) (b :: K.Type) (i :: K.Type) (m :: K.Type -> K.Type)
+data CapCont (e :: RuntimeMode) (step :: CEKStepKind) (b :: K.Type) (i :: K.Type)
   = WithCapC (EvalTerm b i)
-  | ApplyMgrFunC (ManagedCap QualifiedName PactValue) (Closure step b i m) PactValue PactValue
+  | ApplyMgrFunC (ManagedCap QualifiedName PactValue) (Closure e step b i) PactValue PactValue
   -- ^ <cap token of the corresponding function> ^mgr closure ^ old value ^ new value
   | UpdateMgrFunC (ManagedCap QualifiedName PactValue)
   | CreateUserGuardC FullyQualifiedName [EvalTerm b i] [PactValue]
@@ -450,61 +450,61 @@ data CapBodyState b i
 
 instance (NFData b, NFData i) => NFData (CapBodyState b i)
 
-data Cont (step :: CEKStepKind) (b :: K.Type) (i :: K.Type) (m :: K.Type -> K.Type)
+data Cont (e :: RuntimeMode) (step :: CEKStepKind) (b :: K.Type) (i :: K.Type)
   = Mt
   -- ^ Empty Continuation
-  | Fn !(CanApply step b i m) !(CEKEnv step b i m) ![EvalTerm b i] ![CEKValue step b i m] !(Cont step b i m)
+  | Fn !(CanApply e step b i) !(CEKEnv e step b i) ![EvalTerm b i] ![CEKValue e step b i] !(Cont e step b i)
   -- ^ Continuation which evaluates arguments for a function to apply
-  | Args !(CEKEnv step b i m) i ![EvalTerm b i] !(Cont step b i m)
+  | Args !(CEKEnv e step b i) i ![EvalTerm b i] !(Cont e step b i)
   -- ^ Continuation holding the arguments to evaluate in a function application
-  | LetC !(CEKEnv step b i m) !(EvalTerm b i) !(Cont step b i m)
+  | LetC !(CEKEnv e step b i) !(EvalTerm b i) !(Cont e step b i)
   -- ^ Let single-variable pushing
   -- Optimization frame: Bypasses closure creation and thus less alloc
   -- Known as a single argument it will not construct a needless closure
-  | SeqC (CEKEnv step b i m) (EvalTerm b i) (Cont step b i m)
+  | SeqC (CEKEnv e step b i) (EvalTerm b i) (Cont e step b i)
   -- ^ Sequencing expression, holding the next term to evaluate
-  | ListC (CEKEnv step b i m) i [EvalTerm b i] [PactValue] (Cont step b i m)
+  | ListC (CEKEnv e step b i) i [EvalTerm b i] [PactValue] (Cont e step b i)
   -- ^ Continuation for list elements
-  | CondC (CEKEnv step b i m) i (CondCont step b i m) (Cont step b i m)
+  | CondC (CEKEnv e step b i) i (CondCont e step b i) (Cont e step b i)
   -- ^ Continuation for conditionals with lazy semantics
-  | BuiltinC (CEKEnv step b i m) i (BuiltinCont step b i m) (Cont step b i m)
+  | BuiltinC (CEKEnv e step b i) i (BuiltinCont e step b i) (Cont e step b i)
   -- ^ Continuation for higher-order function builtins
-  | ObjC (CEKEnv step b i m) i Field [(Field, EvalTerm b i)] [(Field, PactValue)] (Cont step b i m)
+  | ObjC (CEKEnv e step b i) i Field [(Field, EvalTerm b i)] [(Field, PactValue)] (Cont e step b i)
   -- Todo: merge all cap constructors
   -- ^ Continuation for the current object field being evaluated, and the already evaluated pairs
-  | CapInvokeC (CEKEnv step b i m) i (CapCont step b i m) (Cont step b i m)
+  | CapInvokeC (CEKEnv e step b i) i (CapCont e step b i) (Cont e step b i)
   -- ^ Frame for control flow around argument reduction to with-capability and create-user-guard
-  | CapBodyC (CEKEnv step b i m) i {-# UNPACK #-} !(CapBodyState b i) (Cont step b i m)
+  | CapBodyC (CEKEnv e step b i) i {-# UNPACK #-} !(CapBodyState b i) (Cont e step b i)
   -- ^ CapBodyC includes
   --  - what to do after the cap body (pop it, or compose it)
   --  - Is it a user managed cap? If so, include the body token
   --  - the capability "user body" to evaluate, generally carrying a series of expressions
   --    or a simple return value in the case of `compose-capability`
   --  - The rest of the continuation
-  | CapPopC CapPopState i (Cont step b i m)
+  | CapPopC CapPopState i (Cont e step b i)
   -- ^ What to do after returning from a defcap: do we compose the returned cap, or do we simply pop it from the stack
-  | DefPactStepC (CEKEnv step b i m) i (Cont step b i m)
+  | DefPactStepC (CEKEnv e step b i) i (Cont e step b i)
   -- ^ Cont frame after a defpact, ensuring we save the defpact to the database and whatnot
-  | NestedDefPactStepC (CEKEnv step b i m) i (Cont step b i m) DefPactExec
+  | NestedDefPactStepC (CEKEnv e step b i) i (Cont e step b i) DefPactExec
   -- ^ Frame for control flow around nested defpact execution
-  | IgnoreValueC PactValue (Cont step b i m)
+  | IgnoreValueC PactValue (Cont e step b i)
   -- ^ Frame to ignore value after user guard execution
-  | EnforceBoolC i (Cont step b i m)
+  | EnforceBoolC i (Cont e step b i)
   -- ^ Enforce boolean
-  | EnforcePactValueC i (Cont step b i m)
+  | EnforcePactValueC i (Cont e step b i)
   -- ^ Enforce pact value
-  | ModuleAdminC ModuleName (Cont step b i m)
+  | ModuleAdminC ModuleName (Cont e step b i)
   -- ^ Add module admin on successful cap eval
-  | StackPopC i (Maybe Type) (Cont step b i m)
+  | StackPopC i (Maybe Type) (Cont e step b i)
   -- ^ Pop the current stack frame and check the return value for the declared type
-  | EnforceErrorC i (Cont step b i m)
+  | EnforceErrorC i (Cont e step b i)
   -- ^ Continuation for "enforced" errors.
   deriving (Show, Generic)
 
-instance (NFData b, NFData i) => NFData (BuiltinCont step b i m)
-instance (NFData b, NFData i) => NFData (CapCont step b i m)
-instance (NFData b, NFData i) => NFData (CondCont step b i m)
-instance (NFData b, NFData i) => NFData (Cont step b i m)
+instance (NFData b, NFData i) => NFData (BuiltinCont e step b i)
+instance (NFData b, NFData i) => NFData (CapCont e step b i)
+instance (NFData b, NFData i) => NFData (CondCont e step b i)
+instance (NFData b, NFData i) => NFData (Cont e step b i)
 
 -- | An enumerable set of frame types, for our gas model
 data ContType
@@ -567,24 +567,24 @@ data EvalCapType
   | TestCapEval
   deriving (Show, Eq, Enum, Bounded)
 
-data CEKErrorHandler (step :: CEKStepKind) (b :: K.Type) (i :: K.Type) (m :: K.Type -> K.Type)
+data CEKErrorHandler (e :: RuntimeMode) (step :: CEKStepKind) (b :: K.Type) (i :: K.Type)
   = CEKNoHandler
-  | CEKHandler (CEKEnv step b i m) (EvalTerm b i) (Cont step b i m) (ErrorState i) (CEKErrorHandler step b i m)
-  | CEKEnforceOne (CEKEnv step b i m) i (EvalTerm b i) [EvalTerm b i] (Cont step b i m) (ErrorState i) (CEKErrorHandler step b i m)
+  | CEKHandler (CEKEnv e step b i) (EvalTerm b i) (Cont e step b i) (ErrorState i) (CEKErrorHandler e step b i)
+  | CEKEnforceOne (CEKEnv e step b i) i (EvalTerm b i) [EvalTerm b i] (Cont e step b i) (ErrorState i) (CEKErrorHandler e step b i)
   deriving (Show, Generic)
 
-instance (NFData b, NFData i) => NFData (CEKErrorHandler step b i m)
+instance (NFData b, NFData i) => NFData (CEKErrorHandler e step b i)
 
 data CEKStepKind
   = CEKSmallStep
   | CEKBigStep
   deriving (Eq, Show)
 
-type family CEKEvalResult (step :: CEKStepKind) (b :: K.Type) (i :: K.Type) (m :: K.Type -> K.Type) where
-  CEKEvalResult CEKBigStep b i m = EvalResult CEKBigStep b i m
-  CEKEvalResult CEKSmallStep b i m = CEKReturn b i m
+type family CEKEvalResult (e :: RuntimeMode) (step :: CEKStepKind) (b :: K.Type) (i :: K.Type) where
+  CEKEvalResult e CEKBigStep b i = EvalResult e CEKBigStep b i
+  CEKEvalResult e CEKSmallStep b i = CEKReturn e b i
 
-instance (Show i, Show b) => Show (NativeFn step b i m) where
+instance (Show i, Show b) => Show (NativeFn e step b i) where
   show (NativeFn b _ _ arity _) = unwords
     ["(NativeFn"
     , show b
@@ -593,7 +593,7 @@ instance (Show i, Show b) => Show (NativeFn step b i m) where
     , ")"
     ]
 
-instance (Show i, Show b) => Show (PartialNativeFn step b i m) where
+instance (Show i, Show b) => Show (PartialNativeFn e step b i) where
   show (PartialNativeFn b _ _ arity _ _) = unwords
     ["(NativeFn"
     , show b
@@ -602,10 +602,10 @@ instance (Show i, Show b) => Show (PartialNativeFn step b i m) where
     , ")"
     ]
 
-instance (Pretty b, Show i, Show b) => Pretty (NativeFn step b i m) where
+instance (Pretty b, Show i, Show b) => Pretty (NativeFn e step b i) where
   pretty = pretty . show
 
-instance (Show i, Show b, Pretty b) => Pretty (CEKValue step b i m) where
+instance (Show i, Show b, Pretty b) => Pretty (CEKValue e step b i) where
   pretty = \case
     VPactValue pv -> pretty pv
     VTable tv -> "table" <> P.braces (pretty (_tvName tv))
@@ -614,10 +614,11 @@ instance (Show i, Show b, Pretty b) => Pretty (CEKValue step b i m) where
 
 makeLenses ''CEKEnv
 
+type Eval = EvalM ExecRuntime CoreBuiltin ()
 type CoreTerm = EvalTerm CoreBuiltin ()
-type CoreCEKCont = Cont CEKBigStep CoreBuiltin () Eval
-type CoreCEKHandler = CEKErrorHandler CEKBigStep CoreBuiltin () Eval
-type CoreCEKEnv = CEKEnv CEKBigStep CoreBuiltin () Eval
-type CoreBuiltinEnv = BuiltinEnv CEKBigStep CoreBuiltin () Eval
-type CoreCEKValue = CEKValue CEKBigStep CoreBuiltin () Eval
-type CoreEvalResult = EvalResult CEKBigStep CoreBuiltin () Eval
+type CoreCEKCont = Cont ExecRuntime CEKBigStep CoreBuiltin ()
+type CoreCEKHandler = CEKErrorHandler ExecRuntime CEKBigStep CoreBuiltin ()
+type CoreCEKEnv = CEKEnv ExecRuntime CEKBigStep CoreBuiltin ()
+type CoreBuiltinEnv = BuiltinEnv ExecRuntime CEKBigStep CoreBuiltin ()
+type CoreCEKValue = CEKValue ExecRuntime CEKBigStep CoreBuiltin ()
+type CoreEvalResult = EvalResult ExecRuntime CEKBigStep CoreBuiltin ()

--- a/pact/Pact/Core/IR/Eval/CoreBuiltin.hs
+++ b/pact/Pact/Core/IR/Eval/CoreBuiltin.hs
@@ -87,7 +87,7 @@ import qualified Pact.Core.Trans.TOps as Musl
 ----------------------------------------------------------------------
 -- Our builtin definitions start here
 ----------------------------------------------------------------------
-unaryIntFn :: (CEKEval e step b i,  IsBuiltin b) => (Integer -> Integer) -> NativeFunction e step b i
+unaryIntFn :: (CEKEval e step b i, IsBuiltin b) => (Integer -> Integer) -> NativeFunction e step b i
 unaryIntFn op info b cont handler _env = \case
   [VLiteral (LInteger i)] ->
     returnCEKValue cont handler (VLiteral (LInteger (op i)))
@@ -95,7 +95,7 @@ unaryIntFn op info b cont handler _env = \case
 {-# INLINE unaryIntFn #-}
 
 binaryIntFn
-  :: (CEKEval e step b i,  IsBuiltin b)
+  :: (CEKEval e step b i, IsBuiltin b)
   => (Integer -> Integer -> Integer)
   -> NativeFunction e step b i
 binaryIntFn op info b cont handler _env = \case
@@ -117,7 +117,7 @@ binaryIntFn op info b cont handler _env = \case
 --          GT -> toRational n * multiplier
 -- `roundTo'` thus has the same asymptotic complexity as multiplication/division. Thus, worst case, we can upperbound it via
 -- division
-roundingFn :: (CEKEval e step b i,  IsBuiltin b) => (Rational -> Integer) -> NativeFunction e step b i
+roundingFn :: (CEKEval e step b i, IsBuiltin b) => (Rational -> Integer) -> NativeFunction e step b i
 roundingFn op info b cont handler _env = \case
   [VLiteral (LDecimal d)] ->
     returnCEKValue cont handler (VLiteral (LInteger (truncate (roundTo' op 0 d))))
@@ -135,7 +135,7 @@ roundingFn op info b cont handler _env = \case
 {-# SPECIALIZE rawAdd
    :: NativeFunction ExecRuntime CEKSmallStep CoreBuiltin i
     #-}
-rawAdd :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+rawAdd :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 rawAdd info b cont handler _env = \case
   [VLiteral (LInteger i), VLiteral (LInteger i')] -> do
     chargeGasArgs info (GIntegerOpCost PrimOpAdd i i')
@@ -164,7 +164,7 @@ rawAdd info b cont handler _env = \case
     chargeGasArgs info (GIntegerOpCost PrimOpAdd (decimalMantissa i) (decimalMantissa i'))
     returnCEKValue cont handler (VLiteral (LDecimal (i + i')))
 
-rawSub :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+rawSub :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 rawSub info b cont handler _env = \case
   [VLiteral (LInteger i), VLiteral (LInteger i')] -> do
     chargeGasArgs info (GIntegerOpCost PrimOpSub i i')
@@ -184,7 +184,7 @@ rawSub info b cont handler _env = \case
 
 
 
-rawMul :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+rawMul :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 rawMul info b cont handler _env = \case
   [VLiteral (LInteger i), VLiteral (LInteger i')] -> do
     chargeGasArgs info (GIntegerOpCost PrimOpMul i i')
@@ -203,7 +203,7 @@ rawMul info b cont handler _env = \case
     chargeGasArgs info (GIntegerOpCost PrimOpMul (decimalMantissa i) (decimalMantissa i'))
     returnCEKValue cont handler (VLiteral (LDecimal (i * i')))
 
-rawPow :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+rawPow :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 rawPow info b cont handler _env = \case
   [VLiteral (LInteger i), VLiteral (LInteger i')] -> do
     chargeGasArgs info $ GIntegerOpCost PrimOpPow i i'
@@ -223,7 +223,7 @@ rawPow info b cont handler _env = \case
     guardNanOrInf info result
     returnCEKValue cont handler (VLiteral (LDecimal (f2Dec result)))
 
-rawLogBase :: forall e step b i. (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+rawLogBase :: forall e step b i. (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 rawLogBase info b cont handler _env = \case
   [VLiteral (LInteger base), VLiteral (LInteger n)] -> do
     checkArgs base n
@@ -251,7 +251,7 @@ rawLogBase info b cont handler _env = \case
     when (arg <= 0) $ throwExecutionError info (ArithmeticException "Non-positive log argument")
 
 
-rawDiv :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+rawDiv :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 rawDiv info b cont handler _env = \case
   [VLiteral (LInteger i), VLiteral (LInteger i')] -> do
     when (i' == 0) $ throwExecutionError info (ArithmeticException "div by zero")
@@ -273,7 +273,7 @@ rawDiv info b cont handler _env = \case
     returnCEKValue cont handler (VLiteral (LDecimal (i / i')))
 
 
-rawNegate :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+rawNegate :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 rawNegate info b cont handler _env = \case
   [VLiteral (LInteger i)] ->
     returnCEKValue cont handler (VLiteral (LInteger (negate i)))
@@ -281,36 +281,36 @@ rawNegate info b cont handler _env = \case
     returnCEKValue cont handler (VLiteral (LDecimal (negate i)))
   args -> argsError info b args
 
-rawEq :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+rawEq :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 rawEq info b cont handler _env = \case
   [VPactValue pv, VPactValue pv'] -> do
     isEq <- valEqGassed info pv pv'
     returnCEKValue cont handler (VBool isEq)
   args -> argsError info b args
 
-modInt :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+modInt :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 modInt = binaryIntFn mod
 
-rawNeq :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+rawNeq :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 rawNeq info b cont handler _env = \case
   [VPactValue pv, VPactValue pv'] -> do
     isEq <- valEqGassed info pv pv'
     returnCEKValue cont handler (VBool $ not isEq)
   args -> argsError info b args
 
-rawGt :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+rawGt :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 rawGt = defCmp (== GT)
 
-rawLt :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+rawLt :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 rawLt = defCmp (== LT)
 
-rawGeq :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+rawGeq :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 rawGeq = defCmp (`elem` [GT, EQ])
 
-rawLeq :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+rawLeq :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 rawLeq = defCmp (`elem` [LT, EQ])
 
-defCmp :: (CEKEval e step b i,  IsBuiltin b) => (Ordering -> Bool) -> NativeFunction e step b i
+defCmp :: (CEKEval e step b i, IsBuiltin b) => (Ordering -> Bool) -> NativeFunction e step b i
 defCmp predicate info b cont handler _env = \case
   args@[VLiteral lit1, VLiteral lit2] -> litCmpGassed info lit1 lit2 >>= \case
     Just ordering -> returnCEKValue cont handler $ VBool $ predicate ordering
@@ -320,26 +320,26 @@ defCmp predicate info b cont handler _env = \case
   args -> argsError info b args
 {-# INLINE defCmp #-}
 
-bitAndInt :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+bitAndInt :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 bitAndInt = binaryIntFn (.&.)
 
-bitOrInt :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+bitOrInt :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 bitOrInt = binaryIntFn (.|.)
 
-bitComplementInt :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+bitComplementInt :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 bitComplementInt = unaryIntFn complement
 
-bitXorInt :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+bitXorInt :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 bitXorInt = binaryIntFn xor
 
-bitShiftInt :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+bitShiftInt :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 bitShiftInt info b cont handler _env = \case
   [VLiteral (LInteger i), VLiteral (LInteger i')] -> do
     chargeGasArgs info $ GIntegerOpCost PrimOpShift i i'
     returnCEKValue cont handler (VLiteral (LInteger (i `shift` fromIntegral i')))
   args -> argsError info b args
 
-rawAbs :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+rawAbs :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 rawAbs info b cont handler _env = \case
   [VLiteral (LInteger i)] -> do
     returnCEKValue cont handler (VLiteral (LInteger (abs i)))
@@ -347,7 +347,7 @@ rawAbs info b cont handler _env = \case
     returnCEKValue cont handler (VLiteral (LDecimal (abs e)))
   args -> argsError info b args
 
-rawExp :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+rawExp :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 rawExp info b cont handler _env = \case
   [VLiteral (LInteger i)] -> do
     let result = Musl.trans_exp (fromIntegral i)
@@ -359,7 +359,7 @@ rawExp info b cont handler _env = \case
     returnCEKValue cont handler (VLiteral (LDecimal (f2Dec result)))
   args -> argsError info b args
 
-rawLn :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+rawLn :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 rawLn info b cont handler _env = \case
   [VLiteral (LInteger i)] -> do
     let result = Musl.trans_ln (fromIntegral i)
@@ -371,7 +371,7 @@ rawLn info b cont handler _env = \case
     returnCEKValue cont handler (VLiteral (LDecimal (f2Dec result)))
   args -> argsError info b args
 
-rawSqrt :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+rawSqrt :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 rawSqrt info b cont handler _env = \case
   [VLiteral (LInteger i)] -> do
     when (i < 0) $ throwExecutionError info (ArithmeticException "Square root must be non-negative")
@@ -391,7 +391,6 @@ renderPactValue info pv = do
   chargeGasArgs info $ GConcat $ TextConcat $ GasTextLength $ fromIntegral sz
   pure $ Pretty.renderCompactText pv
 
--- Todo: fix all show instances
 rawShow :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 rawShow info b cont handler _env = \case
   [VPactValue pv] -> do
@@ -400,7 +399,7 @@ rawShow info b cont handler _env = \case
   args -> argsError info b args
 
 -- Todo: Gas here is complicated, greg worked on this previously
-rawContains :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+rawContains :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 rawContains info b cont handler _env = \case
   [VString f, VObject o] -> do
     chargeGasArgs info $ GSearch $ FieldSearch (M.size o)
@@ -415,7 +414,7 @@ rawContains info b cont handler _env = \case
     returnCEKValue cont handler (VBool res)
   args -> argsError info b args
 
-rawSort :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+rawSort :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 rawSort info b cont handler _env = \case
   [VList vli]
     | V.null vli -> returnCEKValue cont handler (VList mempty)
@@ -427,7 +426,7 @@ rawSort info b cont handler _env = \case
     returnCEKValue cont handler (VList vli')
   args -> argsError info b args
 
-coreRemove :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreRemove :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreRemove info b cont handler _env = \case
   [VString s, VObject o] -> do
     chargeGasArgs info $ GObjOp $ ObjOpRemove s (M.size o)
@@ -444,7 +443,7 @@ asObject info b = \case
   PObject o -> pure o
   arg -> argsError info b [VPactValue arg]
 
-rawSortObject :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+rawSortObject :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 rawSortObject info b cont handler _env = \case
   [VList fields, VList objs]
     | V.null fields -> returnCEKValue cont handler (VList objs)
@@ -482,19 +481,19 @@ dec2F = fromRational . toRational
 f2Dec :: Double -> Decimal
 f2Dec = fromRational . toRational
 
-roundDec :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+roundDec :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 roundDec = roundingFn round
 
-floorDec :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+floorDec :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 floorDec = roundingFn floor
 
-ceilingDec :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+ceilingDec :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 ceilingDec = roundingFn ceiling
 
 ---------------------------
 -- bool ops
 ---------------------------
-notBool :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+notBool :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 notBool info b cont handler _env = \case
   [VLiteral (LBool i)] -> returnCEKValue cont handler  (VLiteral (LBool (not i)))
   args -> argsError info b args
@@ -514,7 +513,7 @@ notBool info b cont handler _env = \case
 -- That's because `i` may contain values larger than `Int`, which is the type `length` typically returns.
 -- The sum `i + length t` may overflow `Int`, so it's converted to `Integer`, and the result of the `clamp` is always
 -- below `maxBound :: Int`, so it can be safely casted back without overflow.
-rawTake :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+rawTake :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 rawTake info b cont handler _env = \case
   [VLiteral (LInteger i), VLiteral (LString t)]
     | i >= 0 -> do
@@ -544,7 +543,7 @@ rawTake info b cont handler _env = \case
     returnCEKValue cont handler $ VObject $ M.restrictKeys o (S.fromList strings)
   args -> argsError info b args
 
-rawDrop :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+rawDrop :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 rawDrop info b cont handler _env = \case
   [VLiteral (LInteger i), VLiteral (LString t)]
     | i >= 0 -> do
@@ -569,7 +568,7 @@ rawDrop info b cont handler _env = \case
     returnCEKValue cont handler $ VObject $ M.withoutKeys o (S.fromList strings)
   args -> argsError info b args
 
-rawLength :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+rawLength :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 rawLength info b cont handler _env = \case
   [VString t] -> do
     chargeGasArgs info $ GStrOp $ StrOpLength $ T.length t
@@ -579,7 +578,7 @@ rawLength info b cont handler _env = \case
     returnCEKValue cont handler $ VInteger $ fromIntegral (M.size o)
   args -> argsError info b args
 
-rawReverse :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+rawReverse :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 rawReverse info b cont handler _env = \case
   [VList li] -> do
     chargeGasArgs info (GConcat (ListConcat (GasListLength (V.length li))))
@@ -589,7 +588,7 @@ rawReverse info b cont handler _env = \case
     returnCEKValue cont handler  (VLiteral (LString (T.reverse t)))
   args -> argsError info b args
 
-coreConcat :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreConcat :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreConcat info b cont handler _env = \case
   [VList li]
     | V.null li -> returnCEKValue cont handler (VString mempty)
@@ -600,7 +599,7 @@ coreConcat info b cont handler _env = \case
     returnCEKValue cont handler (VString (T.concat (V.toList li')))
   args -> argsError info b args
 
-strToList :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+strToList :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 strToList info b cont handler _env = \case
   [VLiteral (LString s)] -> do
     chargeGasArgs info $ GStrOp $ StrOpExplode $ T.length s
@@ -609,7 +608,7 @@ strToList info b cont handler _env = \case
   args -> argsError info b args
 
 
-zipList :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+zipList :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 zipList info b cont handler _env = \case
   [VClosure clo, VList l, VList r] ->
     case (V.toList l, V.toList r) of
@@ -620,7 +619,7 @@ zipList info b cont handler _env = \case
       (_, _) -> returnCEKValue cont handler (VList mempty)
   args -> argsError info b args
 
-coreMap :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreMap :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreMap info b cont handler env = \case
   [VClosure clo, VList li] -> case V.toList li of
     x:xs -> do
@@ -630,7 +629,7 @@ coreMap info b cont handler env = \case
     [] -> returnCEKValue cont handler (VList mempty)
   args -> argsError info b args
 
-coreFilter :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreFilter :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreFilter info b cont handler _env = \case
   [VClosure clo, VList li] -> case V.toList li of
     x:xs -> do
@@ -640,7 +639,7 @@ coreFilter info b cont handler _env = \case
     [] -> returnCEKValue cont handler (VList mempty)
   args -> argsError info b args
 
-coreFold :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreFold :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreFold info b cont handler _env = \case
   [VClosure clo, VPactValue initElem, VList li] ->
     case V.toList li of
@@ -651,7 +650,7 @@ coreFold info b cont handler _env = \case
       [] -> returnCEKValue cont handler (VPactValue initElem)
   args -> argsError info b args
 
-coreEnumerate :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreEnumerate :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreEnumerate info b cont handler _env = \case
   [VLiteral (LInteger from), VLiteral (LInteger to)] -> do
     v <- createEnumerateList info from to (if from > to then -1 else 1)
@@ -684,14 +683,14 @@ createEnumerateList info from to inc
     chargeGasArgs info (GMakeList len listSize)
     pure $ V.enumFromStepN from inc (fromIntegral len)
 
-coreEnumerateStepN :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreEnumerateStepN :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreEnumerateStepN info b cont handler _env = \case
   [VLiteral (LInteger from), VLiteral (LInteger to), VLiteral (LInteger inc)] -> do
     v <- createEnumerateList info from to inc
     returnCEKValue cont handler (VList (PLiteral . LInteger <$> v))
   args -> argsError info b args
 
-makeList :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+makeList :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 makeList info b cont handler _env = \case
   [VLiteral (LInteger i), VPactValue v] -> do
     vSize <- sizeOf info SizeOfV0 v
@@ -699,7 +698,7 @@ makeList info b cont handler _env = \case
     returnCEKValue cont handler (VList (V.fromList (replicate (fromIntegral i) v)))
   args -> argsError info b args
 
-coreAccess :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreAccess :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreAccess info b cont handler _env = \case
   [VLiteral (LInteger i), VList vec] ->
     case vec V.!? fromIntegral i of
@@ -714,7 +713,7 @@ coreAccess info b cont handler _env = \case
         throwExecutionError info (ObjectIsMissingField (Field field) (ObjectData o))
   args -> argsError info b args
 
-coreIsCharset :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreIsCharset :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreIsCharset info b cont handler _env = \case
   [VLiteral (LInteger i), VString s] -> do
     chargeGasArgs info $ GStrOp $ StrOpParse $ T.length s
@@ -725,7 +724,7 @@ coreIsCharset info b cont handler _env = \case
         throwNativeExecutionError info b "Unsupported character set"
   args -> argsError info b args
 
-coreYield :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreYield :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreYield info b cont handler _env = \case
   [VObject o] -> go o Nothing
   [VObject o, VString cid] -> go o (Just (ChainId cid))
@@ -748,7 +747,7 @@ coreYield info b cont handler _env = \case
   provenanceOf tid =
     Provenance tid . _mHash <$> getCallingModule info
 
-corePactId :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+corePactId :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 corePactId info b cont handler _env = \case
   [] -> use esDefPactExec >>= \case
     Just dpe -> returnCEKValue cont handler (VString (_defpactId (_peDefPactId dpe)))
@@ -768,7 +767,7 @@ enforceYield info y = case _yProvenance y of
     let p' = Provenance cid (_mHash m):map (Provenance cid) (toList $ _mBlessed m)
     unless (p `elem` p') $ throwExecutionError info (YieldProvenanceDoesNotMatch p p')
 
-coreResume :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreResume :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreResume info b cont handler _env = \case
   [VClosure clo] -> do
     mps <- viewEvalEnv eeDefPactStep
@@ -799,7 +798,7 @@ enforceTopLevelOnly info b = do
 -- Other Core forms
 -----------------------------------
 
-coreB64Encode :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreB64Encode :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreB64Encode info b cont handler _env = \case
   [VLiteral (LString l)] -> do
     chargeGasArgs info $ GStrOp $ StrOpParse $ T.length l
@@ -807,7 +806,7 @@ coreB64Encode info b cont handler _env = \case
   args -> argsError info b args
 
 
-coreB64Decode :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreB64Decode :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreB64Decode info b cont handler _env = \case
   [VLiteral (LString s)] -> do
     chargeGasArgs info $ GStrOp $ StrOpParse $ T.length s
@@ -818,7 +817,7 @@ coreB64Decode info b cont handler _env = \case
 
 
 -- | The implementation of `enforce-guard` native.
-coreEnforceGuard :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreEnforceGuard :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreEnforceGuard info b cont handler env = \case
   [VGuard g] -> enforceGuard info cont handler env g
   [VString s] -> do
@@ -829,7 +828,7 @@ coreEnforceGuard info b cont handler env = \case
       Right ksn -> isKeysetNameInSigs info cont handler env ksn
   args -> argsError info b args
 
-keysetRefGuard :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+keysetRefGuard :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 keysetRefGuard info b cont handler env = \case
   [VString g] -> do
     chargeGasArgs info $ GStrOp $ StrOpParse $ T.length g
@@ -843,7 +842,7 @@ keysetRefGuard info b cont handler env = \case
           Just _ -> returnCEKValue cont handler (VGuard (GKeySetRef ksn))
   args -> argsError info b args
 
-coreTypeOf :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreTypeOf :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreTypeOf info b cont handler _env = \case
   [v] -> case v of
     VPactValue pv ->
@@ -852,13 +851,13 @@ coreTypeOf info b cont handler _env = \case
     VTable tv -> returnCEKValue cont handler $ VString (renderType (TyTable (_tvSchema tv)))
   args -> argsError info b args
 
-coreDec :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreDec :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreDec info b cont handler _env = \case
   [VInteger i] -> returnCEKValue cont handler $ VDecimal $ Decimal 0 i
   args -> argsError info b args
 
 throwReadError
-  :: (CEKEval e step b i,  IsBuiltin b)
+  :: (CEKEval e step b i, IsBuiltin b)
   => i
   -> Cont e step b i
   -> CEKErrorHandler e step b i
@@ -898,7 +897,7 @@ can happen:
   - We may see a PDecimal, in which case we round
   - We may see a PInteger, which we read as-is.
 -}
-coreReadInteger :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreReadInteger :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreReadInteger info b cont handler _env = \case
   [VString s] -> do
     viewEvalEnv eeMsgBody >>= \case
@@ -920,7 +919,7 @@ coreReadInteger info b cont handler _env = \case
       _ -> throwReadError info cont handler b
   args -> argsError info b args
 
-coreReadMsg :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreReadMsg :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreReadMsg info b cont handler _env = \case
   [VString s] -> do
     viewEvalEnv eeMsgBody >>= \case
@@ -951,7 +950,7 @@ instance A.FromJSON ParsedDecimal where
 
 So the string parsing case accepts both the integer, and decimal output
 -}
-coreReadDecimal :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreReadDecimal :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreReadDecimal info b cont handler _env = \case
   [VString s] -> do
     viewEvalEnv eeMsgBody >>= \case
@@ -972,7 +971,7 @@ coreReadDecimal info b cont handler _env = \case
   args -> argsError info b args
 
 
-coreReadString :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreReadString :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreReadString info b cont handler _env = \case
   [VString s] -> do
     viewEvalEnv eeMsgBody >>= \case
@@ -1025,7 +1024,7 @@ readKeyset' info ksn = do
     _ -> pure Nothing
 
 
-coreReadKeyset :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreReadKeyset :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreReadKeyset info b cont handler _env = \case
   [VString ksn] ->
     readKeyset' info ksn >>= \case
@@ -1039,7 +1038,7 @@ coreReadKeyset info b cont handler _env = \case
   args -> argsError info b args
 
 
-coreBind :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreBind :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreBind info b cont handler _env = \case
   [v@VObject{}, VClosure clo] ->
     applyLam clo [v] cont handler
@@ -1050,7 +1049,7 @@ coreBind info b cont handler _env = \case
 -- Db functions
 --------------------------------------------------
 
-createTable :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+createTable :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 createTable info b cont handler env = \case
   [VTable tv] -> do
     enforceTopLevelOnly info b
@@ -1058,7 +1057,7 @@ createTable info b cont handler env = \case
     guardTable info cont' handler env tv GtCreateTable
   args -> argsError info b args
 
-dbSelect :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+dbSelect :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 dbSelect info b cont handler env = \case
   [VTable tv, VClosure clo] -> do
     let cont' = BuiltinC env info (PreSelectC tv clo Nothing) cont
@@ -1069,21 +1068,21 @@ dbSelect info b cont handler env = \case
     guardTable info cont' handler env tv GtSelect
   args -> argsError info b args
 
-foldDb :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+foldDb :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 foldDb info b cont handler env = \case
   [VTable tv, VClosure queryClo, VClosure consumer] -> do
     let cont' = BuiltinC env info (PreFoldDbC tv queryClo consumer) cont
     guardTable info cont' handler env tv GtSelect
   args -> argsError info b args
 
-dbRead :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+dbRead :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 dbRead info b cont handler env = \case
   [VTable tv, VString k] -> do
     let cont' = BuiltinC env info (ReadC tv (RowKey k)) cont
     guardTable info cont' handler env tv GtRead
   args -> argsError info b args
 
-dbWithRead :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+dbWithRead :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 dbWithRead info b cont handler env = \case
   [VTable tv, VString k, VClosure clo] -> do
     let cont1 = Fn clo env [] [] cont
@@ -1091,7 +1090,7 @@ dbWithRead info b cont handler env = \case
     guardTable info cont2 handler env tv GtWithRead
   args -> argsError info b args
 
-dbWithDefaultRead :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+dbWithDefaultRead :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 dbWithDefaultRead info b cont handler env = \case
   [VTable tv, VString k, VObject defaultObj, VClosure clo] -> do
     let cont' = BuiltinC env info (WithDefaultReadC tv (RowKey k) (ObjectData defaultObj) clo) cont
@@ -1099,10 +1098,10 @@ dbWithDefaultRead info b cont handler env = \case
   args -> argsError info b args
 
 -- | Todo: schema checking here? Or only on writes?
-dbWrite :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+dbWrite :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 dbWrite = write' Write
 
-dbInsert :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+dbInsert :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 dbInsert = write' Insert
 
 write' :: (CEKEval e step b i, IsBuiltin b) => WriteType -> NativeFunction e step b i
@@ -1115,14 +1114,14 @@ write' wt info b cont handler env = \case
 dbUpdate :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 dbUpdate = write' Update
 
-dbKeys :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+dbKeys :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 dbKeys info b cont handler env = \case
   [VTable tv] -> do
     let cont' = BuiltinC env info (KeysC tv) cont
     guardTable info cont' handler env tv GtKeys
   args -> argsError info b args
 
-dbTxIds :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+dbTxIds :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 dbTxIds info b cont handler env = \case
   [VTable tv, VInteger tid] -> do
     checkNonLocalAllowed info b
@@ -1131,7 +1130,7 @@ dbTxIds info b cont handler env = \case
   args -> argsError info b args
 
 
-dbTxLog :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+dbTxLog :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 dbTxLog info b cont handler env = \case
   [VTable tv, VInteger tid] -> do
     checkNonLocalAllowed info b
@@ -1139,7 +1138,7 @@ dbTxLog info b cont handler env = \case
     guardTable info cont' handler env tv GtTxLog
   args -> argsError info b args
 
-dbKeyLog :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+dbKeyLog :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 dbKeyLog info b cont handler env = \case
   [VTable tv, VString key, VInteger tid] -> do
     checkNonLocalAllowed info b
@@ -1181,7 +1180,7 @@ defineKeySet' info cont handler env ksname newKs  = do
             let cont' = BuiltinC env info (DefineKeysetC ksn newKs) cont
             enforceGuard info cont' handler env uGuard
 
-defineKeySet :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+defineKeySet :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 defineKeySet info b cont handler env = \case
   [VString ksname, VGuard (GKeyset ks)] -> do
     enforceTopLevelOnly info b
@@ -1198,7 +1197,7 @@ defineKeySet info b cont handler env = \case
 -- Capabilities
 --------------------------------------------------
 
-requireCapability :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+requireCapability :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 requireCapability info b cont handler _env = \case
   [VCapToken ct] -> do
     slots <- use $ esCaps . csSlots
@@ -1208,14 +1207,14 @@ requireCapability info b cont handler _env = \case
   args -> argsError info b args
 
 
-composeCapability :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+composeCapability :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 composeCapability info b cont handler env = \case
   [VCapToken ct] -> do
     enforceStackTopIsDefcap info b
     composeCap info cont handler env ct
   args -> argsError info b args
 
-installCapability :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+installCapability :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 installCapability info b cont handler env = \case
   [VCapToken ct] -> do
     enforceNotWithinDefcap info env "install-capability"
@@ -1223,7 +1222,7 @@ installCapability info b cont handler env = \case
     returnCEKValue cont handler (VString "Installed capability")
   args -> argsError info b args
 
-coreEmitEvent :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreEmitEvent :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreEmitEvent info b cont handler env = \case
   [VCapToken ct@(CapToken fqn _)] -> do
     let cont' = BuiltinC env info (EmitEventC ct) cont
@@ -1238,7 +1237,7 @@ coreEmitEvent info b cont handler env = \case
         enforceMeta _ = pure ()
   args -> argsError info b args
 
-createCapGuard :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+createCapGuard :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 createCapGuard info b cont handler _env = \case
   [VCapToken ct] -> do
     let qn = fqnToQualName (_ctName ct)
@@ -1246,7 +1245,7 @@ createCapGuard info b cont handler _env = \case
     returnCEKValue cont handler (VGuard (GCapabilityGuard cg))
   args -> argsError info b args
 
-createCapabilityPactGuard :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+createCapabilityPactGuard :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 createCapabilityPactGuard info b cont handler _env = \case
   [VCapToken ct] -> do
     pid <- getDefPactId info
@@ -1255,7 +1254,7 @@ createCapabilityPactGuard info b cont handler _env = \case
     returnCEKValue cont handler (VGuard (GCapabilityGuard cg))
   args -> argsError info b args
 
-createModuleGuard :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+createModuleGuard :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 createModuleGuard info b cont handler _env = \case
   [VString n] ->
     findCallingModule >>= \case
@@ -1266,7 +1265,7 @@ createModuleGuard info b cont handler _env = \case
         throwNativeExecutionError info b "create-module-guard: must call within module"
   args -> argsError info b args
 
-createDefPactGuard :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+createDefPactGuard :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 createDefPactGuard info b cont handler _env = \case
   [VString name] -> do
     dpid <- getDefPactId info
@@ -1274,7 +1273,7 @@ createDefPactGuard info b cont handler _env = \case
   args -> argsError info b args
 
 
-coreIntToStr :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreIntToStr :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreIntToStr info b cont handler _env = \case
   [VInteger base, VInteger v]
     | v < 0 ->
@@ -1296,7 +1295,7 @@ coreIntToStr info b cont handler _env = \case
       throwNativeExecutionError info b "invalid base for base64URL conversion"
   args -> argsError info b args
 
-coreStrToInt :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreStrToInt :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreStrToInt info b cont handler _env = \case
   [VString s] -> do
     chargeGasArgs info $ GStrOp $ StrOpParse $ T.length s
@@ -1304,7 +1303,7 @@ coreStrToInt info b cont handler _env = \case
     doBase info cont handler 10 s
   args -> argsError info b args
 
-coreStrToIntBase :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreStrToIntBase :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreStrToIntBase info b cont handler _env = \case
   [VInteger base, VString s]
     | base == 64 -> do
@@ -1333,7 +1332,7 @@ nubByM eq = go
     xs' <- filterM (fmap not . eq x) xs
     (x :) <$> go xs'
 
-coreDistinct  :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreDistinct  :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreDistinct info b cont handler _env = \case
   [VList s] -> do
     uniques <- nubByM (valEqGassed info) $ V.toList s
@@ -1342,7 +1341,7 @@ coreDistinct info b cont handler _env = \case
       $ V.fromList uniques
   args -> argsError info b args
 
-coreFormat  :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreFormat  :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreFormat info b cont handler _env = \case
   [VString s, VList es] -> do
     let parts = T.splitOn "{}" s
@@ -1418,28 +1417,28 @@ integerToBS v = BS.pack $ reverse $ go v
          | otherwise = fromIntegral (i .&. 0xff):go (shift i (-8))
 
 
-coreAndQ :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreAndQ :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreAndQ info b cont handler env = \case
   [VClosure l, VClosure r, VPactValue v] -> do
     let cont' =  CondC env info (AndQC r v) cont
     applyLam l [VPactValue v] cont' handler
   args -> argsError info b args
 
-coreOrQ :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreOrQ :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreOrQ info b cont handler env = \case
   [VClosure l, VClosure r, VPactValue v] -> do
     let cont' =  CondC env info (OrQC r v) cont
     applyLam l [VPactValue v] cont' handler
   args -> argsError info b args
 
-coreNotQ :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreNotQ :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreNotQ info b cont handler env = \case
   [VClosure clo, VPactValue v] -> do
     let cont' = CondC env info NotQC cont
     applyLam clo [VPactValue v] cont' handler
   args -> argsError info b args
 
-coreWhere :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreWhere :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreWhere info b cont handler _env = \case
   [VString field, VClosure app, VObject o] -> do
     case M.lookup (Field field) o of
@@ -1450,7 +1449,7 @@ coreWhere info b cont handler _env = \case
         throwExecutionError info (ObjectIsMissingField (Field field) (ObjectData o))
   args -> argsError info b args
 
-coreHash :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreHash :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreHash = \info b cont handler _env -> \case
   [VString s] ->
     returnCEKValue cont handler (go (T.encodeUtf8 s))
@@ -1460,20 +1459,20 @@ coreHash = \info b cont handler _env -> \case
   where
   go =  VString . hashToText . pactHash
 
-txHash :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+txHash :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 txHash info b cont handler _env = \case
   [] -> do
     h <- viewEvalEnv eeHash
     returnCEKValue cont handler (VString (hashToText h))
   args -> argsError info b args
 
-coreContinue :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreContinue :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreContinue info b cont handler _env = \case
   [v] -> do
     returnCEKValue cont handler v
   args -> argsError info b args
 
-parseTime :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+parseTime :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 parseTime info b cont handler _env = \case
   [VString fmt, VString s] -> do
     chargeGasArgs info $ GStrOp $ StrOpParseTime (T.length fmt) (T.length s)
@@ -1483,7 +1482,7 @@ parseTime info b cont handler _env = \case
         throwNativeExecutionError info b $ "parse-time parse failure"
   args -> argsError info b args
 
-formatTime :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+formatTime :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 formatTime info b cont handler _env = \case
   [VString fmt, VPactValue (PTime t)] -> do
     chargeGasArgs info $ GStrOp $ StrOpFormatTime $ T.length fmt
@@ -1491,7 +1490,7 @@ formatTime info b cont handler _env = \case
     returnCEKValue cont handler $ VString (T.pack timeString)
   args -> argsError info b args
 
-time :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+time :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 time info b cont handler _env = \case
   [VString s] -> do
     case PactTime.parseTime "%Y-%m-%dT%H:%M:%SZ" (T.unpack s) of
@@ -1500,7 +1499,7 @@ time info b cont handler _env = \case
         throwNativeExecutionError info b $ "time default format parse failure"
   args -> argsError info b args
 
-addTime :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+addTime :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 addTime info b cont handler _env = \case
   [VPactValue (PTime t), VPactValue (PDecimal seconds)] -> do
       let newTime = t PactTime..+^ PactTime.fromSeconds seconds
@@ -1510,14 +1509,14 @@ addTime info b cont handler _env = \case
       returnCEKValue cont handler $ VPactValue (PTime newTime)
   args -> argsError info b args
 
-diffTime :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+diffTime :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 diffTime info b cont handler _env = \case
   [VPactValue (PTime x), VPactValue (PTime y)] -> do
     let secondsDifference = PactTime.toSeconds $ x PactTime..-. y
     returnCEKValue cont handler $ VPactValue $ PDecimal secondsDifference
   args -> argsError info b args
 
-minutes :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+minutes :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 minutes info b cont handler _env = \case
   [VDecimal x] -> do
     let seconds = x * 60
@@ -1527,7 +1526,7 @@ minutes info b cont handler _env = \case
     returnCEKValue cont handler $ VDecimal seconds
   args -> argsError info b args
 
-hours :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+hours :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 hours info b cont handler _env = \case
   [VDecimal x] -> do
     let seconds = x * 60 * 60
@@ -1537,7 +1536,7 @@ hours info b cont handler _env = \case
     returnCEKValue cont handler $ VDecimal seconds
   args -> argsError info b args
 
-days :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+days :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 days info b cont handler _env = \case
   [VDecimal x] -> do
     let seconds = x * 60 * 60 * 24
@@ -1547,7 +1546,7 @@ days info b cont handler _env = \case
     returnCEKValue cont handler $ VDecimal seconds
   args -> argsError info b args
 
-describeModule :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+describeModule :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 describeModule info b cont handler env = \case
   [VString s] -> case parseModuleName s of
     Just mname -> do
@@ -1568,7 +1567,7 @@ describeModule info b cont handler env = \case
       throwNativeExecutionError info b $ "invalid module name format"
   args -> argsError info b args
 
-dbDescribeTable :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+dbDescribeTable :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 dbDescribeTable info b cont handler _env = \case
   [VTable (TableValue name _ schema)] -> do
     enforceTopLevelOnly info b
@@ -1578,7 +1577,7 @@ dbDescribeTable info b cont handler _env = \case
       ,("type", PString (renderType (TyTable schema)))]
   args -> argsError info b args
 
-dbDescribeKeySet :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+dbDescribeKeySet :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 dbDescribeKeySet info b cont handler env = \case
   [VString s] -> do
     let pdb = _cePactDb env
@@ -1594,7 +1593,7 @@ dbDescribeKeySet info b cont handler env = \case
         throwNativeExecutionError info b  "incorrect keyset name format"
   args -> argsError info b args
 
-coreCompose :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreCompose :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreCompose info b cont handler env = \case
   [VClosure clo1, VClosure clo2, v] -> do
     let cont' = Fn clo2 env [] [] cont
@@ -1640,21 +1639,21 @@ createPrincipalForGuard info = \case
       pure $ pactHash bs
 
 
-coreCreatePrincipal :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreCreatePrincipal :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreCreatePrincipal info b cont handler _env = \case
   [VGuard g] -> do
     pr <- createPrincipalForGuard info g
     returnCEKValue cont handler $ VString $ Pr.mkPrincipalIdent pr
   args -> argsError info b args
 
-coreIsPrincipal :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreIsPrincipal :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreIsPrincipal info b cont handler _env = \case
   [VString p] -> do
     chargeGasArgs info $ GStrOp $ StrOpParse $ T.length p
     returnCEKValue cont handler $ VBool $ isRight $ parseOnly Pr.principalParser p
   args -> argsError info b args
 
-coreTypeOfPrincipal :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreTypeOfPrincipal :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreTypeOfPrincipal info b cont handler _env = \case
   [VString p] -> do
     chargeGasArgs info $ GStrOp $ StrOpParse $ T.length p
@@ -1664,7 +1663,7 @@ coreTypeOfPrincipal info b cont handler _env = \case
     returnCEKValue cont handler $ VString prty
   args -> argsError info b args
 
-coreValidatePrincipal :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreValidatePrincipal :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreValidatePrincipal info b cont handler _env = \case
   [VGuard g, VString s] -> do
     pr' <- createPrincipalForGuard info g
@@ -1673,13 +1672,13 @@ coreValidatePrincipal info b cont handler _env = \case
   args -> argsError info b args
 
 
-coreCond :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreCond :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreCond info b cont handler _env = \case
   [VClosure clo] -> applyLam clo [] cont handler
   args -> argsError info b args
 
 
-coreIdentity :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreIdentity :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreIdentity info b cont handler _env = \case
   [VPactValue pv] -> returnCEKValue cont handler $ VPactValue pv
   args -> argsError info b args
@@ -1688,7 +1687,7 @@ coreIdentity info b cont handler _env = \case
 --------------------------------------------------
 -- Namespace functions
 --------------------------------------------------
-coreNamespace :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreNamespace :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreNamespace info b cont handler env = \case
   [VString n] -> do
     enforceTopLevelOnly info b
@@ -1710,7 +1709,7 @@ coreNamespace info b cont handler env = \case
   args -> argsError info b args
 
 
-coreDefineNamespace :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreDefineNamespace :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreDefineNamespace info b cont handler env = \case
   [VString n, VGuard usrG, VGuard adminG] -> do
     enforceTopLevelOnly info b
@@ -1754,7 +1753,7 @@ coreDefineNamespace info b cont handler env = \case
   validSpecialChars =
     "%#+-_&$@<>=^?*!|/~"
 
-coreDescribeNamespace :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreDescribeNamespace :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreDescribeNamespace info b cont handler _env = \case
   [VString n] -> do
     pdb <- viewEvalEnv eePactDb
@@ -1773,7 +1772,7 @@ coreDescribeNamespace info b cont handler _env = \case
   args -> argsError info b args
 
 
-coreChainData :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreChainData :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreChainData info b cont handler _env = \case
   [] -> do
     PublicData publicMeta blockHeight blockTime prevBh <- viewEvalEnv eePublicData
@@ -1846,8 +1845,8 @@ fromG2 (Point x y) = ObjectData pts
     , (Field "y", y')]
 
 
-zkPairingCheck :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
--- zkPairingCheck :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+zkPairingCheck :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
+-- zkPairingCheck :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 zkPairingCheck info b cont handler _env = \case
   args@[VList p1s, VList p2s] -> do
     chargeGasArgs info (GAZKArgs (Pairing (max (V.length p1s) (V.length p2s))))
@@ -1859,7 +1858,7 @@ zkPairingCheck info b cont handler _env = \case
     returnCEKValue cont handler $ VBool $ pairingCheck pairs
   args -> argsError info b args
 
-zkScalarMult :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+zkScalarMult :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 zkScalarMult info b cont handler _env = \case
   args@[VString ptTy, VObject p1, VInteger scalar] -> do
     let scalar' = scalar `mod` curveOrder
@@ -1884,7 +1883,7 @@ zkScalarMult info b cont handler _env = \case
   curveOrder :: Integer
   curveOrder = 21888242871839275222246405745257275088548364400416034343698204186575808495617
 
-zkPointAddition :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+zkPointAddition :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 zkPointAddition info b cont handler _env = \case
   args@[VString ptTy, VObject p1, VObject p2] -> do
     case T.toLower ptTy of
@@ -1914,7 +1913,7 @@ zkPointAddition info b cont handler _env = \case
 -- Poseidon
 -----------------------------------
 
-poseidonHash :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+poseidonHash :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 poseidonHash info b cont handler _env = \case
   [VList as]
     | not (V.null as) && length as <= 8,
@@ -1943,7 +1942,7 @@ poseidonHash info _b _cont _handler _env _args = throwExecutionError info $ Eval
 -- SPV
 -----------------------------------
 
-coreVerifySPV :: (CEKEval e step b i,  IsBuiltin b) => NativeFunction e step b i
+coreVerifySPV :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreVerifySPV info b cont handler _env = \case
   [VString proofType, VObject o] -> do
     SPVSupport f _ <- viewEvalEnv eeSPVSupport
@@ -1994,7 +1993,7 @@ coreBuiltinEnv i b env = mkBuiltinFn i b env (coreBuiltinRuntime b)
    -> NativeFunction ExecRuntime CEKSmallStep CoreBuiltin i
     #-}
 coreBuiltinRuntime
-  :: (CEKEval e step b i,  IsBuiltin b)
+  :: (CEKEval e step b i, IsBuiltin b)
   => CoreBuiltin
   -> NativeFunction e step b i
 coreBuiltinRuntime = \case

--- a/pact/Pact/Core/IR/Eval/Direct/Evaluator.hs
+++ b/pact/Pact/Core/IR/Eval/Direct/Evaluator.hs
@@ -160,11 +160,11 @@ interpretGuard
   => i
   -> BuiltinEnv b i m
   -> Guard QualifiedName PactValue
-  -> m Bool
+  -> m PactValue
 interpretGuard info bEnv g = do
   ee <- readEnv
   let eEnv = DirectEnv mempty (_eePactDb ee) bEnv (_eeDefPactStep ee) False
-  enforceGuard info eEnv g
+  PBool <$> enforceGuard info eEnv g
 
 evalResumePact
   :: (MonadEval b i m)

--- a/pact/Pact/Core/IR/Eval/Direct/Evaluator.hs
+++ b/pact/Pact/Core/IR/Eval/Direct/Evaluator.hs
@@ -34,15 +34,14 @@ module Pact.Core.IR.Eval.Direct.Evaluator
 import Control.Lens hiding (op, from, to, parts)
 import Control.Monad
 import Control.Monad.Except
-import Control.Monad.IO.Class
+import Control.Monad.Reader
+import Control.Monad.State.Strict
 import Data.Text(Text)
-import Data.List (find)
-import Data.Foldable (foldl')
+import Data.Foldable
 import Data.Maybe(catMaybes)
 import Data.List.NonEmpty(NonEmpty(..))
 import Data.Bits
 import Data.Either(isLeft, isRight)
-import Data.Foldable(foldlM, traverse_, toList)
 import Data.Decimal(roundTo', Decimal, DecimalRaw(..))
 import Data.Vector(Vector)
 import Data.Maybe(maybeToList)
@@ -108,11 +107,10 @@ import qualified Pact.Core.Trans.TOps as Musl
 
 
 mkDefunClosure
-  :: (MonadEval b i m)
-  => EvalDefun b i
+  :: EvalDefun b i
   -> FullyQualifiedName
-  -> DirectEnv b i m
-  -> m (Closure b i m)
+  -> DirectEnv e b i
+  -> EvalM e b i (Closure e b i)
 mkDefunClosure d fqn e = case _dfunTerm d of
   Lam args body i ->
     pure (Closure fqn (ArgClosure args) (NE.length args) body (_dfunRType d) e i)
@@ -126,8 +124,8 @@ mkDefPactClosure
   :: i
   -> FullyQualifiedName
   -> DefPact Name Type b i
-  -> DirectEnv b i m
-  -> EvalValue b i m
+  -> DirectEnv e b i
+  -> EvalValue e b i
 mkDefPactClosure info fqn dpact env = case _dpArgs dpact of
   [] ->
     let dpc = DefPactClosure fqn NullaryClosure 0 env info
@@ -136,44 +134,44 @@ mkDefPactClosure info fqn dpact env = case _dpArgs dpact of
     let dpc = DefPactClosure fqn (ArgClosure (x :| xs)) (length (x:xs)) env info
     in VDefPactClosure dpc
 
-envFromPurity :: Purity -> DirectEnv b i m -> DirectEnv b i m
+envFromPurity :: Purity -> DirectEnv e b i -> DirectEnv e b i
 envFromPurity PImpure = id
 envFromPurity PReadOnly = readOnlyEnv
 envFromPurity PSysOnly = sysOnlyEnv
 
 eval
-  :: (MonadEval b i m)
+  :: (IsBuiltin b)
   => Purity
-  -> BuiltinEnv b i m
+  -> BuiltinEnv e b i
   -> EvalTerm b i
-  -> m PactValue
+  -> EvalM e b i PactValue
 eval purity benv term = do
-  ee <- readEnv
+  ee <- viewEvalEnv id
   let directEnv = envFromPurity purity (DirectEnv mempty (_eePactDb ee) benv (_eeDefPactStep ee) False)
   evaluate directEnv term >>= \case
     VPactValue pv -> pure pv
     _ -> throwExecutionError (view termInfo term) (EvalError "Evaluation did not reduce to a value")
 
 interpretGuard
-  :: forall b i m
-  .  (MonadEval b i m)
+  :: forall e b i
+  .  (IsBuiltin b)
   => i
-  -> BuiltinEnv b i m
+  -> BuiltinEnv e b i
   -> Guard QualifiedName PactValue
-  -> m PactValue
+  -> EvalM e b i PactValue
 interpretGuard info bEnv g = do
-  ee <- readEnv
+  ee <- viewEvalEnv id
   let eEnv = DirectEnv mempty (_eePactDb ee) bEnv (_eeDefPactStep ee) False
   PBool <$> enforceGuard info eEnv g
 
 evalResumePact
-  :: (MonadEval b i m)
+  :: (IsBuiltin b)
   => i
-  -> BuiltinEnv b i m
+  -> BuiltinEnv e b i
   -> Maybe DefPactExec
-  -> m PactValue
+  -> EvalM e b i PactValue
 evalResumePact info bEnv mdpe = do
-  ee <- readEnv
+  ee <- viewEvalEnv id
   let pdb = _eePactDb ee
   let env = DirectEnv mempty pdb bEnv (_eeDefPactStep ee) False
   resumePact info env mdpe >>= \case
@@ -182,10 +180,10 @@ evalResumePact info bEnv mdpe = do
       throwExecutionError info (EvalError "Evaluation did not reduce to a value")
 
 evaluate
-  :: MonadEval b i m
-  => DirectEnv b i m
+  :: IsBuiltin b
+  => DirectEnv e b i
   -> EvalTerm b i
-  -> m (EvalValue b i m)
+  -> EvalM e b i (EvalValue e b i)
 evaluate env = \case
   Var n info -> do
     case _nKind n of
@@ -341,14 +339,14 @@ evaluate env = \case
 --   - If the cap is managed, install the cap (If possible) then evaluate the body, and if
 --     the cap is user managed, ensure that the manager function run after the cap body
 evalCap
-  :: (MonadEval b i m)
+  :: (IsBuiltin b)
   => i
-  -> DirectEnv b i m
+  -> DirectEnv e b i
   -> FQCapToken
   -> CapPopState
   -> EvalCapType
   -> EvalTerm b i
-  -> m (EvalValue b i m)
+  -> EvalM e b i (EvalValue e b i)
 evalCap info env origToken@(CapToken fqn args) popType ecType contbody = do
   capInStack <- isCapInStack' origToken
   if not capInStack then go else evaluate env contbody
@@ -369,7 +367,7 @@ evalCap info env origToken@(CapToken fqn args) popType ecType contbody = do
           DefManagedMeta (cix,_) _ -> do
             let filteredCap = CapToken qualCapName (filterIndex cix args)
             -- Find the capability post-filtering
-            mgdCaps <- useEvalState (esCaps . csManaged)
+            mgdCaps <- use (esCaps . csManaged)
             case find ((==) filteredCap . _mcCap) mgdCaps of
               Nothing -> do
                 msgCaps <- S.unions <$> viewEvalEnv eeMsgSigs
@@ -387,7 +385,7 @@ evalCap info env origToken@(CapToken fqn args) popType ecType contbody = do
           AutoManagedMeta -> do
             -- Find the capability post-filtering
             let emittedEvent = fqctToPactEvent origToken <$ guard (ecType == NormalCapEval)
-            mgdCaps <- useEvalState (esCaps . csManaged)
+            mgdCaps <- use (esCaps . csManaged)
             case find ((==) qualCapToken . _mcCap) mgdCaps of
               Nothing -> do
                 msgCaps <- S.unions <$> viewEvalEnv eeMsgSigs
@@ -400,23 +398,23 @@ evalCap info env origToken@(CapToken fqn args) popType ecType contbody = do
               Just managedCap ->
                 evalAutomanagedCap emittedEvent newLocals capBody managedCap
       DefEvent -> do
-        oldCapsBeingEvaluated <- useEvalState (esCaps.csCapsBeingEvaluated)
+        oldCapsBeingEvaluated <- use (esCaps.csCapsBeingEvaluated)
         let event = Just (fqctToPactEvent origToken)
         let inCapEnv = set ceInCap True $ set ceLocal newLocals env
-        (esCaps . csSlots) %== (CapSlot qualCapToken []:)
-        (esCaps . csCapsBeingEvaluated) %== S.insert qualCapToken
+        (esCaps . csSlots) %= (CapSlot qualCapToken []:)
+        (esCaps . csCapsBeingEvaluated) %= S.insert qualCapToken
         _ <- evalWithStackFrame info capStackFrame Nothing (evaluate inCapEnv capBody)
-        (esCaps . csCapsBeingEvaluated) .== oldCapsBeingEvaluated
+        (esCaps . csCapsBeingEvaluated) .= oldCapsBeingEvaluated
         evalWithCapBody info popType Nothing event env contbody
       -- Not automanaged _nor_ user managed.
       Unmanaged -> do
         let inCapEnv = set ceInCap True $ set ceLocal newLocals env
-        oldCapsBeingEvaluated <- useEvalState (esCaps.csCapsBeingEvaluated)
-        (esCaps . csSlots) %== (CapSlot qualCapToken []:)
-        (esCaps . csCapsBeingEvaluated) %== S.insert qualCapToken
+        oldCapsBeingEvaluated <- use (esCaps.csCapsBeingEvaluated)
+        (esCaps . csSlots) %= (CapSlot qualCapToken []:)
+        (esCaps . csCapsBeingEvaluated) %= S.insert qualCapToken
         -- we ignore the capbody here
         _ <- evalWithStackFrame info capStackFrame Nothing $ evaluate inCapEnv capBody
-        (esCaps . csCapsBeingEvaluated) .== oldCapsBeingEvaluated
+        (esCaps . csCapsBeingEvaluated) .= oldCapsBeingEvaluated
         case ecType of
           NormalCapEval -> do
             evalWithCapBody info popType Nothing Nothing env contbody
@@ -438,21 +436,21 @@ evalCap info env origToken@(CapToken fqn args) popType ecType contbody = do
       -- pops it. It would be great to do without this, but a lot of our regressions rely on this.
       let inCapEnv = set ceInCap True $ set ceLocal env' $ env
       let inCapBodyToken = _mcOriginalCap managedCap
-      oldCapsBeingEvaluated <- useEvalState (esCaps.csCapsBeingEvaluated)
+      oldCapsBeingEvaluated <- use (esCaps.csCapsBeingEvaluated)
       -- BIG SEMANTICS NOTE HERE
       -- the cap slot here that we push should NOT be the qualified original token.
       -- Instead, it's the original token from the installed from the static cap. Otherwise, enforce checks
       -- within the cap body will fail (That is, keyset enforcement). Instead, once we are evaluating the body,
       -- we pop the current cap stack, then replace the head with the original intended token.
       -- this is done in `CapBodyC` and this is the only way to do this.
-      (esCaps . csSlots) %== (CapSlot inCapBodyToken []:)
-      (esCaps . csCapsBeingEvaluated) %== S.insert inCapBodyToken
+      (esCaps . csSlots) %= (CapSlot inCapBodyToken []:)
+      (esCaps . csCapsBeingEvaluated) %= S.insert inCapBodyToken
       _ <- evalWithStackFrame info capStackFrame Nothing (evaluate inCapEnv capBody)
-      (esCaps . csCapsBeingEvaluated) .== oldCapsBeingEvaluated
+      (esCaps . csCapsBeingEvaluated) .= oldCapsBeingEvaluated
       when (ecType == NormalCapEval) $ do
         updatedV <- enforcePactValue info =<< applyLam (C dfunClo) [VPactValue oldV, VPactValue newV]
         let mcap' = unsafeUpdateManagedParam updatedV managedCap
-        (esCaps . csManaged) %== S.insert mcap'
+        (esCaps . csManaged) %= S.insert mcap'
       evalWithCapBody info popType (Just qualCapToken) emitted env contbody
     _ -> failInvariant info (InvariantInvalidManagedCapKind "expected user managed, received automanaged")
   evalAutomanagedCap emittedEvent env' capBody managedCap = case _mcManaged managedCap of
@@ -460,53 +458,52 @@ evalCap info env origToken@(CapToken fqn args) popType ecType contbody = do
       if b then throwUserRecoverableError info OneShotCapAlreadyUsed
       else do
         let newManaged = AutoManaged True
-        oldCapsBeingEvaluated <- useEvalState (esCaps.csCapsBeingEvaluated)
-        esCaps . csManaged %== S.union (S.singleton (set mcManaged newManaged managedCap))
-        esCaps . csSlots %== (CapSlot qualCapToken []:)
-        (esCaps . csCapsBeingEvaluated) %== S.insert qualCapToken
+        oldCapsBeingEvaluated <- use (esCaps.csCapsBeingEvaluated)
+        esCaps . csManaged %= S.union (S.singleton (set mcManaged newManaged managedCap))
+        esCaps . csSlots %= (CapSlot qualCapToken []:)
+        (esCaps . csCapsBeingEvaluated) %= S.insert qualCapToken
         let inCapEnv = set ceLocal env' $ set ceInCap True $ env
         _ <- evalWithStackFrame info capStackFrame Nothing (evaluate inCapEnv capBody)
-        (esCaps . csCapsBeingEvaluated) .== oldCapsBeingEvaluated
+        (esCaps . csCapsBeingEvaluated) .= oldCapsBeingEvaluated
 
         evalWithCapBody info popType Nothing emittedEvent env contbody
     _ -> failInvariant info (InvariantInvalidManagedCapKind "expected automanaged, received user managed")
 
 evalWithCapBody
-  :: (MonadEval b i m)
+  :: (IsBuiltin b)
   => i
   -> CapPopState
   -> Maybe (CapToken QualifiedName PactValue)
   -> Maybe (PactEvent PactValue)
-  -> DirectEnv b i m
+  -> DirectEnv e b i
   -> EvalTerm b i
-  -> m (EvalValue b i m)
+  -> EvalM e b i (EvalValue e b i)
 evalWithCapBody info cappop mcap mevent env capbody = do
   maybe (pure ()) emitEventUnsafe mevent
   case mcap of
     Nothing -> do
       v <- evaluate env capbody
       popCap info cappop v
-    Just cap -> useEvalState (esCaps . csSlots) >>= \case
+    Just cap -> use (esCaps . csSlots) >>= \case
       (CapSlot _ tl:rest) -> do
-        setEvalState (esCaps . csSlots)  (CapSlot cap tl:rest)
+        (esCaps . csSlots) .= (CapSlot cap tl:rest)
         v <- evaluate env capbody
         popCap info cappop v
       [] -> failInvariant info InvariantEmptyCapStackFailure
 
 popCap
-  :: (MonadEval b i m)
-  => i
+  :: i
   -> CapPopState
-  -> EvalValue b i m
-  -> m (EvalValue b i m)
+  -> EvalValue e b i
+  -> EvalM e b i (EvalValue e b i)
 popCap info cappop v = case cappop of
-  PopCapInvoke -> v <$ (esCaps . csSlots %== safeTail)
+  PopCapInvoke -> v <$ (esCaps . csSlots %= safeTail)
   PopCapComposed -> do
-    useEvalState (esCaps . csSlots) >>= \case
+    use (esCaps . csSlots) >>= \case
       cap:cs -> do
         let csList = _csCap cap : _csComposed cap
             caps' = over (_head . csComposed) (++ csList) cs
-        setEvalState (esCaps . csSlots) caps'
+        (esCaps . csSlots) .= caps'
         return v
       [] -> failInvariant info InvariantEmptyCapStackFailure
 
@@ -515,11 +512,10 @@ popCap info cappop v = case cappop of
 -- Todo: fail invariant
 -- Todo: is this enough checks for ndynref?
 nameToFQN
-  :: (MonadEval b i m)
-  => i
-  -> DirectEnv b i m
+  :: i
+  -> DirectEnv e b i
   -> Name
-  -> m FullyQualifiedName
+  -> EvalM e b i FullyQualifiedName
 nameToFQN info env (Name n nk) = case nk of
   NTopLevel mn mh -> pure (FullyQualifiedName mn n mh)
   NDynRef (DynamicRef dArg i) -> case RAList.lookup (view ceLocal env) i of
@@ -531,12 +527,12 @@ nameToFQN info env (Name n nk) = case nk of
   _ -> failInvariant info (InvariantInvalidBoundVariable n)
 
 guardTable
-  :: (MonadEval b i m)
+  :: (IsBuiltin b)
   => i
-  -> DirectEnv b i m
+  -> DirectEnv e b i
   -> TableValue
   -> GuardTableOp
-  -> m ()
+  -> EvalM e b i ()
 guardTable i env (TableValue tn mh _) dbop = do
   let mn = _tableModuleName tn
   checkLocalBypass $
@@ -551,22 +547,14 @@ guardTable i env (TableValue tn mh _) dbop = do
       GtCreateTable -> notBypassed
       _ | enabled -> return ()
         | otherwise -> notBypassed
-{-# SPECIALIZE guardTable
-   :: ()
-   -> DirectEnv CoreBuiltin () Eval
-   -> TableValue
-   -> GuardTableOp
-   -> Eval ()
-    #-}
 
 
 -- Todo: should we typecheck / arity check here?
 createUserGuard
-  :: (MonadEval b i m)
-  => i
+  :: i
   -> FullyQualifiedName
   -> [PactValue]
-  -> m (EvalValue b i m)
+  -> EvalM e b i (EvalValue e b i)
 createUserGuard info fqn args =
   lookupFqName fqn >>= \case
     Just (Dfun _) ->
@@ -581,46 +569,45 @@ createUserGuard info fqn args =
       failInvariant info (InvariantUnboundFreeVariable fqn)
 
 enforceNotWithinDefcap
-  :: (MonadEval b i m)
-  => i
-  -> DirectEnv b i m
+  :: i
+  -> DirectEnv e b i
   -> T.Text
-  -> m ()
+  -> EvalM e b i ()
 enforceNotWithinDefcap info env form =
   when (_ceInCap env) $ throwExecutionError info (FormIllegalWithinDefcap form)
 
-enforceBool :: (MonadEval b i m) => i -> EvalValue b i m -> m Bool
+enforceBool :: i -> EvalValue e b i -> EvalM e b i Bool
 enforceBool info = \case
   VBool b -> pure b
   VPactValue v' -> throwExecutionError info (ExpectedBoolValue v')
   _ -> throwExecutionError info ExpectedPactValue
 
-enforceBool' :: (MonadEval b i m) => i -> EvalValue b i m -> m (EvalValue b i m)
+enforceBool' :: i -> EvalValue e b i -> EvalM e b i (EvalValue e b i)
 enforceBool' info = \case
   v@VBool{} -> pure v
   VPactValue v' -> throwExecutionError info (ExpectedBoolValue v')
   _ -> throwExecutionError info ExpectedPactValue
 
-enforceString :: (MonadEval b i m) => i -> EvalValue b i m -> m Text
+enforceString ::i -> EvalValue e b i -> EvalM e b i Text
 enforceString info = \case
   VString b -> pure b
   VPactValue v' -> throwExecutionError info $ ExpectedStringValue v'
   _ -> throwExecutionError info $ ExpectedPactValue
 
 
-enforceCapToken :: (MonadEval b i m) => i -> EvalValue b i m -> m (CapToken FullyQualifiedName PactValue)
+enforceCapToken :: i -> EvalValue e b i -> EvalM e b i (CapToken FullyQualifiedName PactValue)
 enforceCapToken info = \case
   VCapToken b -> pure b
   VPactValue v' -> throwExecutionError info $ ExpectedCapToken v'
   _ -> throwExecutionError info $ ExpectedPactValue
 
-enforceBoolValue :: (MonadEval b i m) => i -> EvalValue b i m -> m (EvalValue b i m)
+enforceBoolValue :: i -> EvalValue e b i -> EvalM e b i (EvalValue e b i)
 enforceBoolValue info = \case
   VBool b -> pure (VBool b)
   VPactValue v' -> throwExecutionError info (ExpectedBoolValue v')
   _ -> throwExecutionError info ExpectedPactValue
 
-enforceUserAppClosure :: (MonadEval b i m) => i -> EvalValue b i m -> m (CanApply b i m)
+enforceUserAppClosure :: i -> EvalValue e b i -> EvalM e b i (CanApply e b i)
 enforceUserAppClosure info = \case
   VClosure c -> case c of
     C clo -> pure (C clo)
@@ -632,28 +619,28 @@ enforceUserAppClosure info = \case
   _ -> throwExecutionError info CannotApplyValueToNonClosure
 
 
-enforcePactValue :: (MonadEval b i m) => i -> EvalValue b i m -> m PactValue
+enforcePactValue :: i -> EvalValue e b i -> EvalM e b i PactValue
 enforcePactValue info = \case
   VPactValue pv -> pure pv
   _ -> throwExecutionError info ExpectedPactValue
 
-enforcePactValue' :: (MonadEval b i m) => i -> EvalValue b i m -> m (EvalValue b i m)
+enforcePactValue' :: i -> EvalValue e b i -> EvalM e b i (EvalValue e b i)
 enforcePactValue' info = \case
   VPactValue pv -> pure (VPactValue pv)
   _ -> throwExecutionError info ExpectedPactValue
 
-catchRecoverable :: forall b i m a. (MonadEval b i m) => m a -> (i -> UserRecoverableError -> m a) -> m a
+catchRecoverable :: forall e b i a. EvalM e b i a -> (i -> UserRecoverableError -> EvalM e b i a) -> EvalM e b i a
 catchRecoverable act catch = do
-  eState <- evalStateToErrorState <$> getEvalState
+  eState <- evalStateToErrorState <$> get
   catchError act (handler eState)
   where
-  handler :: ErrorState i -> PactError i -> m a
+  handler :: ErrorState i -> PactError i -> EvalM e b i a
   handler eState (PEUserRecoverableError err _ i) = do
-    modifyEvalState (restoreFromErrorState eState)
+    modify' (restoreFromErrorState eState)
     catch i err
   handler _ e = throwError e
 
-readOnlyEnv :: DirectEnv b i m -> DirectEnv b i m
+readOnlyEnv :: DirectEnv e b i -> DirectEnv e b i
 readOnlyEnv e
   | view (cePactDb . pdbPurity) e == PSysOnly = e
   | otherwise =
@@ -673,7 +660,7 @@ readOnlyEnv e
              }
       in set cePactDb newPactdb e
 
-sysOnlyEnv :: forall b i m. DirectEnv b i m -> DirectEnv b i m
+sysOnlyEnv :: forall e b i. DirectEnv e b i -> DirectEnv e b i
 sysOnlyEnv e
   | view (cePactDb . pdbPurity) e == PSysOnly = e
   | otherwise =
@@ -698,40 +685,62 @@ sysOnlyEnv e
     DUserTables _ -> dbOpDisallowed
     _ -> _pdbRead pdb dom k
 
-evalWithStackFrame :: MonadEval b i m => i -> StackFrame i -> Maybe Type -> m (EvalValue b i m) -> m (EvalValue b i m)
+evalWithStackFrame :: i -> StackFrame i -> Maybe Type -> EvalM e b i (EvalValue e b i) -> EvalM e b i (EvalValue e b i)
 evalWithStackFrame info sf mty act = do
-  esStack %== (sf:)
+  esStack %= (sf:)
 #ifdef WITH_FUNCALL_TRACING
   timeEnter <- liftIO $ getTime ProcessCPUTime
-  esTraceOutput %== (TraceFunctionEnter timeEnter sf info:)
+  esTraceOutput %= (TraceFunctionEnter timeEnter sf info:)
 #endif
   v <- act
-  esStack %== safeTail
+  esStack %= safeTail
   pv <- enforcePactValue info v
   maybeTCType info mty pv
 #ifdef WITH_FUNCALL_TRACING
   timeExit <- liftIO $ getTime ProcessCPUTime
-  esTraceOutput %== (TraceFunctionExit timeExit sf info:)
+  esTraceOutput %= (TraceFunctionExit timeExit sf info:)
 #endif
   return (VPactValue pv)
 {-# INLINE evalWithStackFrame #-}
 
 applyLamUnsafe
-  :: (MonadEval b i m)
-  => CanApply b i m
-  -> [EvalValue b i m]
-  -> m (EvalValue b i m)
+  :: (IsBuiltin b)
+  => CanApply e b i
+  -> [EvalValue e b i]
+  -> EvalM e b i (EvalValue e b i)
 applyLamUnsafe = applyLam
 
 applyLam
-  :: (MonadEval b i m)
-  => CanApply b i m
-  -> [EvalValue b i m]
-  -> m (EvalValue b i m)
+  :: (IsBuiltin b)
+  => CanApply e b i
+  -> [EvalValue e b i]
+  -> EvalM e b i (EvalValue e b i)
+applyLam nclo@(N (NativeFn b env fn arity i)) args
+  | arity == argLen = do
+    chargeFlatNativeGas i b
+    fn i b env args
+  | argLen > arity = throwExecutionError i ClosureAppliedToTooManyArgs
+  | null args = return (VClosure nclo)
+  | otherwise =
+    apply' arity [] args
+  where
+  argLen = length args
+  apply' !a pa (x:xs) = apply' (a - 1) (x:pa) xs
+  apply' !a pa [] =
+    return (VPartialNative (PartialNativeFn b env fn a pa i))
+applyLam (CT (CapTokenClosure fqn argtys arity i)) args
+  | arity == argLen = do
+    chargeGasArgs i (GAApplyLam (Just fqn) (fromIntegral argLen))
+    args' <- traverse (enforcePactValue i) args
+    zipWithM_ (\arg ty -> maybeTCType i ty arg) args' argtys
+    return (VPactValue (PCapToken (CapToken fqn args')))
+  | otherwise = throwExecutionError i ClosureAppliedToTooManyArgs
+  where
+  argLen = length args
 applyLam vc@(C (Closure fqn ca arity term mty env cloi)) args
   | arity == argLen = case ca of
     ArgClosure cloargs -> do
-      chargeGasArgs cloi (GAApplyLam (renderFullyQualName fqn) argLen)
+      chargeGasArgs cloi (GAApplyLam (Just fqn) argLen)
       args' <- traverse (enforcePactValue cloi) args
       zipWithM_ (\arg (Arg _ ty _) -> maybeTCType cloi ty arg) args' (NE.toList cloargs)
       let sf = StackFrame fqn args' SFDefun cloi
@@ -746,7 +755,7 @@ applyLam vc@(C (Closure fqn ca arity term mty env cloi)) args
       | null args ->
         return (VClosure vc)
       | otherwise -> do
-        chargeGasArgs cloi (GAApplyLam (renderFullyQualName fqn) argLen)
+        chargeGasArgs cloi (GAApplyLam (Just fqn) argLen)
         apply' mempty (NE.toList cloargs) args
   where
   argLen = length args
@@ -766,7 +775,7 @@ applyLam (LC (LamClosure ca arity term mty env cloi)) args
   | arity == argLen = case ca of
     ArgClosure _ -> do
       -- Todo: maybe lambda application should mangle some sort of name?
-      chargeGasArgs cloi (GAApplyLam "#lambda" argLen)
+      chargeGasArgs cloi (GAApplyLam Nothing argLen)
       let locals = view ceLocal env
           locals' = foldl' (flip RAList.cons) locals args
       evaluate (set ceLocal locals' env) term
@@ -776,7 +785,7 @@ applyLam (LC (LamClosure ca arity term mty env cloi)) args
   | otherwise = case ca of
       NullaryClosure -> throwExecutionError cloi ClosureAppliedToTooManyArgs
       ArgClosure cloargs -> do
-        chargeGasArgs cloi (GAApplyLam "#lambda" argLen)
+        chargeGasArgs cloi (GAApplyLam Nothing argLen)
         apply' (view ceLocal env) (NE.toList cloargs) args
   where
   argLen = length args
@@ -791,7 +800,7 @@ applyLam (LC (LamClosure ca arity term mty env cloi)) args
     return (VPartialClosure (PartialClosure Nothing (ty :| tys) (length tys + 1) term mty (set ceLocal e env) cloi))
   apply' _ [] _ = throwExecutionError cloi ClosureAppliedToTooManyArgs
 applyLam (PC (PartialClosure li argtys _ term mty env cloi)) args = do
-  chargeGasArgs cloi (GAApplyLam (getSfName li) (length args))
+  chargeGasArgs cloi (GAApplyLam (_sfName <$> li) (length args))
   apply' (view ceLocal env) (NE.toList argtys) args
   where
   apply' e (Arg _ ty _:tys) (x:xs) = do
@@ -808,19 +817,7 @@ applyLam (PC (PartialClosure li argtys _ term mty env cloi)) args = do
     let pclo = PartialClosure li (ty :| tys) (length tys + 1) term mty (set ceLocal e env) cloi
     return (VPartialClosure pclo)
   apply' _ [] _ = throwExecutionError cloi ClosureAppliedToTooManyArgs
-applyLam nclo@(N (NativeFn b env fn arity i)) args
-  | arity == argLen = do
-    chargeFlatNativeGas i b
-    fn i b env args
-  | argLen > arity = throwExecutionError i ClosureAppliedToTooManyArgs
-  | null args = return (VClosure nclo)
-  | otherwise =
-    apply' arity [] args
-  where
-  argLen = length args
-  apply' !a pa (x:xs) = apply' (a - 1) (x:pa) xs
-  apply' !a pa [] =
-    return (VPartialNative (PartialNativeFn b env fn a pa i))
+
 applyLam (PN (PartialNativeFn b env fn arity pArgs i)) args
   | arity == argLen = do
     chargeFlatNativeGas i b
@@ -832,27 +829,18 @@ applyLam (PN (PartialNativeFn b env fn arity pArgs i)) args
   apply' !a pa (x:xs) = apply' (a - 1) (x:pa) xs
   apply' !a pa [] =
     return (VPartialNative (PartialNativeFn b env fn a pa i))
-applyLam (CT (CapTokenClosure fqn argtys arity i)) args
-  | arity == argLen = do
-    chargeGasArgs i (GAApplyLam (renderQualName (fqnToQualName fqn)) (fromIntegral argLen))
-    args' <- traverse (enforcePactValue i) args
-    zipWithM_ (\arg ty -> maybeTCType i ty arg) args' argtys
-    return (VPactValue (PCapToken (CapToken fqn args')))
-  | otherwise = throwExecutionError i ClosureAppliedToTooManyArgs
-  where
-  argLen = length args
 applyLam (DPC (DefPactClosure fqn argtys arity env i)) args
   | arity == argLen = case argtys of
     ArgClosure cloargs -> do
       -- Todo: defpact has much higher overhead, we must charge a bit more gas for this
-      chargeGasArgs i (GAApplyLam (renderQualName (fqnToQualName fqn)) (fromIntegral argLen))
+      chargeGasArgs i (GAApplyLam (Just fqn) (fromIntegral argLen))
       args' <- traverse (enforcePactValue i) args
       zipWithM_ (\arg (Arg _ ty _) -> maybeTCType i ty arg) args' (NE.toList cloargs)
       let pc = DefPactContinuation (fqnToQualName fqn) args'
           env' = set ceLocal (RAList.fromList (reverse args)) env
       initPact i pc env'
     NullaryClosure -> do
-      chargeGasArgs i (GAApplyLam (renderQualName (fqnToQualName fqn)) (fromIntegral argLen))
+      chargeGasArgs i (GAApplyLam (Just fqn) (fromIntegral argLen))
       let pc = DefPactContinuation (fqnToQualName fqn) []
           env' = set ceLocal mempty env
       -- Todo: defpact has much higher overhead, we must charge a bit more gas for this
@@ -861,11 +849,6 @@ applyLam (DPC (DefPactClosure fqn argtys arity env i)) args
   where
   argLen = length args
 
-getSfName :: Maybe (StackFrame i) -> T.Text
-getSfName = \case
-  Just sf -> renderFullyQualName (_sfName sf)
-  Nothing -> "#lambda"
-
 
 
 ------------------------------------------------------
@@ -873,11 +856,11 @@ getSfName = \case
 ------------------------------------------------------
 
 enforceGuard
-  :: (MonadEval b i m)
+  :: (IsBuiltin b)
   => i
-  -> DirectEnv b i m
+  -> DirectEnv e b i
   -> Guard QualifiedName PactValue
-  -> m Bool
+  -> EvalM e b i Bool
 enforceGuard info env g = case g of
   GKeyset ks -> do
     isKeysetInSigs info env ks
@@ -898,17 +881,17 @@ enforceGuard info env g = case g of
          CapabilityPactGuardInvalidPactId curDpid dpid
 
 guardForModuleCall
-  :: (MonadEval b i m)
+  :: (IsBuiltin b)
   => i
-  -> DirectEnv b i m
+  -> DirectEnv e b i
   -> ModuleName
-  -> m ()
-  -> m ()
+  -> EvalM e b i ()
+  -> EvalM e b i ()
 guardForModuleCall i env currMod onFound =
   findCallingModule >>= \case
     Just mn | mn == currMod -> onFound
     _ -> do
-      mc <- useEvalState (esCaps . csModuleAdmin)
+      mc <- use (esCaps . csModuleAdmin)
       if S.member currMod mc then onFound
       else getModule i (view cePactDb env) currMod >>= acquireModuleAdmin i env
 
@@ -917,11 +900,11 @@ guardForModuleCall i env currMod onFound =
 -- checking whether `esCaps . csModuleAdmin` for the particular
 -- module is in scope
 acquireModuleAdmin
-  :: (MonadEval b i m)
+  :: (IsBuiltin b)
   => i
-  -> DirectEnv b i m
+  -> DirectEnv e b i
   -> EvalModule b i
-  -> m ()
+  -> EvalM e b i ()
 acquireModuleAdmin i env mdl = do
   case _mGovernance mdl of
     KeyGov ksn -> do
@@ -929,26 +912,26 @@ acquireModuleAdmin i env mdl = do
     CapGov (FQName fqn) -> do
       let wcapBody = Constant LUnit i
       () <$ evalCap i env (CapToken fqn []) PopCapInvoke NormalCapEval wcapBody
-  (esCaps . csModuleAdmin) %== S.insert (_mName mdl)
+  (esCaps . csModuleAdmin) %= S.insert (_mName mdl)
 
 
 acquireModuleAdminCapability
-  :: (MonadEval b i m)
+  :: (IsBuiltin b)
   => i
-  -> DirectEnv b i m
+  -> DirectEnv e b i
   -> ModuleName
-  -> m ()
+  -> EvalM e b i ()
 acquireModuleAdminCapability i env mname = do
-  sc <- S.member mname <$> useEvalState (esCaps . csModuleAdmin)
+  sc <- S.member mname <$> use (esCaps . csModuleAdmin)
   unless sc $ getModule i (_cePactDb env) mname >>= acquireModuleAdmin i env
 
 
 runUserGuard
-  :: (MonadEval b i m)
+  :: (IsBuiltin b)
   => i
-  -> DirectEnv b i m
+  -> DirectEnv e b i
   -> UserGuard QualifiedName PactValue
-  -> m Bool
+  -> EvalM e b i Bool
 runUserGuard info env (UserGuard qn args) =
   getModuleMemberWithHash info (_cePactDb env) qn >>= \case
     (Dfun d, mh) -> do
@@ -960,10 +943,9 @@ runUserGuard info env (UserGuard qn args) =
     (d, _) -> throwExecutionError info (UserGuardMustBeADefun qn (defKind (_qnModName qn) d))
 
 enforceCapGuard
-  :: (MonadEval b i m)
-  => i
+  :: i
   -> CapabilityGuard QualifiedName PactValue
-  -> m Bool
+  -> EvalM e b i Bool
 enforceCapGuard info cg@(CapabilityGuard qn args mpid) = case mpid of
   Nothing -> enforceCap
   Just pid -> do
@@ -980,11 +962,11 @@ enforceCapGuard info cg@(CapabilityGuard qn args mpid) = case mpid of
 
 -- Keyset Code
 isKeysetInSigs
-  :: (MonadEval b i m)
+  :: (IsBuiltin b)
   => i
-  -> DirectEnv b i m
+  -> DirectEnv e b i
   -> KeySet
-  -> m Bool
+  -> EvalM e b i Bool
 isKeysetInSigs info env (KeySet kskeys ksPred) = do
   matchedSigs <- M.filterWithKey matchKey <$> viewEvalEnv eeMsgSigs
   sigs <- checkSigCaps matchedSigs
@@ -1026,11 +1008,11 @@ isKeysetInSigs info env (KeySet kskeys ksPred) = do
           throwExecutionError info (InvalidCustomKeysetPredicate "expected native")
 
 isKeysetNameInSigs
-  :: (MonadEval b i m)
+  :: (IsBuiltin b)
   => i
-  -> DirectEnv b i m
+  -> DirectEnv e b i
   -> KeySetName
-  -> m Bool
+  -> EvalM e b i Bool
 isKeysetNameInSigs info env ksn = do
   pdb <- viewEvalEnv eePactDb
   liftDbFunction info (readKeySet pdb ksn) >>= \case
@@ -1044,10 +1026,9 @@ isKeysetNameInSigs info env ksn = do
 ------------------------------------------------------
 
 requireCap
-  :: (MonadEval b i m)
-  => i
+  :: i
   -> FQCapToken
-  -> m (EvalValue b i m)
+  -> EvalM e b i (EvalValue e b i)
 requireCap info (CapToken fqn args) = do
   let qualCapToken = CapToken (fqnToQualName fqn) args
   capInStack <- isCapInStack qualCapToken
@@ -1055,46 +1036,31 @@ requireCap info (CapToken fqn args) = do
   else throwUserRecoverableError info (CapabilityNotGranted qualCapToken)
 
 isCapInStack
-  :: (MonadEval b i m)
-  => CapToken QualifiedName PactValue
-  -> m Bool
+  :: CapToken QualifiedName PactValue
+  -> EvalM e b i Bool
 isCapInStack ct = do
   capSet <- getAllStackCaps
   pure $ S.member ct capSet
-{-# SPECIALIZE isCapInStack
-   :: CapToken QualifiedName PactValue
-   -> Eval Bool
-    #-}
+
 
 isCapInStack'
-  :: (MonadEval b i m)
-  => CapToken FullyQualifiedName PactValue
-  -> m Bool
+  :: CapToken FullyQualifiedName PactValue
+  -> EvalM e b i Bool
 isCapInStack' (CapToken fqn args) =
   isCapInStack (CapToken (fqnToQualName fqn) args)
-{-# SPECIALIZE isCapInStack'
-   :: FQCapToken
-   -> Eval Bool
-    #-}
 
 composeCap
-  :: (MonadEval b i m)
+  :: (IsBuiltin b)
   => i
-  -> DirectEnv b i m
+  -> DirectEnv e b i
   -> FQCapToken
-  -> m (EvalValue b i m)
+  -> EvalM e b i (EvalValue e b i)
 composeCap info env origToken =
   isCapInStack' origToken >>= \case
     False ->
       evalCap info env origToken PopCapComposed NormalCapEval (Constant (LBool True) info)
     True ->
       return (VBool True)
-{-# SPECIALIZE composeCap
-   :: ()
-   -> DirectEnv CoreBuiltin () Eval
-   -> FQCapToken
-   -> Eval (EvalValue CoreBuiltin () Eval)
-    #-}
 
 filterIndex :: Int -> [a] -> [a]
 filterIndex i xs = [x | (x, i') <- zip xs [0..], i /= i']
@@ -1106,12 +1072,11 @@ findMsgSigCap cix ct1 ct2 =
 -- Todo:
 -- `capAutonomous` are what we should use to match semantics accurately.
 installCap
-  :: (MonadEval b i m)
-  => i
-  -> DirectEnv b i m
+  :: i
+  -> DirectEnv e b i
   -> FQCapToken
   -> Bool
-  -> m (ManagedCap QualifiedName PactValue)
+  -> EvalM e b i (ManagedCap QualifiedName PactValue)
 installCap info _env (CapToken fqn args) autonomous = do
   let ct = CapToken (fqnToQualName fqn) args
   d <- getDefCap info fqn
@@ -1122,20 +1087,20 @@ installCap info _env (CapToken fqn args) autonomous = do
         let mcapType = ManagedParam fqnMgr managedParam paramIx
             ctFiltered = CapToken (fqnToQualName fqn) (filterIndex paramIx args)
             mcap = ManagedCap ctFiltered ct mcapType
-        capAlreadyInstalled <- S.member mcap <$> useEvalState (esCaps . csManaged)
+        capAlreadyInstalled <- S.member mcap <$> use (esCaps . csManaged)
         when capAlreadyInstalled $ throwExecutionError info (CapAlreadyInstalled ct)
-        (esCaps . csManaged) %== S.insert mcap
+        (esCaps . csManaged) %= S.insert mcap
         when autonomous $
-          (esCaps . csAutonomous) %== S.insert ct
+          (esCaps . csAutonomous) %= S.insert ct
         pure mcap
       AutoManagedMeta -> do
         let mcapType = AutoManaged False
             mcap = ManagedCap ct ct mcapType
-        capAlreadyInstalled <- S.member mcap <$> useEvalState (esCaps . csManaged)
+        capAlreadyInstalled <- S.member mcap <$> use (esCaps . csManaged)
         when capAlreadyInstalled $ throwExecutionError info (CapAlreadyInstalled ct)
-        (esCaps . csManaged) %== S.insert mcap
+        (esCaps . csManaged) %= S.insert mcap
         when autonomous $
-          (esCaps . csAutonomous) %== S.insert ct
+          (esCaps . csAutonomous) %= S.insert ct
         pure mcap
     DefEvent ->
       throwExecutionError info (InvalidManagedCap fqn)
@@ -1148,11 +1113,11 @@ installCap info _env (CapToken fqn args) autonomous = do
 -- DefPacts
 ------------------------------------------------------
 initPact
-  :: (MonadEval b i m)
+  :: (IsBuiltin b)
   => i
   -> DefPactContinuation QualifiedName PactValue
-  -> DirectEnv b i m
-  -> m (EvalValue b i m)
+  -> DirectEnv e b i
+  -> EvalM e b i (EvalValue e b i)
 initPact i pc cenv = do
   case view ceDefPactStep cenv of
     Nothing -> do
@@ -1178,14 +1143,14 @@ nestedPactsNotAdvanced resultState ps =
 {-# INLINE nestedPactsNotAdvanced #-}
 
 applyPact
-  :: (MonadEval b i m)
+  :: (IsBuiltin b)
   => i
   -> DefPactContinuation QualifiedName PactValue
   -> DefPactStep
-  -> DirectEnv b i m
+  -> DirectEnv e b i
   -> M.Map DefPactId DefPactExec
-  -> m (EvalValue b i m)
-applyPact i pc ps cenv nested = useEvalState esDefPactExec >>= \case
+  -> EvalM e b i (EvalValue e b i)
+applyPact i pc ps cenv nested = use esDefPactExec >>= \case
   Just pe -> throwExecutionError i (MultipleOrNestedDefPactExecFound pe)
   Nothing -> getModuleMemberWithHash i (_cePactDb cenv) (pc ^. pcName) >>= \case
     (DPact defPact, mh) -> do
@@ -1208,7 +1173,7 @@ applyPact i pc ps cenv nested = useEvalState esDefPactExec >>= \case
                , _peNestedDefPactExec = nested
                }
 
-      setEvalState esDefPactExec (Just pe)
+      esDefPactExec .= (Just pe)
       let sf = StackFrame (qualNameToFqn (pc ^. pcName) mh) (pc ^. pcArgs) SFDefPact i
 
       result <- case (ps ^. psRollback, step) of
@@ -1220,7 +1185,7 @@ applyPact i pc ps cenv nested = useEvalState esDefPactExec >>= \case
           throwExecutionError i (DefPactStepHasNoRollback ps)
 
       -- After evaluation, check the result state
-      useEvalState esDefPactExec >>= \case
+      use esDefPactExec >>= \case
         Nothing -> failInvariant i $ InvariantPactExecNotInEnv Nothing
         Just resultExec -> case cenv ^. ceDefPactStep of
           Nothing -> failInvariant i (InvariantPactStepNotInEnv Nothing)
@@ -1236,23 +1201,15 @@ applyPact i pc ps cenv nested = useEvalState esDefPactExec >>= \case
             return result
 
     (_, mh) -> failInvariant i (InvariantExpectedDefPact (qualNameToFqn (pc ^. pcName) mh))
-{-# SPECIALIZE applyPact
-   :: ()
-   -> DefPactContinuation QualifiedName PactValue
-   -> DefPactStep
-   -> DirectEnv CoreBuiltin () Eval
-   -> M.Map DefPactId DefPactExec
-   -> Eval (EvalValue CoreBuiltin () Eval)
-    #-}
 
 applyNestedPact
-  :: (MonadEval b i m)
+  :: (IsBuiltin b)
   => i
   -> DefPactContinuation QualifiedName PactValue
   -> DefPactStep
-  -> DirectEnv b i m
-  -> m (EvalValue b i m)
-applyNestedPact i pc ps cenv = useEvalState esDefPactExec >>= \case
+  -> DirectEnv e b i
+  -> EvalM e b i (EvalValue e b i)
+applyNestedPact i pc ps cenv = use esDefPactExec >>= \case
   Nothing -> failInvariant i $ InvariantPactExecNotInEnv Nothing
 
   Just pe -> getModuleMemberWithHash i (_cePactDb cenv) (pc ^. pcName) >>= \case
@@ -1291,7 +1248,7 @@ applyNestedPact i pc ps cenv = useEvalState esDefPactExec >>= \case
           | otherwise ->
             throwExecutionError i (NestedDefPactNeverStarted ps)
 
-      setEvalState esDefPactExec (Just exec)
+      esDefPactExec .= (Just exec)
       let
         cenv' = set ceDefPactStep (Just ps) cenv
       let contFqn = qualNameToFqn (pc ^. pcName) mh
@@ -1303,29 +1260,22 @@ applyNestedPact i pc ps cenv = useEvalState esDefPactExec >>= \case
           evalWithStackFrame i sf Nothing $ evaluate cenv' rollbackExpr
         (True, Step{}) -> throwExecutionError i (DefPactStepHasNoRollback ps)
 
-      useEvalState esDefPactExec >>= \case
+      use esDefPactExec >>= \case
         Nothing -> failInvariant i $ InvariantPactExecNotInEnv Nothing
         Just resultExec -> do
           when (nestedPactsNotAdvanced resultExec ps) $
             throwExecutionError i (NestedDefpactsNotAdvanced (_peDefPactId resultExec))
           let npe = pe & peNestedDefPactExec %~ M.insert (_psDefPactId ps) resultExec
-          setEvalState esDefPactExec (Just npe)
+          esDefPactExec .= (Just npe)
           return result
     (_, mh) -> failInvariant i (InvariantExpectedDefPact (qualNameToFqn (pc ^. pcName) mh))
-{-# SPECIALIZE applyNestedPact
-   :: ()
-   -> DefPactContinuation QualifiedName PactValue
-   -> DefPactStep
-   -> DirectEnv CoreBuiltin () Eval
-   -> Eval (EvalValue CoreBuiltin () Eval)
-    #-}
 
 resumePact
-  :: (MonadEval b i m)
+  :: (IsBuiltin b)
   => i
-  -> DirectEnv b i m
+  -> DirectEnv e b i
   -> Maybe DefPactExec
-  -> m (EvalValue b i m)
+  -> EvalM e b i (EvalValue e b i)
 resumePact i env crossChainContinuation = viewEvalEnv eeDefPactStep >>= \case
   Nothing -> throwExecutionError i DefPactStepNotInEnvironment
   Just ps -> do
@@ -1353,7 +1303,7 @@ resumePact i env crossChainContinuation = viewEvalEnv eeDefPactStep >>= \case
 
         resumeDefPactExec ccExec
       where
-        --resumeDefPactExec :: CEKEval step b i m, MonadEval b i m => DefPactExec -> m (CEKEvalResult step b i m)
+        --resumeDefPactExec :: CEKEval step e b i, IsBuiltin b => DefPactExec -> m (CEKEvalResult step e b i)
         resumeDefPactExec pe = do
           when (_psDefPactId ps /= _peDefPactId pe) $
             throwExecutionError i (DefPactIdMismatch (_psDefPactId ps) (_peDefPactId pe))
@@ -1374,20 +1324,13 @@ resumePact i env crossChainContinuation = viewEvalEnv eeDefPactStep >>= \case
                          Nothing -> _peYield pe
               env' = set ceLocal (RAList.fromList (reverse args)) $ set ceDefPactStep (Just $ set psResume resume ps) env
           applyPact i pc ps env' (_peNestedDefPactExec pe)
-{-# SPECIALIZE resumePact
-   :: ()
-   -> DirectEnv CoreBuiltin () Eval
-   -> Maybe DefPactExec
-   -> Eval (EvalValue CoreBuiltin () Eval)
-    #-}
 
 emitXChainEvents
-  :: (MonadEval b i m)
-  => Maybe Yield
+  :: Maybe Yield
   -- ^ from '_psResume', indicating a cross-chain resume.
   -> DefPactExec
    -- ^ tested for yield provenance to indicate a cross-chain yield.
-  -> m ()
+  -> EvalM e b i ()
 emitXChainEvents mResume dpe = do
   forM_ mResume $ \r -> case r of
     (Yield _ (Just (Provenance _ mh)) (Just sc)) ->
@@ -1404,36 +1347,28 @@ emitXChainEvents mResume dpe = do
       , PList (V.fromList (view (peContinuation . pcArgs) dpe)) ]
       mh
 
-emitReservedEvent :: MonadEval b i m => T.Text -> [PactValue] -> ModuleHash -> m ()
+emitReservedEvent :: T.Text -> [PactValue] -> ModuleHash -> EvalM e b i ()
 emitReservedEvent name params mhash = do
   let pactModule = ModuleName "pact" Nothing
   let pe = PactEvent name params pactModule mhash
   emitEventUnsafe pe
 
 emitEventUnsafe
-  :: (MonadEval b i m)
-  => PactEvent PactValue
-  -> m ()
-emitEventUnsafe pe = esEvents %== (++ [pe])
+  :: PactEvent PactValue
+  -> EvalM e b i ()
+emitEventUnsafe pe = esEvents %= (++ [pe])
 
 emitCapability
-  :: (MonadEval b i m)
-  => i
+  :: i
   -> CapToken FullyQualifiedName PactValue
-  -> m ()
+  -> EvalM e b i ()
 emitCapability info tkn =
   emitEvent info (fqctToPactEvent tkn)
-{-# SPECIALIZE emitCapability
-   :: ()
-   -> CapToken FullyQualifiedName PactValue
-   -> Eval ()
-    #-}
 
 emitEvent
-  :: (MonadEval b i m)
-  => i
+  :: i
   -> PactEvent PactValue
-  -> m ()
+  -> EvalM e b i ()
 emitEvent info pe = findCallingModule >>= \case
     Just mn -> do
       -- Todo: ++ definitely feels suboptimal, especially for gas.
@@ -1441,7 +1376,7 @@ emitEvent info pe = findCallingModule >>= \case
       -- well as after final emission.
       let ctModule = _peModule pe
       if ctModule == mn then do
-        esEvents %== (++ [pe])
+        esEvents %= (++ [pe])
       else throwExecutionError info (EventDoesNotMatchModule mn)
     Nothing -> throwExecutionError info (EventDoesNotMatchModule (_peModule pe))
 
@@ -1463,7 +1398,7 @@ tryNodeGas = (MilliGas 100)
 ----------------------------------------------------------------------
 -- Our builtin definitions start here
 ----------------------------------------------------------------------
-unaryIntFn :: (MonadEval b i m) => (Integer -> Integer) -> NativeFunction b i m
+unaryIntFn :: (IsBuiltin b) => (Integer -> Integer) -> NativeFunction e b i
 unaryIntFn op info b _env = \case
   [VLiteral (LInteger i)] ->
     return (VLiteral (LInteger (op i)))
@@ -1471,9 +1406,9 @@ unaryIntFn op info b _env = \case
 {-# INLINE unaryIntFn #-}
 
 binaryIntFn
-  :: (MonadEval b i m)
+  :: (IsBuiltin b)
   => (Integer -> Integer -> Integer)
-  -> NativeFunction b i m
+  -> NativeFunction e b i
 binaryIntFn op info b _env = \case
   [VLiteral (LInteger i), VLiteral (LInteger i')] -> return (VLiteral (LInteger (op i i')))
   args -> argsError info b args
@@ -1493,7 +1428,7 @@ binaryIntFn op info b _env = \case
 --          GT -> toRational n * multiplier
 -- `roundTo'` thus has the same asymptotic complexity as multiplication/division. Thus, worst case, we can upperbound it via
 -- division
-roundingFn :: (MonadEval b i m) => (Rational -> Integer) -> NativeFunction b i m
+roundingFn :: (IsBuiltin b) => (Rational -> Integer) -> NativeFunction e b i
 roundingFn op info b _env = \case
   [VLiteral (LDecimal d)] ->
     return (VLiteral (LInteger (truncate (roundTo' op 0 d))))
@@ -1505,7 +1440,7 @@ roundingFn op info b _env = \case
 ---------------------------------
 -- Arithmetic Ops
 ------------------------------
-rawAdd :: (MonadEval b i m) => NativeFunction b i m
+rawAdd :: (IsBuiltin b) => NativeFunction e b i
 rawAdd info b _env = \case
   [VLiteral (LInteger i), VLiteral (LInteger i')] -> do
     chargeGasArgs info (GIntegerOpCost PrimOpAdd i i')
@@ -1534,7 +1469,7 @@ rawAdd info b _env = \case
     chargeGasArgs info (GIntegerOpCost PrimOpAdd (decimalMantissa i) (decimalMantissa i'))
     return (VLiteral (LDecimal (i + i')))
 
-rawSub :: (MonadEval b i m) => NativeFunction b i m
+rawSub :: (IsBuiltin b) => NativeFunction e b i
 rawSub info b _env = \case
   [VLiteral (LInteger i), VLiteral (LInteger i')] -> do
     chargeGasArgs info (GIntegerOpCost PrimOpSub i i')
@@ -1554,7 +1489,7 @@ rawSub info b _env = \case
 
 
 
-rawMul :: (MonadEval b i m) => NativeFunction b i m
+rawMul :: (IsBuiltin b) => NativeFunction e b i
 rawMul info b _env = \case
   [VLiteral (LInteger i), VLiteral (LInteger i')] -> do
     chargeGasArgs info (GIntegerOpCost PrimOpMul i i')
@@ -1573,7 +1508,7 @@ rawMul info b _env = \case
     chargeGasArgs info (GIntegerOpCost PrimOpMul (decimalMantissa i) (decimalMantissa i'))
     return (VLiteral (LDecimal (i * i')))
 
-rawPow :: (MonadEval b i m) => NativeFunction b i m
+rawPow :: (IsBuiltin b) => NativeFunction e b i
 rawPow info b _env = \case
   [VLiteral (LInteger i), VLiteral (LInteger i')] -> do
     chargeGasArgs info $ GIntegerOpCost PrimOpPow i i'
@@ -1593,7 +1528,7 @@ rawPow info b _env = \case
     guardNanOrInf info result
     return (VLiteral (LDecimal (f2Dec result)))
 
-rawLogBase :: forall b i m. (MonadEval b i m) => NativeFunction b i m
+rawLogBase :: forall e b i. (IsBuiltin b) => NativeFunction e b i
 rawLogBase info b _env = \case
   [VLiteral (LInteger base), VLiteral (LInteger n)] -> do
     checkArgs base n
@@ -1615,13 +1550,13 @@ rawLogBase info b _env = \case
     let result = Musl.trans_logBase (dec2F base) (dec2F arg)
     guardNanOrInf info result
     return (VLiteral (LDecimal (f2Dec result)))
-  checkArgs :: (Num a, Ord a) => a -> a -> m ()
+  checkArgs :: (Num a, Ord a) => a -> a -> EvalM e b i ()
   checkArgs base arg = do
     when (base < 0) $ throwExecutionError info (ArithmeticException "Negative log base")
     when (arg <= 0) $ throwExecutionError info (ArithmeticException "Non-positive log argument")
 
 
-rawDiv :: (MonadEval b i m) => NativeFunction b i m
+rawDiv :: (IsBuiltin b) => NativeFunction e b i
 rawDiv info b _env = \case
   [VLiteral (LInteger i), VLiteral (LInteger i')] -> do
     when (i' == 0) $ throwExecutionError info (ArithmeticException "div by zero")
@@ -1643,7 +1578,7 @@ rawDiv info b _env = \case
     return (VLiteral (LDecimal (i / i')))
 
 
-rawNegate :: (MonadEval b i m) => NativeFunction b i m
+rawNegate :: (IsBuiltin b) => NativeFunction e b i
 rawNegate info b _env = \case
   [VLiteral (LInteger i)] ->
     return (VLiteral (LInteger (negate i)))
@@ -1651,36 +1586,36 @@ rawNegate info b _env = \case
     return (VLiteral (LDecimal (negate i)))
   args -> argsError info b args
 
-rawEq :: (MonadEval b i m) => NativeFunction b i m
+rawEq :: (IsBuiltin b) => NativeFunction e b i
 rawEq info b _env = \case
   [VPactValue pv, VPactValue pv'] -> do
     isEq <- valEqGassed info pv pv'
     return (VBool isEq)
   args -> argsError info b args
 
-modInt :: (MonadEval b i m) => NativeFunction b i m
+modInt :: (IsBuiltin b) => NativeFunction e b i
 modInt = binaryIntFn mod
 
-rawNeq :: (MonadEval b i m) => NativeFunction b i m
+rawNeq :: (IsBuiltin b) => NativeFunction e b i
 rawNeq info b _env = \case
   [VPactValue pv, VPactValue pv'] -> do
     isEq <- valEqGassed info pv pv'
     return (VBool $ not isEq)
   args -> argsError info b args
 
-rawGt :: (MonadEval b i m) => NativeFunction b i m
+rawGt :: (IsBuiltin b) => NativeFunction e b i
 rawGt = defCmp (== GT)
 
-rawLt :: (MonadEval b i m) => NativeFunction b i m
+rawLt :: (IsBuiltin b) => NativeFunction e b i
 rawLt = defCmp (== LT)
 
-rawGeq :: (MonadEval b i m) => NativeFunction b i m
+rawGeq :: (IsBuiltin b) => NativeFunction e b i
 rawGeq = defCmp (`elem` [GT, EQ])
 
-rawLeq :: (MonadEval b i m) => NativeFunction b i m
+rawLeq :: (IsBuiltin b) => NativeFunction e b i
 rawLeq = defCmp (`elem` [LT, EQ])
 
-defCmp :: (MonadEval b i m) => (Ordering -> Bool) -> NativeFunction b i m
+defCmp :: (IsBuiltin b) => (Ordering -> Bool) -> NativeFunction e b i
 defCmp predicate info b _env = \case
   args@[VLiteral lit1, VLiteral lit2] -> litCmpGassed info lit1 lit2 >>= \case
     Just ordering -> return $ VBool $ predicate ordering
@@ -1702,22 +1637,22 @@ defCmp predicate info b _env = \case
   args -> argsError info b args
 {-# INLINE defCmp #-}
 
-bitAndInt :: (MonadEval b i m) => NativeFunction b i m
+bitAndInt :: (IsBuiltin b) => NativeFunction e b i
 bitAndInt = binaryIntFn (.&.)
 
-bitOrInt :: (MonadEval b i m) => NativeFunction b i m
+bitOrInt :: (IsBuiltin b) => NativeFunction e b i
 bitOrInt = binaryIntFn (.|.)
 
-bitComplementInt :: (MonadEval b i m) => NativeFunction b i m
+bitComplementInt :: (IsBuiltin b) => NativeFunction e b i
 bitComplementInt = unaryIntFn complement
 
-bitXorInt :: (MonadEval b i m) => NativeFunction b i m
+bitXorInt :: (IsBuiltin b) => NativeFunction e b i
 bitXorInt = binaryIntFn xor
 
-bitShiftInt :: (MonadEval b i m) => NativeFunction b i m
+bitShiftInt :: (IsBuiltin b) => NativeFunction e b i
 bitShiftInt =  binaryIntFn (\i s -> shift i (fromIntegral s))
 
-rawAbs :: (MonadEval b i m) => NativeFunction b i m
+rawAbs :: (IsBuiltin b) => NativeFunction e b i
 rawAbs info b _env = \case
   [VLiteral (LInteger i)] -> do
     return (VLiteral (LInteger (abs i)))
@@ -1725,7 +1660,7 @@ rawAbs info b _env = \case
     return (VLiteral (LDecimal (abs e)))
   args -> argsError info b args
 
-rawExp :: (MonadEval b i m) => NativeFunction b i m
+rawExp :: (IsBuiltin b) => NativeFunction e b i
 rawExp info b _env = \case
   [VLiteral (LInteger i)] -> do
     let result = Musl.trans_exp (fromIntegral i)
@@ -1737,7 +1672,7 @@ rawExp info b _env = \case
     return (VLiteral (LDecimal (f2Dec result)))
   args -> argsError info b args
 
-rawLn :: (MonadEval b i m) => NativeFunction b i m
+rawLn :: (IsBuiltin b) => NativeFunction e b i
 rawLn info b _env = \case
   [VLiteral (LInteger i)] -> do
     let result = Musl.trans_ln (fromIntegral i)
@@ -1749,7 +1684,7 @@ rawLn info b _env = \case
     return (VLiteral (LDecimal (f2Dec result)))
   args -> argsError info b args
 
-rawSqrt :: (MonadEval b i m) => NativeFunction b i m
+rawSqrt :: (IsBuiltin b) => NativeFunction e b i
 rawSqrt info b _env = \case
   [VLiteral (LInteger i)] -> do
     when (i < 0) $ throwExecutionError info (ArithmeticException "Square root must be non-negative")
@@ -1763,19 +1698,20 @@ rawSqrt info b _env = \case
     return (VLiteral (LDecimal (f2Dec result)))
   args -> argsError info b args
 
-renderPactValue :: MonadEval b i m => i -> PactValue -> m T.Text
+renderPactValue :: i -> PactValue -> EvalM e b i T.Text
 renderPactValue info pv = do
-  sz <- sizeOf SizeOfV0 pv
+  sz <- sizeOf info SizeOfV0 pv
   chargeGasArgs info $ GConcat $ TextConcat $ GasTextLength $ fromIntegral sz
   pure $ Pretty.renderCompactText pv
 
-rawShow :: (MonadEval b i m) => NativeFunction b i m
+-- Todo: fix all show instances
+rawShow :: (IsBuiltin b) => NativeFunction e b i
 rawShow info b _env = \case
   [VPactValue pv] -> VString <$> renderPactValue info pv
   args -> argsError info b args
 
 -- Todo: Gas here is complicated, greg worked on this previously
-rawContains :: (MonadEval b i m) => NativeFunction b i m
+rawContains :: (IsBuiltin b) => NativeFunction e b i
 rawContains info b _env = \case
   [VString f, VObject o] -> do
     chargeGasArgs info $ GSearch $ FieldSearch (M.size o)
@@ -1790,7 +1726,7 @@ rawContains info b _env = \case
     return (VBool res)
   args -> argsError info b args
 
-rawSort :: (MonadEval b i m) => NativeFunction b i m
+rawSort :: (IsBuiltin b) => NativeFunction e b i
 rawSort info b _env = \case
   [VList vli]
     | V.null vli -> return (VList mempty)
@@ -1802,7 +1738,7 @@ rawSort info b _env = \case
     return (VList vli')
   args -> argsError info b args
 
-coreRemove :: (MonadEval b i m) => NativeFunction b i m
+coreRemove :: (IsBuiltin b) => NativeFunction e b i
 coreRemove info b _env = \case
   [VString s, VObject o] -> do
     chargeGasArgs info $ GObjOp $ ObjOpRemove s (M.size o)
@@ -1810,16 +1746,16 @@ coreRemove info b _env = \case
   args -> argsError info b args
 
 asObject
-  :: (MonadEval b i m)
+  :: (IsBuiltin b)
   => i
   -> b
   -> PactValue
-  -> m (M.Map Field PactValue)
+  -> EvalM e b i (M.Map Field PactValue)
 asObject info b = \case
   PObject o -> pure o
   arg -> argsError info b [VPactValue arg]
 
-rawSortObject :: (MonadEval b i m) => NativeFunction b i m
+rawSortObject :: (IsBuiltin b) => NativeFunction e b i
 rawSortObject info b _env = \case
   [VList fields, VList objs]
     | V.null fields -> return (VList objs)
@@ -1847,7 +1783,7 @@ rawSortObject info b _env = \case
 -- double ops
 -- -------------------------
 
-guardNanOrInf :: MonadEval b i m => i -> Double -> m ()
+guardNanOrInf :: i -> Double -> EvalM e b i ()
 guardNanOrInf info a =
   when (isNaN a || isInfinite a) $ throwExecutionError info (FloatingPointError "Floating operation resulted in Infinity or NaN")
 
@@ -1857,19 +1793,19 @@ dec2F = fromRational . toRational
 f2Dec :: Double -> Decimal
 f2Dec = fromRational . toRational
 
-roundDec :: (MonadEval b i m) => NativeFunction b i m
+roundDec :: (IsBuiltin b) => NativeFunction e b i
 roundDec = roundingFn round
 
-floorDec :: (MonadEval b i m) => NativeFunction b i m
+floorDec :: (IsBuiltin b) => NativeFunction e b i
 floorDec = roundingFn floor
 
-ceilingDec :: (MonadEval b i m) => NativeFunction b i m
+ceilingDec :: (IsBuiltin b) => NativeFunction e b i
 ceilingDec = roundingFn ceiling
 
 ---------------------------
 -- bool ops
 ---------------------------
-notBool :: (MonadEval b i m) => NativeFunction b i m
+notBool :: (IsBuiltin b) => NativeFunction e b i
 notBool info b _env = \case
   [VLiteral (LBool i)] -> return  (VLiteral (LBool (not i)))
   args -> argsError info b args
@@ -1889,7 +1825,7 @@ notBool info b _env = \case
 -- That's because `i` may contain values larger than `Int`, which is the type `length` typically returns.
 -- The sum `i + length t` may overflow `Int`, so it's converted to `Integer`, and the result of the `clamp` is always
 -- below `maxBound :: Int`, so it can be safely casted back without overflow.
-rawTake :: (MonadEval b i m) => NativeFunction b i m
+rawTake :: (IsBuiltin b) => NativeFunction e b i
 rawTake info b _env = \case
   [VLiteral (LInteger i), VLiteral (LString t)]
     | i >= 0 -> do
@@ -1919,7 +1855,7 @@ rawTake info b _env = \case
     return $ VObject $ M.restrictKeys o (S.fromList strings)
   args -> argsError info b args
 
-rawDrop :: (MonadEval b i m) => NativeFunction b i m
+rawDrop :: (IsBuiltin b) => NativeFunction e b i
 rawDrop info b _env = \case
   [VLiteral (LInteger i), VLiteral (LString t)]
     | i >= 0 -> do
@@ -1944,7 +1880,7 @@ rawDrop info b _env = \case
     return $ VObject $ M.withoutKeys o (S.fromList strings)
   args -> argsError info b args
 
-rawLength :: (MonadEval b i m) => NativeFunction b i m
+rawLength :: (IsBuiltin b) => NativeFunction e b i
 rawLength info b _env = \case
   [VString t] -> do
     chargeGasArgs info $ GStrOp $ StrOpLength $ T.length t
@@ -1954,7 +1890,7 @@ rawLength info b _env = \case
     return $ VInteger $ fromIntegral (M.size o)
   args -> argsError info b args
 
-rawReverse :: (MonadEval b i m) => NativeFunction b i m
+rawReverse :: (IsBuiltin b) => NativeFunction e b i
 rawReverse info b _env = \case
   [VList li] -> do
     chargeGasArgs info (GConcat (ListConcat (GasListLength (V.length li))))
@@ -1964,7 +1900,7 @@ rawReverse info b _env = \case
     return  (VLiteral (LString (T.reverse t)))
   args -> argsError info b args
 
-coreConcat :: (MonadEval b i m) => NativeFunction b i m
+coreConcat :: (IsBuiltin b) => NativeFunction e b i
 coreConcat info b _env = \case
   [VList li]
     | V.null li -> return (VString mempty)
@@ -1975,7 +1911,7 @@ coreConcat info b _env = \case
     return (VString (T.concat (V.toList li')))
   args -> argsError info b args
 
-strToList :: (MonadEval b i m) => NativeFunction b i m
+strToList :: (IsBuiltin b) => NativeFunction e b i
 strToList info b _env = \case
   [VLiteral (LString s)] -> do
     chargeGasArgs info $ GStrOp $ StrOpExplode $ T.length s
@@ -1984,7 +1920,7 @@ strToList info b _env = \case
   args -> argsError info b args
 
 
-zipList :: (MonadEval b i m) => NativeFunction b i m
+zipList :: (IsBuiltin b) => NativeFunction e b i
 zipList info b _env = \case
   [VClosure clo, VList l, VList r] ->
     VList <$> V.zipWithM go l r
@@ -1994,7 +1930,7 @@ zipList info b _env = \case
       enforcePactValue info =<< applyLam clo [VPactValue x, VPactValue y]
   args -> argsError info b args
 
-coreMap :: (MonadEval b i m) => NativeFunction b i m
+coreMap :: (IsBuiltin b) => NativeFunction e b i
 coreMap info b _env = \case
   [VClosure clo, VList li] ->
     VList <$> traverse go li
@@ -2004,7 +1940,7 @@ coreMap info b _env = \case
       applyLam clo [VPactValue x] >>= enforcePactValue info
   args -> argsError info b args
 
-coreFilter :: (MonadEval b i m) => NativeFunction b i m
+coreFilter :: (IsBuiltin b) => NativeFunction e b i
 coreFilter info b _env = \case
   [VClosure clo, VList li] ->
     VList <$> V.filterM go li
@@ -2014,7 +1950,7 @@ coreFilter info b _env = \case
       applyLam clo [VPactValue e] >>= enforceBool info
   args -> argsError info b args
 
-coreFold :: (MonadEval b i m) => NativeFunction b i m
+coreFold :: (IsBuiltin b) => NativeFunction e b i
 coreFold info b _env = \case
   [VClosure clo, VPactValue initElem, VList li] ->
     VPactValue <$> foldlM go initElem li
@@ -2024,7 +1960,7 @@ coreFold info b _env = \case
       applyLam clo [VPactValue e, VPactValue inc] >>= enforcePactValue info
   args -> argsError info b args
 
-coreEnumerate :: (MonadEval b i m) => NativeFunction b i m
+coreEnumerate :: (IsBuiltin b) => NativeFunction e b i
 coreEnumerate info b _env = \case
   [VLiteral (LInteger from), VLiteral (LInteger to)] -> do
     v <- createEnumerateList info from to (if from > to then -1 else 1)
@@ -2032,18 +1968,17 @@ coreEnumerate info b _env = \case
   args -> argsError info b args
 
 createEnumerateList
-  :: (MonadEval b i m)
-  => i
+  :: i
   -> Integer
   -- ^ from
   -> Integer
   -- ^ to
   -> Integer
   -- ^ Step
-  -> m (Vector Integer)
+  -> EvalM e b i (Vector Integer)
 createEnumerateList info from to inc
   | from == to = do
-    fromSize <- sizeOf SizeOfV0 from
+    fromSize <- sizeOf info SizeOfV0 from
     chargeGasArgs info (GMakeList 1 fromSize)
     pure (V.singleton from)
   | inc == 0 = pure mempty -- note: covered by the flat cost
@@ -2053,26 +1988,26 @@ createEnumerateList info from to inc
     throwExecutionError info (EnumerationError "enumerate: increment diverges above from interval bounds.")
   | otherwise = do
     let len = succ (abs (from - to) `div` abs inc)
-    listSize <- sizeOf SizeOfV0 (max (abs from) (abs to))
+    listSize <- sizeOf info SizeOfV0 (max (abs from) (abs to))
     chargeGasArgs info (GMakeList len listSize)
     pure $ V.enumFromStepN from inc (fromIntegral len)
 
-coreEnumerateStepN :: (MonadEval b i m) => NativeFunction b i m
+coreEnumerateStepN :: (IsBuiltin b) => NativeFunction e b i
 coreEnumerateStepN info b _env = \case
   [VLiteral (LInteger from), VLiteral (LInteger to), VLiteral (LInteger inc)] -> do
     v <- createEnumerateList info from to inc
     return (VList (PLiteral . LInteger <$> v))
   args -> argsError info b args
 
-makeList :: (MonadEval b i m) => NativeFunction b i m
+makeList :: (IsBuiltin b) => NativeFunction e b i
 makeList info b _env = \case
   [VLiteral (LInteger i), VPactValue v] -> do
-    vSize <- sizeOf SizeOfV0 v
+    vSize <- sizeOf info SizeOfV0 v
     chargeGasArgs info (GMakeList (fromIntegral i) vSize)
     return (VList (V.fromList (replicate (fromIntegral i) v)))
   args -> argsError info b args
 
-coreAccess :: (MonadEval b i m) => NativeFunction b i m
+coreAccess :: (IsBuiltin b) => NativeFunction e b i
 coreAccess info b _env = \case
   [VLiteral (LInteger i), VList vec] ->
     case vec V.!? fromIntegral i of
@@ -2085,7 +2020,7 @@ coreAccess info b _env = \case
         throwExecutionError info (ObjectIsMissingField (Field field) (ObjectData o))
   args -> argsError info b args
 
-coreIsCharset :: (MonadEval b i m) => NativeFunction b i m
+coreIsCharset :: (IsBuiltin b) => NativeFunction e b i
 coreIsCharset info b _env = \case
   [VLiteral (LInteger i), VString s] -> do
     chargeGasArgs info $ GStrOp $ StrOpParse $ T.length s
@@ -2095,50 +2030,49 @@ coreIsCharset info b _env = \case
       _ -> throwNativeExecutionError info b "Unsupported character set"
   args -> argsError info b args
 
-coreYield :: (MonadEval b i m) => NativeFunction b i m
+coreYield :: (IsBuiltin b) => NativeFunction e b i
 coreYield info b _env = \case
   [VObject o] -> go o Nothing
   [VObject o, VString cid] -> go o (Just (ChainId cid))
   args -> argsError info b args
   where
   go o mcid = do
-    mpe <- useEvalState esDefPactExec
+    mpe <- use esDefPactExec
     case mpe of
       Nothing -> throwExecutionError info YieldOutsideDefPact
       Just pe -> case mcid of
         Nothing -> do
-          esDefPactExec . _Just . peYield .== Just (Yield o Nothing Nothing)
+          esDefPactExec . _Just . peYield .= Just (Yield o Nothing Nothing)
           return (VObject o)
         Just cid -> do
           sourceChain <- viewEvalEnv (eePublicData . pdPublicMeta . pmChainId)
           p <- provenanceOf cid
           when (_peStepHasRollback pe) $ throwExecutionError info $ EvalError "Cross-chain yield not allowed in step with rollback"
-          esDefPactExec . _Just . peYield .== Just (Yield o (Just p) (Just sourceChain))
+          esDefPactExec . _Just . peYield .= Just (Yield o (Just p) (Just sourceChain))
           return (VObject o)
   provenanceOf tid =
     Provenance tid . _mHash <$> getCallingModule info
 
-corePactId :: (MonadEval b i m) => NativeFunction b i m
+corePactId :: (IsBuiltin b) => NativeFunction e b i
 corePactId info b _env = \case
-  [] -> useEvalState esDefPactExec >>= \case
+  [] -> use esDefPactExec >>= \case
     Just dpe -> return (VString (_defpactId (_peDefPactId dpe)))
     Nothing -> throwExecutionError info NotInDefPactExecution
   args -> argsError info b args
 
 enforceYield
-  :: (MonadEval b i m)
-  => i
+  :: i
   -> Yield
-  -> m ()
+  -> EvalM e b i ()
 enforceYield info y = case _yProvenance y of
   Nothing -> pure ()
   Just p -> do
     m <- getCallingModule info
     cid <- viewEvalEnv $ eePublicData . pdPublicMeta . pmChainId
-    let p' = Provenance cid (_mHash m):map (Provenance cid) (toList $ _mBlessed m)
+    let p' = Provenance cid (_mHash m):map (Provenance cid) (S.toList $ _mBlessed m)
     unless (p `elem` p') $ throwExecutionError info (YieldProvenanceDoesNotMatch p p')
 
-coreResume :: (MonadEval b i m) => NativeFunction b i m
+coreResume :: (IsBuiltin b) => NativeFunction e b i
 coreResume info b _env = \case
   [VClosure clo] -> do
     mps <- viewEvalEnv eeDefPactStep
@@ -2155,9 +2089,9 @@ coreResume info b _env = \case
 -- try-related ops
 -----------------------------------
 
-enforceTopLevelOnly :: (MonadEval b i m) => i -> b -> m ()
+enforceTopLevelOnly :: (IsBuiltin b) => i -> b -> EvalM e b i ()
 enforceTopLevelOnly info b = do
-  s <- useEvalState esStack
+  s <- use esStack
   unless (null s) $ throwExecutionError info (NativeIsTopLevelOnly (builtinName b))
 
 -----------------------------------
@@ -2169,7 +2103,7 @@ enforceTopLevelOnly info b = do
 -- Other Core forms
 -----------------------------------
 
-coreB64Encode :: (MonadEval b i m) => NativeFunction b i m
+coreB64Encode :: (IsBuiltin b) => NativeFunction e b i
 coreB64Encode info b _env = \case
   [VLiteral (LString l)] -> do
     chargeGasArgs info $ GStrOp $ StrOpParse $ T.length l
@@ -2177,7 +2111,7 @@ coreB64Encode info b _env = \case
   args -> argsError info b args
 
 
-coreB64Decode :: (MonadEval b i m) => NativeFunction b i m
+coreB64Decode :: (IsBuiltin b) => NativeFunction e b i
 coreB64Decode info b _env = \case
   [VLiteral (LString s)] -> do
     chargeGasArgs info $ GStrOp $ StrOpParse $ T.length s
@@ -2188,7 +2122,7 @@ coreB64Decode info b _env = \case
 
 
 -- | The implementation of `enforce-guard` native.
-coreEnforceGuard :: (MonadEval b i m) => NativeFunction b i m
+coreEnforceGuard :: (IsBuiltin b) => NativeFunction e b i
 coreEnforceGuard info b env = \case
   [VGuard g] -> VBool <$> enforceGuard info env g
   [VString s] -> do
@@ -2199,7 +2133,7 @@ coreEnforceGuard info b env = \case
         VBool <$> isKeysetNameInSigs info env ksn
   args -> argsError info b args
 
-keysetRefGuard :: (MonadEval b i m) => NativeFunction b i m
+keysetRefGuard :: (IsBuiltin b) => NativeFunction e b i
 keysetRefGuard info b env = \case
   [VString g] -> do
     chargeGasArgs info $ GStrOp $ StrOpParse $ T.length g
@@ -2212,7 +2146,7 @@ keysetRefGuard info b env = \case
           Just _ -> return (VGuard (GKeySetRef ksn))
   args -> argsError info b args
 
-coreTypeOf :: (MonadEval b i m) => NativeFunction b i m
+coreTypeOf :: (IsBuiltin b) => NativeFunction e b i
 coreTypeOf info b _env = \case
   [v] -> case v of
     VPactValue pv ->
@@ -2221,7 +2155,7 @@ coreTypeOf info b _env = \case
     VTable tv -> return $ VString (renderType (TyTable (_tvSchema tv)))
   args -> argsError info b args
 
-coreDec :: (MonadEval b i m) => NativeFunction b i m
+coreDec :: (IsBuiltin b) => NativeFunction e b i
 coreDec info b _env = \case
   [VInteger i] -> return $ VDecimal $ Decimal 0 i
   args -> argsError info b args
@@ -2231,7 +2165,8 @@ coreDec info b _env = \case
 --------------------------------------------------
 
 -- | Throw a recoverable error to be used in the read-* family of functions
-throwReadError :: (MonadError (PactError info) m, MonadEvalState b info m,  IsBuiltin b) => info -> b -> m a
+throwReadError
+  :: (IsBuiltin b) => i -> b -> EvalM e b i a
 throwReadError info b =
   throwUserRecoverableError info $ EnvReadFunctionFailure  (builtinName b)
 
@@ -2266,7 +2201,7 @@ can happen:
   - We may see a PDecimal, in which case we round
   - We may see a PInteger, which we read as-is.
 -}
-coreReadInteger :: (MonadEval b i m) => NativeFunction b i m
+coreReadInteger :: (IsBuiltin b) => NativeFunction e b i
 coreReadInteger info b _env = \case
   [VString s] -> do
     viewEvalEnv eeMsgBody >>= \case
@@ -2289,7 +2224,7 @@ coreReadInteger info b _env = \case
   args -> argsError info b args
 
 
-coreReadMsg :: (MonadEval b i m) => NativeFunction b i m
+coreReadMsg :: (IsBuiltin b) => NativeFunction e b i
 coreReadMsg info b _env = \case
   [VString s] -> do
     viewEvalEnv eeMsgBody >>= \case
@@ -2320,7 +2255,7 @@ instance A.FromJSON ParsedDecimal where
 
 So the string parsing case accepts both the integer, and decimal output
 -}
-coreReadDecimal :: (MonadEval b i m) => NativeFunction b i m
+coreReadDecimal :: (IsBuiltin b) => NativeFunction e b i
 coreReadDecimal info b _env = \case
   [VString s] -> do
     viewEvalEnv eeMsgBody >>= \case
@@ -2340,7 +2275,7 @@ coreReadDecimal info b _env = \case
       _ -> throwReadError info b
   args -> argsError info b args
 
-coreReadString :: (MonadEval b i m) => NativeFunction b i m
+coreReadString :: (IsBuiltin b) => NativeFunction e b i
 coreReadString info b _env = \case
   [VString s] -> do
     viewEvalEnv eeMsgBody >>= \case
@@ -2352,7 +2287,7 @@ coreReadString info b _env = \case
       _ -> throwReadError info b
   args -> argsError info b args
 
-readKeyset' :: (MonadEval b i m) => i -> T.Text -> m (Maybe KeySet)
+readKeyset' :: i -> T.Text -> EvalM e b i (Maybe KeySet)
 readKeyset' info ksn = do
   viewEvalEnv eeMsgBody >>= \case
     PObject envData -> do
@@ -2393,7 +2328,7 @@ readKeyset' info ksn = do
     _ -> pure Nothing
 
 
-coreReadKeyset :: (MonadEval b i m) => NativeFunction b i m
+coreReadKeyset :: (IsBuiltin b) => NativeFunction e b i
 coreReadKeyset info b _env = \case
   [VString ksn] ->
     readKeyset' info ksn >>= \case
@@ -2406,7 +2341,7 @@ coreReadKeyset info b _env = \case
   args -> argsError info b args
 
 
-coreBind :: (MonadEval b i m) => NativeFunction b i m
+coreBind :: (IsBuiltin b) => NativeFunction e b i
 coreBind info b _env = \case
   [v@VObject{}, VClosure clo] ->
     applyLam clo [v] >>= enforcePactValue' info
@@ -2417,7 +2352,7 @@ coreBind info b _env = \case
 -- Db functions
 --------------------------------------------------
 
-createTable :: (MonadEval b i m) => NativeFunction b i m
+createTable :: (IsBuiltin b) => NativeFunction e b i
 createTable info b env = \case
   [VTable tv] -> do
     enforceTopLevelOnly info b
@@ -2427,7 +2362,7 @@ createTable info b env = \case
     return (VString "TableCreated")
   args -> argsError info b args
 
-dbSelect :: (MonadEval b i m) => NativeFunction b i m
+dbSelect :: (IsBuiltin b) => NativeFunction e b i
 dbSelect info b env = \case
   [VTable tv, VClosure clo] ->
     selectRead tv clo Nothing
@@ -2454,7 +2389,7 @@ dbSelect info b env = \case
 
 
 
-foldDb :: (MonadEval b i m) => NativeFunction b i m
+foldDb :: (IsBuiltin b) => NativeFunction e b i
 foldDb info b env = \case
   [VTable tv, VClosure queryClo, VClosure consumer] -> do
     -- let cont' = BuiltinC env info (PreFoldDbC tv queryClo consumer) cont
@@ -2478,26 +2413,25 @@ foldDb info b env = \case
   args -> argsError info b args
 
 readUserTable
-  :: MonadEval b i m
-  => i
-  -> DirectEnv b i m
+  :: i
+  -> DirectEnv e b i
   -> TableValue
   -> RowKey
-  -> m RowData
+  -> EvalM e b i RowData
 readUserTable info env tv rk = do
   liftDbFunction info (_pdbRead (_cePactDb env) (tvToDomain tv) rk) >>= \case
     Just rd ->
       return rd
     Nothing -> throwUserRecoverableError info $ NoSuchObjectInDb (_tvName tv) rk
 
-dbRead :: (MonadEval b i m) => NativeFunction b i m
+dbRead :: (IsBuiltin b) => NativeFunction e b i
 dbRead info b env = \case
   [VTable tv, VString rk] -> do
     guardTable info env tv GtRead
     VObject . _unRowData <$> readUserTable info env tv (RowKey rk)
   args -> argsError info b args
 
-dbWithRead :: (MonadEval b i m) => NativeFunction b i m
+dbWithRead :: (IsBuiltin b) => NativeFunction e b i
 dbWithRead info b env = \case
   [VTable tv, VString rk, VClosure clo] -> do
     guardTable info env tv GtRead
@@ -2505,7 +2439,7 @@ dbWithRead info b env = \case
     applyLam clo [VObject o] >>= enforcePactValue' info
   args -> argsError info b args
 
-dbWithDefaultRead :: (MonadEval b i m) => NativeFunction b i m
+dbWithDefaultRead :: (IsBuiltin b) => NativeFunction e b i
 dbWithDefaultRead info b env = \case
   [VTable tv, VString rk, VObject defaultObj, VClosure clo] -> do
     guardTable info env tv GtWithDefaultRead
@@ -2517,13 +2451,13 @@ dbWithDefaultRead info b env = \case
   args -> argsError info b args
 
 -- | Todo: schema checking here? Or only on writes?
-dbWrite :: (MonadEval b i m) => NativeFunction b i m
+dbWrite :: (IsBuiltin b) => NativeFunction e b i
 dbWrite = write' Write
 
-dbInsert :: (MonadEval b i m) => NativeFunction b i m
+dbInsert :: (IsBuiltin b) => NativeFunction e b i
 dbInsert = write' Insert
 
-write' :: (MonadEval b i m) => WriteType -> NativeFunction b i m
+write' :: (IsBuiltin b) => WriteType -> NativeFunction e b i
 write' wt info b env = \case
   [VTable tv, VString key, VObject rv] -> do
     guardTable info env tv GtWrite
@@ -2531,17 +2465,17 @@ write' wt info b env = \case
     let check' = if wt == Update then checkPartialSchema else checkSchema
     if check' rv (_tvSchema tv) then do
       let rdata = RowData rv
-      rvSize <- sizeOf SizeOfV0 rv
+      rvSize <- sizeOf info SizeOfV0 rv
       chargeGasArgs info (GWrite rvSize)
       _ <- liftGasM info $ _pdbWrite pdb wt (tvToDomain tv) (RowKey key) rdata
       return (VString "Write succeeded")
     else throwExecutionError info (WriteValueDidNotMatchSchema (_tvSchema tv) (ObjectData rv))
   args -> argsError info b args
 
-dbUpdate :: (MonadEval b i m) => NativeFunction b i m
+dbUpdate :: (IsBuiltin b) => NativeFunction e b i
 dbUpdate = write' Update
 
-dbKeys :: (MonadEval b i m) => NativeFunction b i m
+dbKeys :: (IsBuiltin b) => NativeFunction e b i
 dbKeys info b env = \case
   [VTable tv] -> do
     guardTable info env tv GtKeys
@@ -2553,7 +2487,7 @@ dbKeys info b env = \case
     -- guardTable info cont' handler env tv GtKeys
   args -> argsError info b args
 
-dbTxIds :: (MonadEval b i m) => NativeFunction b i m
+dbTxIds :: (IsBuiltin b) => NativeFunction e b i
 dbTxIds info b env = \case
   [VTable tv, VInteger tid] -> do
     checkNonLocalAllowed info b
@@ -2565,7 +2499,7 @@ dbTxIds info b env = \case
   args -> argsError info b args
 
 
-dbTxLog :: (MonadEval b i m) => NativeFunction b i m
+dbTxLog :: (IsBuiltin b) => NativeFunction e b i
 dbTxLog info b env = \case
   [VTable tv, VInteger tid] -> do
     checkNonLocalAllowed info b
@@ -2583,7 +2517,7 @@ dbTxLog info b env = \case
         , (Field "value", PObject rdata)]
   args -> argsError info b args
 
-dbKeyLog :: (MonadEval b i m) => NativeFunction b i m
+dbKeyLog :: (IsBuiltin b) => NativeFunction e b i
 dbKeyLog info b env = \case
   [VTable tv, VString key, VInteger tid] -> do
     checkNonLocalAllowed info b
@@ -2604,12 +2538,12 @@ dbKeyLog info b env = \case
   args -> argsError info b args
 
 defineKeySet'
-  :: (MonadEval b i m)
+  :: (IsBuiltin b)
   => i
-  -> DirectEnv b i m
+  -> DirectEnv e b i
   -> T.Text
   -> KeySet
-  -> m (EvalValue b i m)
+  -> EvalM e b i (EvalValue e b i)
 defineKeySet' info env ksname newKs  = do
   let pdb = view cePactDb env
   ignoreNamespaces <- not <$> isExecutionFlagSet FlagRequireKeysetNs
@@ -2617,7 +2551,7 @@ defineKeySet' info env ksname newKs  = do
     Left {} -> throwExecutionError info (InvalidKeysetNameFormat ksname)
     Right ksn -> do
       let writeKs = do
-            newKsSize <- sizeOf SizeOfV0 newKs
+            newKsSize <- sizeOf info SizeOfV0 newKs
             chargeGasArgs info (GWrite newKsSize)
             writeKeySet info pdb Write ksn newKs
             return (VString "Keyset write success")
@@ -2626,14 +2560,14 @@ defineKeySet' info env ksname newKs  = do
           _ <- isKeysetInSigs info env oldKs
           writeKs
         Nothing | ignoreNamespaces -> writeKs
-        Nothing | otherwise -> useEvalState (esLoaded . loNamespace) >>= \case
+        Nothing | otherwise -> use (esLoaded . loNamespace) >>= \case
           Nothing -> throwExecutionError info CannotDefineKeysetOutsideNamespace
           Just (Namespace ns uGuard _adminGuard) -> do
             when (Just ns /= _keysetNs ksn) $ throwExecutionError info (MismatchingKeysetNamespace ns)
             _ <- enforceGuard info env uGuard
             writeKs
 
-defineKeySet :: (MonadEval b i m) => NativeFunction b i m
+defineKeySet :: (IsBuiltin b) => NativeFunction e b i
 defineKeySet info b env = \case
   [VString ksname, VGuard (GKeyset ks)] -> do
     enforceTopLevelOnly info b
@@ -2650,23 +2584,23 @@ defineKeySet info b env = \case
 -- Capabilities
 --------------------------------------------------
 
-requireCapability :: (MonadEval b i m) => NativeFunction b i m
+requireCapability :: (IsBuiltin b) => NativeFunction e b i
 requireCapability info b _env = \case
   [VCapToken ct] -> do
-    slots <- useEvalState $ esCaps . csSlots
+    slots <- use $ esCaps . csSlots
     let cnt = sum [1 + length cs | CapSlot _ cs <- slots]
     chargeGasArgs info $ GCapOp $ CapOpRequire cnt
     requireCap info ct
   args -> argsError info b args
 
-composeCapability :: (MonadEval b i m) => NativeFunction b i m
+composeCapability :: (IsBuiltin b) => NativeFunction e b i
 composeCapability info b env = \case
   [VCapToken ct] -> do
     enforceStackTopIsDefcap info b
     composeCap info env ct
   args -> argsError info b args
 
-installCapability :: (MonadEval b i m) => NativeFunction b i m
+installCapability :: (IsBuiltin b) => NativeFunction e b i
 installCapability info b env = \case
   [VCapToken ct] -> do
     enforceNotWithinDefcap info env "install-capability"
@@ -2674,7 +2608,7 @@ installCapability info b env = \case
     return (VString "Installed capability")
   args -> argsError info b args
 
-coreEmitEvent :: (MonadEval b i m) => NativeFunction b i m
+coreEmitEvent :: (IsBuiltin b) => NativeFunction e b i
 coreEmitEvent info b env = \case
   [VCapToken ct@(CapToken fqn _)] -> do
     -- let cont' = BuiltinC env info (EmitEventC ct) cont
@@ -2688,7 +2622,7 @@ coreEmitEvent info b env = \case
     enforceMeta _ = pure ()
   args -> argsError info b args
 
-createCapGuard :: (MonadEval b i m) => NativeFunction b i m
+createCapGuard :: (IsBuiltin b) => NativeFunction e b i
 createCapGuard info b _env = \case
   [VCapToken ct] -> do
     let qn = fqnToQualName (_ctName ct)
@@ -2696,7 +2630,7 @@ createCapGuard info b _env = \case
     return (VGuard (GCapabilityGuard cg))
   args -> argsError info b args
 
-createCapabilityPactGuard :: (MonadEval b i m) => NativeFunction b i m
+createCapabilityPactGuard :: (IsBuiltin b) => NativeFunction e b i
 createCapabilityPactGuard info b _env = \case
   [VCapToken ct] -> do
     pid <- getDefPactId info
@@ -2705,7 +2639,7 @@ createCapabilityPactGuard info b _env = \case
     return (VGuard (GCapabilityGuard cg))
   args -> argsError info b args
 
-createModuleGuard :: (MonadEval b i m) => NativeFunction b i m
+createModuleGuard :: (IsBuiltin b) => NativeFunction e b i
 createModuleGuard info b _env = \case
   [VString n] ->
     findCallingModule >>= \case
@@ -2716,7 +2650,7 @@ createModuleGuard info b _env = \case
         throwNativeExecutionError info b "create-module-guard: must call within module"
   args -> argsError info b args
 
-createDefPactGuard :: (MonadEval b i m) => NativeFunction b i m
+createDefPactGuard :: (IsBuiltin b) => NativeFunction e b i
 createDefPactGuard info b _env = \case
   [VString name] -> do
     dpid <- getDefPactId info
@@ -2724,7 +2658,7 @@ createDefPactGuard info b _env = \case
   args -> argsError info b args
 
 
-coreIntToStr :: (MonadEval b i m) => NativeFunction b i m
+coreIntToStr :: (IsBuiltin b) => NativeFunction e b i
 coreIntToStr info b _env = \case
   [VInteger base, VInteger v]
     | v < 0 ->
@@ -2744,7 +2678,7 @@ coreIntToStr info b _env = \case
     | otherwise -> throwNativeExecutionError info b "invalid base for base64URL conversion"
   args -> argsError info b args
 
-coreStrToInt :: (MonadEval b i m) => NativeFunction b i m
+coreStrToInt :: (IsBuiltin b) => NativeFunction e b i
 coreStrToInt info b _env = \case
   [VString s] -> do
     chargeGasArgs info $ GStrOp $ StrOpParse $ T.length s
@@ -2752,7 +2686,7 @@ coreStrToInt info b _env = \case
     doBase info 10 s
   args -> argsError info b args
 
-coreStrToIntBase :: (MonadEval b i m) => NativeFunction b i m
+coreStrToIntBase :: (IsBuiltin b) => NativeFunction e b i
 coreStrToIntBase info b _env = \case
   [VInteger base, VString s]
     | base == 64 -> do
@@ -2781,7 +2715,7 @@ nubByM eq = go
     xs' <- filterM (fmap not . eq x) xs
     (x :) <$> go xs'
 
-coreDistinct  :: (MonadEval b i m) => NativeFunction b i m
+coreDistinct  :: (IsBuiltin b) => NativeFunction e b i
 coreDistinct info b _env = \case
   [VList s] -> do
     uniques <- nubByM (valEqGassed info) $ V.toList s
@@ -2790,7 +2724,7 @@ coreDistinct info b _env = \case
       $ V.fromList uniques
   args -> argsError info b args
 
-coreFormat  :: (MonadEval b i m) => NativeFunction b i m
+coreFormat  :: (IsBuiltin b) => NativeFunction e b i
 coreFormat info b _env = \case
   [VString s, VList es] -> do
     let parts = T.splitOn "{}" s
@@ -2815,20 +2749,18 @@ coreFormat info b _env = \case
   args -> argsError info b args
 
 checkLen
-  :: (MonadEval b i m)
-  => i
+  :: i
   -> T.Text
-  -> m ()
+  -> EvalM e b i ()
 checkLen info txt =
   unless (T.length txt <= 512) $
       throwExecutionError info $ DecodeError "Invalid input, only up to 512 length supported"
 
 doBase
-  :: (MonadEval b i m)
-  => i
+  :: i
   -> Integer
   -> T.Text
-  -> m (EvalValue b i m)
+  -> EvalM e b i (EvalValue e b i)
 doBase info base txt = case baseStrToInt base txt of
   Left e -> throwExecutionError info (DecodeError e)
   Right n -> return (VInteger n)
@@ -2865,7 +2797,7 @@ integerToBS v = BS.pack $ reverse $ go v
          | otherwise = fromIntegral (i .&. 0xff):go (shift i (-8))
 
 
-coreAndQ :: (MonadEval b i m) => NativeFunction b i m
+coreAndQ :: (IsBuiltin b) => NativeFunction e b i
 coreAndQ info b _env = \case
   [VClosure l, VClosure r, VPactValue v] -> do
     c1 <- enforceBool info =<< applyLam l [VPactValue v]
@@ -2873,7 +2805,7 @@ coreAndQ info b _env = \case
     else return (VBool False)
   args -> argsError info b args
 
-coreOrQ :: (MonadEval b i m) => NativeFunction b i m
+coreOrQ :: (IsBuiltin b) => NativeFunction e b i
 coreOrQ info b _env = \case
   [VClosure l, VClosure r, VPactValue v] -> do
     c1 <- enforceBool info =<< applyLam l [VPactValue v]
@@ -2881,14 +2813,14 @@ coreOrQ info b _env = \case
     else applyLam r [VPactValue v] >>= enforceBool' info
   args -> argsError info b args
 
-coreNotQ :: (MonadEval b i m) => NativeFunction b i m
+coreNotQ :: (IsBuiltin b) => NativeFunction e b i
 coreNotQ info b _env = \case
   [VClosure clo, VPactValue v] -> do
     c <- enforceBool info =<< applyLam clo [VPactValue v]
     return (VBool (not c))
   args -> argsError info b args
 
-coreWhere :: (MonadEval b i m) => NativeFunction b i m
+coreWhere :: (IsBuiltin b) => NativeFunction e b i
 coreWhere info b _env = \case
   [VString field, VClosure app, VObject o] -> do
     case M.lookup (Field field) o of
@@ -2898,7 +2830,7 @@ coreWhere info b _env = \case
         throwExecutionError info (ObjectIsMissingField (Field field) (ObjectData o))
   args -> argsError info b args
 
-coreHash :: (MonadEval b i m) => NativeFunction b i m
+coreHash :: (IsBuiltin b) => NativeFunction e b i
 coreHash = \info b _env -> \case
   [VString s] ->
     return (go (T.encodeUtf8 s))
@@ -2908,20 +2840,20 @@ coreHash = \info b _env -> \case
   where
   go =  VString . hashToText . pactHash
 
-txHash :: (MonadEval b i m) => NativeFunction b i m
+txHash :: (IsBuiltin b) => NativeFunction e b i
 txHash info b _env = \case
   [] -> do
     h <- viewEvalEnv eeHash
     return (VString (hashToText h))
   args -> argsError info b args
 
-coreContinue :: (MonadEval b i m) => NativeFunction b i m
+coreContinue :: (IsBuiltin b) => NativeFunction e b i
 coreContinue info b _env = \case
   [v] -> do
     return v
   args -> argsError info b args
 
-parseTime :: (MonadEval b i m) => NativeFunction b i m
+parseTime :: (IsBuiltin b) => NativeFunction e b i
 parseTime info b _env = \case
   [VString fmt, VString s] -> do
     chargeGasArgs info $ GStrOp $ StrOpParseTime (T.length fmt) (T.length s)
@@ -2931,7 +2863,7 @@ parseTime info b _env = \case
         throwNativeExecutionError info b $ "parse-time parse failure"
   args -> argsError info b args
 
-formatTime :: (MonadEval b i m) => NativeFunction b i m
+formatTime :: (IsBuiltin b) => NativeFunction e b i
 formatTime info b _env = \case
   [VString fmt, VPactValue (PTime t)] -> do
     chargeGasArgs info $ GStrOp $ StrOpFormatTime $ T.length fmt
@@ -2939,7 +2871,7 @@ formatTime info b _env = \case
     return $ VString (T.pack timeString)
   args -> argsError info b args
 
-time :: (MonadEval b i m) => NativeFunction b i m
+time :: (IsBuiltin b) => NativeFunction e b i
 time info b _env = \case
   [VString s] -> do
     case PactTime.parseTime "%Y-%m-%dT%H:%M:%SZ" (T.unpack s) of
@@ -2948,7 +2880,7 @@ time info b _env = \case
         throwNativeExecutionError info b $ "time default format parse failure"
   args -> argsError info b args
 
-addTime :: (MonadEval b i m) => NativeFunction b i m
+addTime :: (IsBuiltin b) => NativeFunction e b i
 addTime info b _env = \case
   [VPactValue (PTime t), VPactValue (PDecimal seconds)] -> do
       let newTime = t PactTime..+^ PactTime.fromSeconds seconds
@@ -2958,14 +2890,14 @@ addTime info b _env = \case
       return $ VPactValue (PTime newTime)
   args -> argsError info b args
 
-diffTime :: (MonadEval b i m) => NativeFunction b i m
+diffTime :: (IsBuiltin b) => NativeFunction e b i
 diffTime info b _env = \case
   [VPactValue (PTime x), VPactValue (PTime y)] -> do
     let secondsDifference = PactTime.toSeconds $ x PactTime..-. y
     return $ VPactValue $ PDecimal secondsDifference
   args -> argsError info b args
 
-minutes :: (MonadEval b i m) => NativeFunction b i m
+minutes :: (IsBuiltin b) => NativeFunction e b i
 minutes info b _env = \case
   [VDecimal x] -> do
     let seconds = x * 60
@@ -2975,7 +2907,7 @@ minutes info b _env = \case
     return $ VDecimal seconds
   args -> argsError info b args
 
-hours :: (MonadEval b i m) => NativeFunction b i m
+hours :: (IsBuiltin b) => NativeFunction e b i
 hours info b _env = \case
   [VDecimal x] -> do
     let seconds = x * 60 * 60
@@ -2985,7 +2917,7 @@ hours info b _env = \case
     return $ VDecimal seconds
   args -> argsError info b args
 
-days :: (MonadEval b i m) => NativeFunction b i m
+days :: (IsBuiltin b) => NativeFunction e b i
 days info b _env = \case
   [VDecimal x] -> do
     let seconds = x * 60 * 60 * 24
@@ -2995,7 +2927,7 @@ days info b _env = \case
     return $ VDecimal seconds
   args -> argsError info b args
 
-describeModule :: (MonadEval b i m) => NativeFunction b i m
+describeModule :: (IsBuiltin b) => NativeFunction e b i
 describeModule info b env = \case
   [VString s] -> case parseModuleName s of
     Just mname -> do
@@ -3015,7 +2947,7 @@ describeModule info b env = \case
     Nothing -> throwNativeExecutionError info b $ "invalid module name format"
   args -> argsError info b args
 
-dbDescribeTable :: (MonadEval b i m) => NativeFunction b i m
+dbDescribeTable :: (IsBuiltin b) => NativeFunction e b i
 dbDescribeTable info b _env = \case
   [VTable (TableValue name _ schema)] -> do
     enforceTopLevelOnly info b
@@ -3025,7 +2957,7 @@ dbDescribeTable info b _env = \case
       ,("type", PString (renderType (TyTable schema)))]
   args -> argsError info b args
 
-dbDescribeKeySet :: (MonadEval b i m) => NativeFunction b i m
+dbDescribeKeySet :: (IsBuiltin b) => NativeFunction e b i
 dbDescribeKeySet info b env = \case
   [VString s] -> do
     let pdb = _cePactDb env
@@ -3041,7 +2973,7 @@ dbDescribeKeySet info b env = \case
         throwNativeExecutionError info b  "incorrect keyset name format"
   args -> argsError info b args
 
-coreCompose :: (MonadEval b i m) => NativeFunction b i m
+coreCompose :: (IsBuiltin b) => NativeFunction e b i
 coreCompose info b _env = \case
   [VClosure clo1, VClosure clo2, v] -> do
     v' <- enforcePactValue info =<< applyLam clo1 [v]
@@ -3050,7 +2982,7 @@ coreCompose info b _env = \case
     -- applyLam clo1 [v] cont' handler
   args -> argsError info b args
 
-createPrincipalForGuard :: (MonadEval b i m) => i -> Guard QualifiedName PactValue -> m (Pr.Principal)
+createPrincipalForGuard :: i -> Guard QualifiedName PactValue -> EvalM e b i (Pr.Principal)
 createPrincipalForGuard info = \case
   GKeyset (KeySet ks pf) -> case (toList ks, pf) of
     ([k], KeysAll)
@@ -3089,21 +3021,21 @@ createPrincipalForGuard info = \case
       pure $ pactHash bs
 
 
-coreCreatePrincipal :: (MonadEval b i m) => NativeFunction b i m
+coreCreatePrincipal :: (IsBuiltin b) => NativeFunction e b i
 coreCreatePrincipal info b _env = \case
   [VGuard g] -> do
     pr <- createPrincipalForGuard info g
     return $ VString $ Pr.mkPrincipalIdent pr
   args -> argsError info b args
 
-coreIsPrincipal :: (MonadEval b i m) => NativeFunction b i m
+coreIsPrincipal :: (IsBuiltin b) => NativeFunction e b i
 coreIsPrincipal info b _env = \case
   [VString p] -> do
     chargeGasArgs info $ GStrOp $ StrOpParse $ T.length p
     return $ VBool $ isRight $ parseOnly Pr.principalParser p
   args -> argsError info b args
 
-coreTypeOfPrincipal :: (MonadEval b i m) => NativeFunction b i m
+coreTypeOfPrincipal :: (IsBuiltin b) => NativeFunction e b i
 coreTypeOfPrincipal info b _env = \case
   [VString p] -> do
     chargeGasArgs info $ GStrOp $ StrOpParse $ T.length p
@@ -3113,7 +3045,7 @@ coreTypeOfPrincipal info b _env = \case
     return $ VString prty
   args -> argsError info b args
 
-coreValidatePrincipal :: (MonadEval b i m) => NativeFunction b i m
+coreValidatePrincipal :: (IsBuiltin b) => NativeFunction e b i
 coreValidatePrincipal info b _env = \case
   [VGuard g, VString s] -> do
     pr' <- createPrincipalForGuard info g
@@ -3122,13 +3054,13 @@ coreValidatePrincipal info b _env = \case
   args -> argsError info b args
 
 
-coreCond :: (MonadEval b i m) => NativeFunction b i m
+coreCond :: (IsBuiltin b) => NativeFunction e b i
 coreCond info b _env = \case
   [VClosure clo] ->
     applyLam clo [] >>= enforcePactValue' info
   args -> argsError info b args
 
-coreIdentity :: (MonadEval b i m) => NativeFunction b i m
+coreIdentity :: (IsBuiltin b) => NativeFunction e b i
 coreIdentity info b _env = \case
   [VPactValue pv] -> return $ VPactValue pv
   args -> argsError info b args
@@ -3136,21 +3068,21 @@ coreIdentity info b _env = \case
 --------------------------------------------------
 -- Namespace functions
 --------------------------------------------------
-coreNamespace :: (MonadEval b i m) => NativeFunction b i m
+coreNamespace :: (IsBuiltin b) => NativeFunction e b i
 coreNamespace info b env = \case
   [VString n] -> do
     enforceTopLevelOnly info b
     let pdb = view cePactDb env
     if T.null n then do
-      (esLoaded . loNamespace) .== Nothing
+      (esLoaded . loNamespace) .= Nothing
       return (VString "Namespace reset to root")
     else do
       chargeGasArgs info $ GRead $ fromIntegral $ T.length n
       liftDbFunction info (_pdbRead pdb DNamespaces (NamespaceName n)) >>= \case
         Just ns -> do
-          size <- sizeOf SizeOfV0 ns
+          size <- sizeOf info SizeOfV0 ns
           chargeGasArgs info $ GRead size
-          (esLoaded . loNamespace) .== Just ns
+          (esLoaded . loNamespace) .= Just ns
           let msg = "Namespace set to " <> n
           return (VString msg)
         Nothing ->
@@ -3158,7 +3090,7 @@ coreNamespace info b env = \case
   args -> argsError info b args
 
 
-coreDefineNamespace :: (MonadEval b i m) => NativeFunction b i m
+coreDefineNamespace :: (IsBuiltin b) => NativeFunction e b i
 coreDefineNamespace info b env = \case
   [VString n, VGuard usrG, VGuard adminG] -> do
     enforceTopLevelOnly info b
@@ -3171,13 +3103,13 @@ coreDefineNamespace info b env = \case
       -- https://static.wikia.nocookie.net/onepiece/images/5/52/Lao_G_Manga_Infobox.png/revision/latest?cb=20150405020446
       -- Enforce the old guard
       Just existing@(Namespace _ _ laoG) -> do
-        size <- sizeOf SizeOfV0 existing
+        size <- sizeOf info SizeOfV0 existing
         chargeGasArgs info $ GRead size
         allow <- enforceGuard info env laoG
         writeNs allow nsn ns
       Nothing -> viewEvalEnv eeNamespacePolicy >>= \case
         SimpleNamespacePolicy -> do
-          nsSize <- sizeOf SizeOfV0 ns
+          nsSize <- sizeOf info SizeOfV0 ns
           chargeGasArgs info (GWrite nsSize)
           liftGasM info $ _pdbWrite pdb Write DNamespaces nsn ns
           return $ VString $ "Namespace defined: " <> n
@@ -3192,7 +3124,7 @@ coreDefineNamespace info b env = \case
   pdb = _cePactDb env
   writeNs allow nsn ns = do
     unless allow $ throwNativeExecutionError info b $ "Namespace definition not permitted"
-    nsSize <- sizeOf SizeOfV0 ns
+    nsSize <- sizeOf info SizeOfV0 ns
     chargeGasArgs info (GWrite nsSize)
     liftGasM info $ _pdbWrite pdb Write DNamespaces nsn ns
     return $ VString $ "Namespace defined: " <> (_namespaceName nsn)
@@ -3208,14 +3140,14 @@ coreDefineNamespace info b env = \case
   validSpecialChars =
     "%#+-_&$@<>=^?*!|/~"
 
-coreDescribeNamespace :: (MonadEval b i m) => NativeFunction b i m
+coreDescribeNamespace :: (IsBuiltin b) => NativeFunction e b i
 coreDescribeNamespace info b _env = \case
   [VString n] -> do
     pdb <- viewEvalEnv eePactDb
     chargeGasArgs info $ GRead $ fromIntegral $ T.length n
     liftDbFunction info (_pdbRead pdb DNamespaces (NamespaceName n)) >>= \case
       Just existing@(Namespace _ usrG laoG) -> do
-        size <- sizeOf SizeOfV0 existing
+        size <- sizeOf info SizeOfV0 existing
         chargeGasArgs info $ GRead size
         let obj = M.fromList
                   [ (Field "user-guard", PGuard usrG)
@@ -3227,7 +3159,7 @@ coreDescribeNamespace info b _env = \case
   args -> argsError info b args
 
 
-coreChainData :: (MonadEval b i m) => NativeFunction b i m
+coreChainData :: (IsBuiltin b) => NativeFunction e b i
 coreChainData info b _env = \case
   [] -> do
     PublicData publicMeta blockHeight blockTime prevBh <- viewEvalEnv eePublicData
@@ -3248,7 +3180,7 @@ coreChainData info b _env = \case
 -- -------------------------
 
 #ifndef WITHOUT_CRYPTO
-ensureOnCurve :: (Num p, Eq p, MonadEval b i m) => i -> CurvePoint p -> p -> m ()
+ensureOnCurve :: (Num p, Eq p) => i -> CurvePoint p -> p -> EvalM e b i ()
 ensureOnCurve info p bp = unless (isOnCurve p bp) $ throwExecutionError info PointNotOnCurve
 
 toG1 :: ObjectData PactValue -> Maybe G1
@@ -3300,7 +3232,7 @@ fromG2 (Point x y) = ObjectData pts
     , (Field "y", y')]
 
 
-zkPairingCheck :: (MonadEval b i m) => NativeFunction b i m
+zkPairingCheck :: (IsBuiltin b) => NativeFunction e b i
 zkPairingCheck info b _env = \case
   args@[VList p1s, VList p2s] -> do
     chargeGasArgs info (GAZKArgs (Pairing (max (V.length p1s) (V.length p2s))))
@@ -3312,7 +3244,7 @@ zkPairingCheck info b _env = \case
     return $ VBool $ pairingCheck pairs
   args -> argsError info b args
 
-zkScalarMult :: (MonadEval b i m) => NativeFunction b i m
+zkScalarMult :: (IsBuiltin b) => NativeFunction e b i
 zkScalarMult info b _env = \case
   args@[VString ptTy, VObject p1, VInteger scalar] -> do
     let scalar' = scalar `mod` curveOrder
@@ -3337,7 +3269,7 @@ zkScalarMult info b _env = \case
   curveOrder :: Integer
   curveOrder = 21888242871839275222246405745257275088548364400416034343698204186575808495617
 
-zkPointAddition :: (MonadEval b i m) => NativeFunction b i m
+zkPointAddition :: (IsBuiltin b) => NativeFunction e b i
 zkPointAddition info b _env = \case
   args@[VString ptTy, VObject p1, VObject p2] -> do
     case T.toLower ptTy of
@@ -3367,7 +3299,7 @@ zkPointAddition info b _env = \case
 -- Poseidon
 -----------------------------------
 
-poseidonHash :: (MonadEval b i m) => NativeFunction b i m
+poseidonHash :: (IsBuiltin b) => NativeFunction e b i
 poseidonHash info b _env = \case
   [VList as]
     | not (V.null as) && length as <= 8,
@@ -3378,17 +3310,17 @@ poseidonHash info b _env = \case
 
 #else
 
-zkPairingCheck :: (MonadEval b i m) => NativeFunction b i m
-zkPairingCheck info _b _env _args = failInvariant info "crypto disabled"
+zkPairingCheck :: (IsBuiltin b) => NativeFunction e b i
+zkPairingCheck info _b _env _args = throwExecutionError info $ EvalError $ "crypto disabled"
 
-zkScalarMult :: (MonadEval b i m) => NativeFunction b i m
-zkScalarMult info _b _env _args = failInvariant info "crypto disabled"
+zkScalarMult :: (IsBuiltin b) => NativeFunction e b i
+zkScalarMult info _b _env _args = throwExecutionError info $ EvalError $ "crypto disabled"
 
-zkPointAddition :: (MonadEval b i m) => NativeFunction b i m
-zkPointAddition info _b _env _args = failInvariant info "crypto disabled"
+zkPointAddition :: (IsBuiltin b) => NativeFunction e b i
+zkPointAddition info _b _env _args = throwExecutionError info $ EvalError $ "crypto disabled"
 
-poseidonHash :: (MonadEval b i m) => NativeFunction b i m
-poseidonHash info _b _env _args = failInvariant info "crypto disabled"
+poseidonHash :: (IsBuiltin b) => NativeFunction e b i
+poseidonHash info _b _env _args = throwExecutionError info $ EvalError $ "crypto disabled"
 
 #endif
 
@@ -3396,7 +3328,7 @@ poseidonHash info _b _env _args = failInvariant info "crypto disabled"
 -- SPV
 -----------------------------------
 
-coreVerifySPV :: (MonadEval b i m) => NativeFunction b i m
+coreVerifySPV :: (IsBuiltin b) => NativeFunction e b i
 coreVerifySPV info b _env = \case
   [VString proofType, VObject o] -> do
     SPVSupport f _ <- viewEvalEnv eeSPVSupport
@@ -3408,7 +3340,7 @@ coreVerifySPV info b _env = \case
 -----------------------------------
 -- Verifiers
 -----------------------------------
-coreEnforceVerifier :: (MonadEval b i m) => NativeFunction b i m
+coreEnforceVerifier :: (IsBuiltin b) => NativeFunction e b i
 coreEnforceVerifier info b _env = \case
   [VString verName] -> do
     enforceStackTopIsDefcap info b
@@ -3431,36 +3363,27 @@ coreEnforceVerifier info b _env = \case
 
 
 coreBuiltinEnv
-  :: forall i m. (MonadEval CoreBuiltin i m)
-  => BuiltinEnv CoreBuiltin i m
+  :: forall e i
+  . BuiltinEnv e CoreBuiltin i
 coreBuiltinEnv i b env = mkDirectBuiltinFn i b env (coreBuiltinRuntime b)
 
-{-# SPECIALIZE coreBuiltinRuntime
-   :: CoreBuiltin
-   -> NativeFunction CoreBuiltin () Eval
-    #-}
-{-# SPECIALIZE coreBuiltinRuntime
-   :: CoreBuiltin
-   -> NativeFunction CoreBuiltin () Eval
-    #-}
 coreBuiltinRuntime
-  :: (MonadEval b i m)
+  :: (IsBuiltin b)
   => CoreBuiltin
-  -> NativeFunction b i m
+  -> NativeFunction e b i
 coreBuiltinRuntime =
 #ifdef WITH_NATIVE_TRACING
   _traceNative . go
   where
   _traceNative
-    :: (MonadEval b i m)
-    => NativeFunction b i m
-    -> NativeFunction b i m
+    :: NativeFunction e b i
+    -> NativeFunction e b i
   _traceNative f info b env args = do
     timeEnter <- liftIO $ getTime ProcessCPUTime
-    esTraceOutput %== (TraceNativeEnter timeEnter b info:)
+    esTraceOutput %= (TraceNativeEnter timeEnter b info:)
     output <- f info b env args
     timeExit <- liftIO $ getTime ProcessCPUTime
-    esTraceOutput %== (TraceNativeExit timeExit b info:)
+    esTraceOutput %= (TraceNativeExit timeExit b info:)
     pure output
 #else
   go

--- a/pact/Pact/Core/IR/Eval/Direct/ReplBuiltin.hs
+++ b/pact/Pact/Core/IR/Eval/Direct/ReplBuiltin.hs
@@ -1,12 +1,15 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE DataKinds #-}
+
 module Pact.Core.IR.Eval.Direct.ReplBuiltin
   (replBuiltinEnv) where
 
 
-
 import Control.Lens
 import Control.Monad(when)
+import Control.Monad.State.Strict
 import Control.Monad.Except
-import Control.Monad.IO.Class(liftIO)
 import Data.Default
 import Data.Either(partitionEithers)
 import Data.Text(Text)
@@ -57,7 +60,7 @@ prettyShowValue = \case
   VTable (TableValue (TableName tn mn) _ _) -> "table{" <> renderModuleName mn <> "_" <> tn <> "}"
   VClosure _ -> "<#closure>"
 
-corePrint :: NativeFunction ReplCoreBuiltin SpanInfo (ReplM ReplCoreBuiltin)
+corePrint :: NativeFunction ReplRuntime ReplCoreBuiltin SpanInfo
 corePrint info b _env = \case
   [v] -> do
     liftIO $ putStrLn $ T.unpack (prettyShowValue v)
@@ -65,10 +68,10 @@ corePrint info b _env = \case
   args -> argsError info b args
 
 
-coreExpect :: NativeFunction ReplCoreBuiltin SpanInfo (ReplM ReplCoreBuiltin)
+coreExpect :: NativeFunction ReplRuntime ReplCoreBuiltin SpanInfo
 coreExpect info b _env = \case
   [VLiteral (LString msg), VClosure expected, VClosure provided] -> do
-    es <- getEvalState
+    es <- get
     tryError (applyLamUnsafe provided []) >>= \case
       Right (VPactValue v2) -> do
         applyLamUnsafe expected [] >>= enforcePactValue info >>= \case
@@ -81,13 +84,13 @@ coreExpect info b _env = \case
       Right _v ->
         throwUserRecoverableError info $ UserEnforceError "FAILURE: expect expression did not return a pact value for comparison"
       Left err -> do
-        putEvalState es
-        currSource <- use replCurrSource
+        put es
+        currSource <- useReplState replCurrSource
         return $ VString $ "FAILURE: " <> msg <> " evaluation of actual failed with error message:\n" <>
           replError currSource err
   args -> argsError info b args
 
-coreExpectThat :: NativeFunction ReplCoreBuiltin SpanInfo (ReplM ReplCoreBuiltin)
+coreExpectThat :: NativeFunction ReplRuntime ReplCoreBuiltin SpanInfo
 coreExpectThat info b _env = \case
   [VLiteral (LString msg), VClosure vclo, v] -> do
     applyLamUnsafe vclo [v] >>= \case
@@ -97,38 +100,38 @@ coreExpectThat info b _env = \case
       _ -> throwNativeExecutionError info b "Expect-that: condition did not return a boolean"
   args -> argsError info b args
 
-coreExpectFailure :: NativeFunction ReplCoreBuiltin SpanInfo (ReplM ReplCoreBuiltin)
+coreExpectFailure :: NativeFunction ReplRuntime ReplCoreBuiltin SpanInfo
 coreExpectFailure info b _env = \case
   [VString doc, VClosure vclo] -> do
-    es <- getEvalState
+    es <- get
     tryError (applyLamUnsafe vclo []) >>= \case
       Left (PEUserRecoverableError _ _ _) -> do
-        putEvalState es
+        put es
         return $ VLiteral $ LString $ "Expect failure: Success: " <> doc
       Left _err -> do
-        putEvalState es
+        put es
         return $ VLiteral $ LString $ "Expect failure: Success: " <> doc
       Right _ ->
         return $ VLiteral $ LString $ "FAILURE: " <> doc <> ": expected failure, got result"
   [VString desc, VString toMatch, VClosure vclo] -> do
-    es <- getEvalState
+    es <- get
     tryError (applyLamUnsafe vclo []) >>= \case
       Left (PEUserRecoverableError userErr _ _) -> do
-        putEvalState es
+        put es
         let err = renderCompactText userErr
         if toMatch `T.isInfixOf` err
           then return $ VLiteral $ LString $ "Expect failure: Success: " <> desc
           else return $ VLiteral $ LString $
                "FAILURE: " <> desc <> ": expected error message '" <> toMatch <> "', got '" <> err <> "'"
       Left _err -> do
-        putEvalState es
+        put es
         return $ VLiteral $ LString $ "Expect failure: Success: " <> desc
       Right v ->
         return $ VLiteral $ LString $ "FAILURE: " <> toMatch <> ": expected failure, got result: " <> prettyShowValue v
   args -> argsError info b args
 
 
-continuePact :: NativeFunction ReplCoreBuiltin SpanInfo (ReplM ReplCoreBuiltin)
+continuePact :: NativeFunction ReplRuntime ReplCoreBuiltin SpanInfo
 continuePact info b env = \case
   [VInteger s] -> go s False Nothing Nothing
   [VInteger s, VBool r] -> go s r Nothing Nothing
@@ -137,7 +140,7 @@ continuePact info b env = \case
   args -> argsError info b args
   where
     go step rollback mpid userResume = do
-      mpe <- useEvalState esDefPactExec
+      mpe <- use esDefPactExec
       (pid, myield) <- case mpe of
         Nothing -> do
           pid <- maybe (throwExecutionError info NoDefPactIdAndExecEnvSupplied) (pure . DefPactId) mpid
@@ -153,23 +156,23 @@ continuePact info b env = \case
                   pure (Yield o Nothing Nothing)
           in pure (pid, yield)
       let pactStep = DefPactStep (fromInteger step) rollback pid myield
-      setEvalState esDefPactExec Nothing
-      replEvalEnv . eeDefPactStep .= Just pactStep
+      esDefPactExec .= Nothing
+      replEvalEnv . eeDefPactStep .== Just pactStep
       merr <- tryError $ resumePact info env Nothing
-      replEvalEnv . eeDefPactStep .= Nothing
+      replEvalEnv . eeDefPactStep .== Nothing
       liftEither merr
 
-pactState :: NativeFunction ReplCoreBuiltin SpanInfo (ReplM ReplCoreBuiltin)
+pactState :: NativeFunction ReplRuntime ReplCoreBuiltin SpanInfo
 pactState info b _env = \case
   [] -> go False
   [VBool clear] -> go clear
   args -> argsError info b args
   where
   go clear = do
-    mpe <- useEvalState esDefPactExec
+    mpe <- use esDefPactExec
     case mpe of
       Just pe -> do
-        when clear $ esDefPactExec .== Nothing
+        when clear $ esDefPactExec .= Nothing
         let yield' = case _peYield pe of
               Nothing ->  PLiteral (LBool False)
               Just (Yield y _ _) -> PObject y
@@ -180,18 +183,18 @@ pactState info b _env = \case
         return (VObject (M.fromList ps))
       Nothing -> throwUserRecoverableError info $ UserEnforceError "pact-state: no pact exec in context"
 
-coreplEvalEnvStackFrame :: NativeFunction ReplCoreBuiltin SpanInfo (ReplM ReplCoreBuiltin)
+coreplEvalEnvStackFrame :: NativeFunction ReplRuntime ReplCoreBuiltin SpanInfo
 coreplEvalEnvStackFrame info b _env = \case
   [] -> do
-    sfs <- fmap (PString . T.pack . show) <$> use (replEvalState . esStack)
+    sfs <- fmap (PString . T.pack . show) <$> use esStack
     return $ VList (V.fromList sfs)
   args -> argsError info b args
 
-envEvents :: NativeFunction ReplCoreBuiltin SpanInfo (ReplM ReplCoreBuiltin)
+envEvents :: NativeFunction ReplRuntime ReplCoreBuiltin SpanInfo
 envEvents info b _env = \case
   [VBool clear] -> do
-    events <- fmap envToObj <$> useEvalState esEvents
-    when clear $ setEvalState esEvents []
+    events <- fmap envToObj <$> use esEvents
+    when clear $ esEvents .= []
     return (VList (V.fromList events))
     where
     envToObj (PactEvent name args mn mh) =
@@ -203,34 +206,34 @@ envEvents info b _env = \case
         , ("module-hash", PString (hashToText (_mhHash mh)))]
   args -> argsError info b args
 
-envHash :: NativeFunction ReplCoreBuiltin SpanInfo (ReplM ReplCoreBuiltin)
+envHash :: NativeFunction ReplRuntime ReplCoreBuiltin SpanInfo
 envHash info b _env = \case
   [VString s] -> do
     case decodeBase64UrlUnpadded (T.encodeUtf8 s) of
       Left e -> throwUserRecoverableError info $ UserEnforceError (T.pack e)
       Right hs -> do
-        (replEvalEnv . eeHash) .= Hash (toShort hs)
+        (replEvalEnv . eeHash) .== Hash (toShort hs)
         return $ VString $ "Set tx hash to " <> s
   args -> argsError info b args
 
-envData :: NativeFunction ReplCoreBuiltin SpanInfo (ReplM ReplCoreBuiltin)
+envData :: NativeFunction ReplRuntime ReplCoreBuiltin SpanInfo
 envData info b _env = \case
   [VPactValue pv] -> do
     -- to mimic prod, we must roundtrip here
     -- if it fails silently, this is fine.
     let pv' = fromMaybe pv (Legacy.roundtripPactValue pv)
-    (replEvalEnv . eeMsgBody) .= pv'
+    (replEvalEnv . eeMsgBody) .== pv'
     return (VString "Setting transaction data")
   args -> argsError info b args
 
-envChainData :: NativeFunction ReplCoreBuiltin SpanInfo (ReplM ReplCoreBuiltin)
+envChainData :: NativeFunction ReplRuntime ReplCoreBuiltin SpanInfo
 envChainData info b _env = \case
   [VObject cdataObj] -> do
     pd <- viewEvalEnv eePublicData
     go pd (M.toList cdataObj)
     where
     go pd [] = do
-      replEvalEnv . eePublicData .= pd
+      replEvalEnv . eePublicData .== pd
       return (VString "Updated public metadata")
     go pd ((k,v):rest) = case v of
       PInteger i
@@ -254,20 +257,20 @@ envChainData info b _env = \case
         throwUserRecoverableError info $ UserEnforceError $ "envChainData: bad public metadata value for key: " <> _field k
   args -> argsError info b args
 
-envKeys :: NativeFunction ReplCoreBuiltin SpanInfo (ReplM ReplCoreBuiltin)
+envKeys :: NativeFunction ReplRuntime ReplCoreBuiltin SpanInfo
 envKeys info b _env = \case
   [VList ks] -> do
     keys <- traverse (asString info b) ks
-    replEvalEnv . eeMsgSigs .= M.fromList ((,mempty) . PublicKeyText <$> V.toList keys)
+    replEvalEnv . eeMsgSigs .== M.fromList ((,mempty) . PublicKeyText <$> V.toList keys)
     return (VString "Setting transaction keys")
   args -> argsError info b args
 
-envSigs :: NativeFunction ReplCoreBuiltin SpanInfo (ReplM ReplCoreBuiltin)
+envSigs :: NativeFunction ReplRuntime ReplCoreBuiltin SpanInfo
 envSigs info b _env = \case
   [VList ks] ->
     case traverse keyCapObj ks of
       Just sigs -> do
-        (replEvalEnv . eeMsgSigs) .= M.fromList (V.toList sigs)
+        (replEvalEnv . eeMsgSigs) .== M.fromList (V.toList sigs)
         return $ VString "Setting transaction signatures/caps"
       Nothing -> throwUserRecoverableError info $
         UserEnforceError ("env-sigs: Expected object with 'key': string, 'caps': [capability]")
@@ -284,13 +287,13 @@ envSigs info b _env = \case
       _ -> Nothing
   args -> argsError info b args
 
-beginTx :: NativeFunction ReplCoreBuiltin SpanInfo (ReplM ReplCoreBuiltin)
+beginTx :: NativeFunction ReplRuntime ReplCoreBuiltin SpanInfo
 beginTx info b _env = \case
   [VString s] -> begin' info (Just s) >>= renderTx info "Begin Tx"
   [] -> begin' info Nothing >>= renderTx info "Begin Tx"
   args -> argsError info b args
 
-renderTx :: MonadEval b i m => i -> Text -> Maybe (TxId, Maybe Text) -> m (EvalValue b i m)
+renderTx :: i -> Text -> Maybe (TxId, Maybe Text) -> EvalM e b i (EvalValue e b i)
 renderTx _info start (Just (TxId tid, mt)) =
   return $ VString $ start <> " " <> T.pack (show tid) <> maybe mempty (" " <>) mt
 renderTx info start Nothing =
@@ -298,52 +301,52 @@ renderTx info start Nothing =
 
 begin' :: SpanInfo -> Maybe Text -> ReplM b (Maybe (TxId, Maybe Text))
 begin' info mt = do
-  pdb <- use (replEvalEnv . eePactDb)
+  pdb <- useReplState (replEvalEnv . eePactDb)
   mode <- viewEvalEnv eeMode
   mTxId <- liftDbFunction info (_pdbBeginTx pdb mode)
-  replTx .= ((,mt) <$> mTxId)
+  replTx .== ((,mt) <$> mTxId)
   return ((,mt) <$> mTxId)
 
 emptyTxState :: ReplM b ()
 emptyTxState = do
-  fqdefs <- useEvalState (esLoaded . loAllLoaded)
-  cs <- useEvalState esStack
-  esc <- useEvalState esCheckRecursion
+  fqdefs <- use (esLoaded . loAllLoaded)
+  cs <- use esStack
+  esc <- use esCheckRecursion
   let newEvalState =
         set esStack cs
         $ set (esLoaded . loAllLoaded) fqdefs
         $ set esCheckRecursion esc def
-  replEvalState .= newEvalState
+  put newEvalState
 
 
-commitTx :: NativeFunction ReplCoreBuiltin SpanInfo (ReplM ReplCoreBuiltin)
+commitTx :: NativeFunction ReplRuntime ReplCoreBuiltin SpanInfo
 commitTx info b _env = \case
   [] -> do
-    pdb <- use (replEvalEnv . eePactDb)
+    pdb <- useReplState (replEvalEnv . eePactDb)
     _txLog <- liftDbFunction info (_pdbCommitTx pdb)
     emptyTxState
-    use replTx >>= \case
+    useReplState replTx >>= \case
       Just tx -> do
-        replTx .= Nothing
+        replTx .== Nothing
         renderTx info "Commit Tx" (Just tx)
       Nothing -> renderTx info "Commit Tx" Nothing
   args -> argsError info b args
 
 
-rollbackTx :: NativeFunction ReplCoreBuiltin SpanInfo (ReplM ReplCoreBuiltin)
+rollbackTx :: NativeFunction ReplRuntime ReplCoreBuiltin SpanInfo
 rollbackTx info b _env = \case
   [] -> do
-    pdb <- use (replEvalEnv . eePactDb)
+    pdb <- useReplState (replEvalEnv . eePactDb)
     liftDbFunction info (_pdbRollbackTx pdb)
     emptyTxState
-    use replTx >>= \case
+    useReplState replTx >>= \case
       Just tx -> do
-        replTx .= Nothing
+        replTx .== Nothing
         renderTx info "Rollback Tx" (Just tx)
       Nothing -> renderTx info "Rollback Tx" Nothing
   args -> argsError info b args
 
-sigKeyset :: NativeFunction ReplCoreBuiltin SpanInfo (ReplM ReplCoreBuiltin)
+sigKeyset :: NativeFunction ReplRuntime ReplCoreBuiltin SpanInfo
 sigKeyset info b _env = \case
   [] -> do
     sigs <- S.fromList . M.keys <$> viewEvalEnv eeMsgSigs
@@ -351,7 +354,7 @@ sigKeyset info b _env = \case
   args -> argsError info b args
 
 
-testCapability :: NativeFunction ReplCoreBuiltin SpanInfo (ReplM ReplCoreBuiltin)
+testCapability :: NativeFunction ReplRuntime ReplCoreBuiltin SpanInfo
 testCapability info b env = \case
   [VCapToken origToken] -> do
     d <- getDefCap info (_ctName origToken)
@@ -365,13 +368,13 @@ testCapability info b env = \case
         installCap info env origToken False *> evalCap info env origToken PopCapInvoke TestCapEval cBody
   args -> argsError info b args
 
-envExecConfig :: NativeFunction ReplCoreBuiltin SpanInfo (ReplM ReplCoreBuiltin)
+envExecConfig :: NativeFunction ReplRuntime ReplCoreBuiltin SpanInfo
 envExecConfig info b _env = \case
   [VList s] -> do
     s' <- traverse go (V.toList s)
     let (knownFlags, _unkownFlags) = partitionEithers s'
     -- TODO: Emit warnings of unkown flags
-    replEvalEnv . eeFlags .= S.fromList knownFlags
+    replEvalEnv . eeFlags .== S.fromList knownFlags
     let reps = PString . flagRep <$> knownFlags
     return (VList (V.fromList reps))
     where
@@ -381,7 +384,7 @@ envExecConfig info b _env = \case
       --failInvariant info $ "Invalid flag, allowed: " <> T.pack (show (M.keys flagReps))
   args -> argsError info b args
 
-envNamespacePolicy :: NativeFunction ReplCoreBuiltin SpanInfo (ReplM ReplCoreBuiltin)
+envNamespacePolicy :: NativeFunction ReplRuntime ReplCoreBuiltin SpanInfo
 envNamespacePolicy info b _env = \case
   [VBool allowRoot, VClosure (C clo)] -> do
     pdb <- viewEvalEnv eePactDb
@@ -391,13 +394,13 @@ envNamespacePolicy info b _env = \case
     getModuleMember info pdb qn >>= \case
       Dfun _ -> do
         let nsp = SmartNamespacePolicy allowRoot qn
-        replEvalEnv . eeNamespacePolicy .= nsp
+        replEvalEnv . eeNamespacePolicy .== nsp
         return (VString "Installed namespace policy")
       _ ->
         throwUserRecoverableError info $ UserEnforceError "invalid namespace manager function type"
   args -> argsError info b args
 
-envGas :: NativeFunction ReplCoreBuiltin SpanInfo (ReplM ReplCoreBuiltin)
+envGas :: NativeFunction ReplRuntime ReplCoreBuiltin SpanInfo
 envGas info b _env = \case
   [] -> do
     Gas gas <- milliGasToGas <$> getGas
@@ -407,7 +410,7 @@ envGas info b _env = \case
     return $ VString $ "Set gas to " <> T.pack (show g)
   args -> argsError info b args
 
-envMilliGas :: NativeFunction ReplCoreBuiltin SpanInfo (ReplM ReplCoreBuiltin)
+envMilliGas :: NativeFunction ReplRuntime ReplCoreBuiltin SpanInfo
 envMilliGas info b _env = \case
   [] -> do
     MilliGas gas <- getGas
@@ -417,18 +420,18 @@ envMilliGas info b _env = \case
     return $ VString $ "Set milligas to" <> T.pack (show g)
   args -> argsError info b args
 
-envGasLimit :: NativeFunction ReplCoreBuiltin SpanInfo (ReplM ReplCoreBuiltin)
+envGasLimit :: NativeFunction ReplRuntime ReplCoreBuiltin SpanInfo
 envGasLimit info b _env = \case
   [VInteger g] -> do
-    (replEvalEnv . eeGasModel . gmGasLimit) .= MilliGasLimit (gasToMilliGas (Gas (fromInteger g)))
+    (replEvalEnv . eeGasModel . gmGasLimit) .== MilliGasLimit (gasToMilliGas (Gas (fromInteger g)))
     return $ VString $ "Set gas limit to " <> T.pack (show g)
   args -> argsError info b args
 
-envGasLog :: NativeFunction ReplCoreBuiltin SpanInfo (ReplM ReplCoreBuiltin)
+envGasLog :: NativeFunction ReplRuntime ReplCoreBuiltin SpanInfo
 envGasLog info b _env = \case
   [] -> do
-    gl <- useEvalState esGasLog
-    setEvalState esGasLog $ Just []
+    gl <- use esGasLog
+    esGasLog .= Just []
     case gl of
       Nothing ->
         return (VString "Enabled gas log")
@@ -447,15 +450,15 @@ envGasLog info b _env = \case
             Left ga -> pretty ga <> ":currTotalGas=" <> pretty millisUsed
             Right nativeArg -> "Native" <> parens (pretty nativeArg) <> ":currTotalGas=" <> pretty millisUsed
 
-envEnableReplNatives :: NativeFunction ReplCoreBuiltin SpanInfo (ReplM ReplCoreBuiltin)
+envEnableReplNatives :: NativeFunction ReplRuntime ReplCoreBuiltin SpanInfo
 envEnableReplNatives info b _env = \case
   [VBool enabled] -> do
     let s = if enabled then "enabled" else "disabled"
-    replNativesEnabled .= enabled
+    replNativesEnabled .== enabled
     return $ VString $ "repl natives " <> s
   args -> argsError info b args
 
-envGasModel :: NativeFunction ReplCoreBuiltin SpanInfo (ReplM ReplCoreBuiltin)
+envGasModel :: NativeFunction ReplRuntime ReplCoreBuiltin SpanInfo
 envGasModel info b _env = \case
   [] -> do
     gm <- viewEvalEnv eeGasModel
@@ -467,12 +470,12 @@ envGasModel info b _env = \case
       "table" -> pure $ replTableGasModel (_gmGasLimit gm)
       "fixed" -> pure (constantGasModel mempty (_gmGasLimit gm))
       _ -> argsError info b args
-    replEvalEnv . eeGasModel .= newmodel'
+    replEvalEnv . eeGasModel .== newmodel'
     return $ VString $ "Set gas model to " <> _gmDesc newmodel'
   [VString "fixed", VInteger arg] -> do
     gm <- viewEvalEnv eeGasModel
     let newmodel' = constantGasModel (gasToMilliGas (Gas (fromIntegral arg))) (_gmGasLimit gm)
-    replEvalEnv . eeGasModel .= newmodel'
+    replEvalEnv . eeGasModel .== newmodel'
     return $ VString $ "Set gas model to " <> _gmDesc newmodel'
   args -> argsError info b args
 
@@ -481,7 +484,7 @@ envGasModel info b _env = \case
 -- Pact Version
 -----------------------------------
 
-coreVersion :: (MonadEval b i m) => NativeFunction b i m
+coreVersion :: IsBuiltin b => NativeFunction e b i
 coreVersion info b _env = \case
   [] -> let
     v = T.pack (V.showVersion PI.version)
@@ -489,7 +492,7 @@ coreVersion info b _env = \case
   args -> argsError info b args
 
 
-coreEnforceVersion :: (MonadEval b i m) => NativeFunction b i m
+coreEnforceVersion :: IsBuiltin b => NativeFunction e b i
 coreEnforceVersion info b _env = \case
   [VString lowerBound] -> do
     lowerBound' <- mkVersion lowerBound
@@ -509,20 +512,20 @@ coreEnforceVersion info b _env = \case
         Left _msg -> throwExecutionError info (EnforcePactVersionParseFailure s)
         Right li -> pure (V.makeVersion li)
 
-envModuleAdmin ::  NativeFunction ReplCoreBuiltin SpanInfo (ReplM ReplCoreBuiltin)
+envModuleAdmin ::  NativeFunction ReplRuntime ReplCoreBuiltin SpanInfo
 envModuleAdmin info b _env = \case
   [VModRef modRef] -> do
     let modName = _mrModule modRef
-    (esCaps . csModuleAdmin) %== S.insert modName
+    (esCaps . csModuleAdmin) %= S.insert modName
     return $ VString $ "Acquired module admin for: " <> renderModuleName modName
   args -> argsError info b args
 
-envVerifiers :: NativeFunction ReplCoreBuiltin SpanInfo (ReplM ReplCoreBuiltin)
+envVerifiers :: NativeFunction ReplRuntime ReplCoreBuiltin SpanInfo
 envVerifiers info b _env = \case
   [VList ks] ->
     case traverse verifCapObj ks of
       Just sigs -> do
-        (replEvalEnv . eeMsgVerifiers) .= M.fromList (V.toList sigs)
+        (replEvalEnv . eeMsgVerifiers) .== M.fromList (V.toList sigs)
         return $ VString "Setting transaction verifiers/caps"
       Nothing ->
         throwNativeExecutionError info b ("Expected object with 'name': string, 'caps': [capability]")
@@ -541,13 +544,13 @@ envVerifiers info b _env = \case
 
 
 replBuiltinEnv
-  :: BuiltinEnv (ReplBuiltin CoreBuiltin) SpanInfo (ReplM (ReplBuiltin CoreBuiltin))
+  :: BuiltinEnv ReplRuntime (ReplBuiltin CoreBuiltin) SpanInfo
 replBuiltinEnv i b env =
   mkDirectBuiltinFn i b env (replCoreBuiltinRuntime b)
 
 replCoreBuiltinRuntime
   :: ReplBuiltin CoreBuiltin
-  -> NativeFunction (ReplBuiltin CoreBuiltin) SpanInfo (ReplM (ReplBuiltin CoreBuiltin))
+  -> NativeFunction ReplRuntime (ReplBuiltin CoreBuiltin) SpanInfo
 replCoreBuiltinRuntime = \case
   RBuiltinWrap cb ->
     coreBuiltinRuntime cb

--- a/pact/Pact/Core/IR/Eval/Direct/Types.hs
+++ b/pact/Pact/Core/IR/Eval/Direct/Types.hs
@@ -163,19 +163,19 @@ data PartialNativeFn e b i
   { _pNative :: !b
   , _pNativeEnv :: !(DirectEnv e b i)
   , _pNativeFn :: !(NativeFunction e b i)
-  , _pNativeArity :: {-# UNPACK #-} !Int
+  , _pNativeArity :: !Int
   , _pNativeAppliedArgs :: ![EvalValue e b i]
   , _pNativeLoc :: i
   } deriving (Generic)
 
 data CanApply (e :: RuntimeMode) (b :: K.Type) (i :: K.Type)
-  = C {-# UNPACK #-} !(Closure e b i)
-  | LC {-# UNPACK #-} !(LamClosure e b i)
-  | PC {-# UNPACK #-} !(PartialClosure e b i)
-  | N {-# UNPACK #-} !(NativeFn e b i)
-  | PN {-# UNPACK #-} !(PartialNativeFn e b i)
-  | DPC {-# UNPACK #-} !(DefPactClosure e b i)
-  | CT {-# UNPACK #-} !(CapTokenClosure i)
+  = C !(Closure e b i)
+  | N !(NativeFn e b i)
+  | CT !(CapTokenClosure i)
+  | LC !(LamClosure e b i)
+  | PC !(PartialClosure e b i)
+  | PN !(PartialNativeFn e b i)
+  | DPC !(DefPactClosure e b i)
   deriving (Show, Generic)
 
 
@@ -216,9 +216,8 @@ instance Show (EvalValue e b i) where
     VTable vt -> "table" <> show (_tvName vt)
     VClosure _ -> "closure<>"
 
--- | Locally bound variables
--- type DirectEnv e b i = RAList (EvalValue e b i)
-
+-- | Locally bound variables and
+--   our local read-only environment.
 data DirectEnv e b i
   = DirectEnv
   { _ceLocal :: RAList (EvalValue e b i)
@@ -246,7 +245,7 @@ data NativeFn (e :: RuntimeMode) (b :: K.Type) (i :: K.Type)
   { _native :: !b
   , _nativeEnv :: !(DirectEnv e b i)
   , _nativeFn :: !(NativeFunction e b i)
-  , _nativeArity :: {-# UNPACK #-} !Int
+  , _nativeArity :: !Int
   , _nativeLoc :: i
   } deriving (Generic)
 

--- a/pact/Pact/Core/IR/Eval/Runtime/Types.hs
+++ b/pact/Pact/Core/IR/Eval/Runtime/Types.hs
@@ -13,28 +13,11 @@
 {-# LANGUAGE InstanceSigs #-}
 
 module Pact.Core.IR.Eval.Runtime.Types
- ( EvalM(..)
- , runEvalM
- , EvalState(..)
- , esStack
- , esCaps, esEvents
- , csModuleAdmin
- , esLoaded
- , CapState(..)
- , csSlots, csManaged, csCapsBeingEvaluated
- , ManagedCap(..)
- , mcCap, mcManaged, mcOriginalCap
- , ManagedCapType(..)
- , StackFrame(..)
- , TableValue(..)
- , ErrorState(..)
- , Eval
- ) where
+  ( TableValue(..)
+  , ErrorState(..)) where
 
-import Control.Monad.Catch
-import Control.Monad.Reader
-import Control.Monad.State.Strict
-import Control.Monad.Except
+
+
 import Data.List.NonEmpty(NonEmpty)
 import GHC.Generics
 import Control.DeepSeq
@@ -47,13 +30,7 @@ import Pact.Core.Hash
 import Pact.Core.Type
 import Pact.Core.Capabilities
 import Pact.Core.Environment
-import Pact.Core.Debug
-import Pact.Core.Errors
-import Pact.Core.Builtin
 
-
-
-type Eval = EvalM CoreBuiltin ()
 
 data TableValue
   = TableValue
@@ -70,36 +47,3 @@ data ErrorState i
   deriving (Show, Generic)
 
 instance NFData i => NFData (ErrorState i)
-
--- Todo: are we going to inject state as the reader monad here?
-newtype EvalM b i a =
-  EvalT (ReaderT (EvalEnv b i) (ExceptT (PactError i) (StateT (EvalState b i) IO)) a)
-  deriving
-    ( Functor, Applicative, Monad
-    , MonadIO
-    , MonadThrow
-    , MonadCatch
-    , MonadMask
-    , MonadReader (EvalEnv b i)
-    , MonadError (PactError i))
-  via (ReaderT (EvalEnv b i) (ExceptT (PactError i) (StateT (EvalState b i) IO)))
-
-instance PhaseDebug b i (EvalM b i) where
-  debugPrint _ _ = pure ()
-
-instance MonadEvalEnv b i (EvalM b i) where
-  readEnv = EvalT ask
-
-instance MonadEvalState b i (EvalM b i) where
-  getEvalState = EvalT get
-  putEvalState p = EvalT (put p)
-  modifyEvalState f = EvalT (modify' f)
-
-
-runEvalM
-  :: EvalEnv b i
-  -> EvalState b i
-  -> EvalM b i a
-  -> IO (Either (PactError i) a, EvalState b i)
-runEvalM env st (EvalT action) =
-  runStateT (runExceptT (runReaderT action env)) st

--- a/pact/Pact/Core/Info.hs
+++ b/pact/Pact/Core/Info.hs
@@ -5,6 +5,7 @@ module Pact.Core.Info
 
 import Data.Default
 import GHC.Generics
+import Control.DeepSeq (NFData)
 
 data SpanInfo
   = SpanInfo
@@ -16,6 +17,8 @@ data SpanInfo
 
 instance Default SpanInfo where
   def = SpanInfo 0 0 0 0
+
+instance NFData SpanInfo
 
 -- | Combine two Span infos
 -- and spit out how far down the expression spans.

--- a/pact/Pact/Core/Interpreter.hs
+++ b/pact/Pact/Core/Interpreter.hs
@@ -7,11 +7,12 @@ import Pact.Core.Guards
 import Pact.Core.Persistence
 import Pact.Core.IR.Term
 import Pact.Core.PactValue
+import Pact.Core.Environment
 
 -- | Our Interpreter abstraction for
 --   working with different pact interpreters.
-data Interpreter b i m
+data Interpreter e b i
   = Interpreter
-  { interpretGuard :: !(i -> Guard QualifiedName PactValue -> m PactValue)
-  , eval :: !(Purity -> EvalTerm b i -> m PactValue)
+  { interpretGuard :: !(i -> Guard QualifiedName PactValue -> EvalM e b i PactValue)
+  , eval :: !(Purity -> EvalTerm b i -> EvalM e b i PactValue)
   }

--- a/pact/Pact/Core/Legacy/LegacyPactValue.hs
+++ b/pact/Pact/Core/Legacy/LegacyPactValue.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE InstanceSigs #-}
+
 module Pact.Core.Legacy.LegacyPactValue
   (roundtripPactValue) where
 

--- a/pact/Pact/Core/Legacy/LegacyPactValue.hs
+++ b/pact/Pact/Core/Legacy/LegacyPactValue.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE InstanceSigs #-}
 module Pact.Core.Legacy.LegacyPactValue
   (roundtripPactValue) where
 

--- a/pact/Pact/Core/Persistence/MockPersistence.hs
+++ b/pact/Pact/Core/Persistence/MockPersistence.hs
@@ -145,12 +145,12 @@ mockPactDb serial = do
     , _pdbRollbackTx = rollbackTx pactTables
     , _pdbTxIds = txIds (ptTxLogQueue pactTables)
     , _pdbGetTxLog = txLog (ptTxLogQueue pactTables)
-    } --   }
+    }
   where
   beginTx pts@PactTables{..} em = do
     readIORef ptRollbackState >>= \case
       -- A tx is already in progress, so we fail to get a
-      -- tx id
+      -- new tx id
       Just _ -> pure Nothing
       -- No tx in progress, get the state of the pure tables prior to rollback.
       Nothing -> do

--- a/pact/Pact/Core/Persistence/MockPersistence.hs
+++ b/pact/Pact/Core/Persistence/MockPersistence.hs
@@ -384,7 +384,7 @@ mockPactDb serial = do
             MockSysTable (M.insert (renderKey rowkey) encodedData msys)
       TFDUser _ ->
         -- noop, should not be used for user tables
-        pure ()
+        error "Invariant violated: writeSysTable used for user table"
 
 rightToMaybe :: Either e a -> Maybe a
 rightToMaybe = \case

--- a/pact/Pact/Core/Persistence/MockPersistence.hs
+++ b/pact/Pact/Core/Persistence/MockPersistence.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Pact.Core.Persistence.MockPersistence (
@@ -8,14 +11,15 @@ module Pact.Core.Persistence.MockPersistence (
 
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad (unless)
-import Control.Exception(throwIO)
+import Control.Exception.Safe
 import Control.Lens ((^?), (^.), ix, view)
-import Data.Maybe (isJust, fromMaybe)
+import Data.Maybe (isJust, fromMaybe, catMaybes)
 import Data.List (find)
 import Data.Map (Map)
 import Data.IORef
-import qualified Data.Map.Strict as Map
+import Data.Text(Text)
 import qualified Data.Map.Strict as M
+import qualified Data.Text as T
 import Data.ByteString (ByteString)
 
 
@@ -29,79 +33,179 @@ import Pact.Core.Gas
 import Pact.Core.Errors
 
 import qualified Pact.Core.Errors as Errors
-import qualified Pact.Core.Persistence as Persistence
 import Pact.Core.PactValue
 import Pact.Core.Literal
 
 
 type TxLogQueue = IORef (Map TxId [TxLog ByteString])
 
+-- | Small newtype to ensure we
+--   turn the table names into Text keys
+newtype Rendered v
+  = Rendered { _unRender :: Text }
+  deriving (Eq, Ord, Show)
+
+renderTableName :: TableName -> Rendered TableName
+renderTableName tn = Rendered (toUserTable tn)
+
+newtype MockUserTable =
+  MockUserTable (Map (Rendered TableName) (Map RowKey ByteString))
+  deriving (Eq, Show, Ord)
+  deriving (Semigroup, Monoid) via (Map (Rendered TableName) (Map RowKey ByteString))
+
+newtype MockSysTable k v =
+  MockSysTable (Map (Rendered k) ByteString)
+  deriving (Eq, Show, Ord)
+  deriving (Semigroup, Monoid) via (Map (Rendered k) ByteString)
+
+data TableFromDomain k v b i where
+  TFDUser :: IORef (MockUserTable) -> TableFromDomain RowKey RowData b i
+  TFDSys :: IORef (MockSysTable k v) -> TableFromDomain k v b i
+
+tableFromDomain :: Domain k v b i -> PactTables b i -> TableFromDomain k v b i
+tableFromDomain d PactTables{..} = case d of
+  DUserTables {} -> TFDUser ptUser
+  DKeySets -> TFDSys ptKeysets
+  DModules -> TFDSys ptModules
+  DNamespaces -> TFDSys ptNamespaces
+  DDefPacts -> TFDSys ptDefPact
+
+
+-- | A record collection of all of the mutable
+--   table references
+data PactTables b i
+  = PactTables
+  { ptTxId :: !(IORef TxId)
+  , ptUser :: !(IORef MockUserTable)
+  , ptModules :: !(IORef (MockSysTable ModuleName (ModuleData b i)))
+  , ptKeysets :: !(IORef (MockSysTable KeySetName KeySet))
+  , ptNamespaces :: !(IORef (MockSysTable NamespaceName Namespace))
+  , ptDefPact :: !(IORef (MockSysTable DefPactId (Maybe DefPactExec)))
+  , ptTxLogQueue :: TxLogQueue
+  , ptRollbackState :: IORef (Maybe (PactTablesState b i))
+  }
+
+-- | The state of the database at the beginning of a transaction
+data PactTablesState b i
+  = PactTablesState
+  { _ptsExecMode :: ExecutionMode
+  , _ptsUser :: !MockUserTable
+  , _ptsModules :: !(MockSysTable ModuleName (ModuleData b i))
+  , _ptsKeysets :: !(MockSysTable KeySetName KeySet)
+  , _ptsNamespaces :: !(MockSysTable NamespaceName Namespace)
+  , _ptsDefPact :: !(MockSysTable DefPactId (Maybe DefPactExec))
+  , _ptsTxLogQueue :: Map TxId [TxLog ByteString]
+  }
+
+
+-- | Create an empty table
+createPactTables :: IO (PactTables b i)
+createPactTables = do
+  refMod <- newIORef mempty
+  refKs <- newIORef mempty
+  refUsrTbl <- newIORef mempty
+  refPacts <- newIORef mempty
+  refNS <- newIORef mempty
+  refRb <- newIORef Nothing
+  refTxLog <- newIORef mempty
+  refTxId <- newIORef $ TxId 0
+  pure $ PactTables
+    { ptTxId = refTxId
+    , ptUser = refUsrTbl
+    , ptModules = refMod
+    , ptKeysets = refKs
+    , ptNamespaces = refNS
+    , ptDefPact = refPacts
+    , ptTxLogQueue = refTxLog
+    , ptRollbackState = refRb }
+
+getRollbackState :: ExecutionMode -> PactTables b i -> IO (PactTablesState b i)
+getRollbackState em PactTables{..} =
+  PactTablesState em
+    <$> readIORef ptUser
+    <*> readIORef ptModules
+    <*> readIORef ptKeysets
+    <*> readIORef ptNamespaces
+    <*> readIORef ptDefPact
+    <*> readIORef ptTxLogQueue
+
+
+
 mockPactDb :: forall b i. PactSerialise b i -> IO (PactDb b i)
 mockPactDb serial = do
-  refMod <- newIORef M.empty
-  refKs <- newIORef M.empty
-  refUsrTbl <- newIORef M.empty
-  refPacts <- newIORef M.empty
-  refNS <- newIORef M.empty
-  refRb <- newIORef Nothing
-  refTxLog :: TxLogQueue <- newIORef mempty
-  refTxId <- newIORef $ TxId 0
+  pactTables <- createPactTables
   pure $ PactDb
     { _pdbPurity = PImpure
-    , _pdbRead = read' refKs refMod refNS refUsrTbl refPacts
-    , _pdbWrite = write refKs refMod refNS refUsrTbl refTxId refTxLog refPacts
-    , _pdbKeys = keys refKs refMod refNS refUsrTbl refPacts
-    , _pdbCreateUserTable = \tn -> createUsrTable refUsrTbl refTxId refTxLog tn
-    , _pdbBeginTx = beginTx refRb refTxId refTxLog refMod refKs refUsrTbl
-    , _pdbCommitTx = commitTx refRb refTxId refTxLog refMod refKs refUsrTbl
-    , _pdbRollbackTx = rollbackTx refRb refTxLog refMod refKs refUsrTbl
-    , _pdbTxIds = txIds refTxLog
-    , _pdbGetTxLog = txLog refTxLog
-    }
+    , _pdbRead = read' pactTables
+    , _pdbWrite = write pactTables
+    , _pdbKeys = keys pactTables
+    , _pdbCreateUserTable = createUsrTable pactTables
+    , _pdbBeginTx = beginTx pactTables
+    , _pdbCommitTx = commitTx pactTables
+    , _pdbRollbackTx = rollbackTx pactTables
+    , _pdbTxIds = txIds (ptTxLogQueue pactTables)
+    , _pdbGetTxLog = txLog (ptTxLogQueue pactTables)
+    } --   }
   where
-  beginTx refRb refTxId refTxLog refMod refKs refUsrTbl em = do
-    readIORef refRb >>= \case
-      Just (_, _, _, _, _) -> pure Nothing
+  beginTx pts@PactTables{..} em = do
+    readIORef ptRollbackState >>= \case
+      -- A tx is already in progress, so we fail to get a
+      -- tx id
+      Just _ -> pure Nothing
+      -- No tx in progress, get the state of the pure tables prior to rollback.
       Nothing -> do
-        mods <- readIORef refMod
-        ks <- readIORef refKs
-        usrTbl <- readIORef refUsrTbl
-        txl <- readIORef refTxLog
-        writeIORef refRb (Just (em, txl, mods, ks, usrTbl))
-        tid <- readIORef refTxId
+        rbs <- getRollbackState em pts
+
+        writeIORef ptRollbackState (Just rbs)
+        tid <- readIORef ptTxId
         pure (Just tid)
 
-  commitTx refRb refTxId refTxLog refMod refKs refUsrTbl = readIORef refRb >>= \case
-    Just (em, txl, mods, ks, usr) -> case em of
+  commitTx PactTables{..} = readIORef ptRollbackState >>= \case
+    -- We are successfully in a transaction
+    Just (PactTablesState em usr mods ks ns dp txl) -> case em of
       Transactional -> do
-        writeIORef refRb Nothing
-        txId <- atomicModifyIORef' refTxId (\(TxId i) -> (TxId (succ i), TxId i))
-        txLogQueue <- readIORef refTxLog
-        pure (Map.findWithDefault [] txId txLogQueue)
+        -- Reset the rollback state,
+        -- increment to the next tx id, and return the
+        -- tx logs for the transaction
+        writeIORef ptRollbackState Nothing
+        txId <- atomicModifyIORef' ptTxId (\(TxId i) -> (TxId (succ i), TxId i))
+        txLogQueue <- readIORef ptTxLogQueue
+        pure (M.findWithDefault [] txId txLogQueue)
       Local -> do
-        writeIORef refRb Nothing
-        writeIORef refMod mods
-        writeIORef refKs ks
-        writeIORef refUsrTbl usr
-        writeIORef refTxLog txl
-        txId <- readIORef refTxId
-        pure (Map.findWithDefault [] txId txl)
+        -- in local, we simply roll back all tables
+        -- then and return the logs, then roll back the logs table
+        writeIORef ptRollbackState Nothing
+        writeIORef ptModules mods
+        writeIORef ptKeysets ks
+        writeIORef ptUser usr
+        writeIORef ptTxLogQueue txl
+        writeIORef ptNamespaces ns
+        writeIORef ptDefPact dp
+
+        txId <- readIORef ptTxId
+        txl' <- readIORef ptTxLogQueue
+
+        let logs = M.findWithDefault [] txId txl'
+        writeIORef ptTxLogQueue txl
+        pure logs
     Nothing ->
       throwIO Errors.NoTxToCommit
 
-  rollbackTx refRb refTxLog refMod refKs refUsrTbl = readIORef refRb >>= \case
-    Just (_, txl, mods, ks, usr) -> do
-      writeIORef refRb Nothing
-      writeIORef refTxLog txl
-      writeIORef refMod mods
-      writeIORef refKs ks
-      writeIORef refUsrTbl usr
+  rollbackTx PactTables{..} = readIORef ptRollbackState >>= \case
+    Just (PactTablesState _ usr mods ks ns dp txl) -> do
+      writeIORef ptRollbackState Nothing
+      writeIORef ptModules mods
+      writeIORef ptKeysets ks
+      writeIORef ptUser usr
+      writeIORef ptTxLogQueue txl
+      writeIORef ptNamespaces ns
+      writeIORef ptDefPact dp
     Nothing -> throwIO Errors.NoTxToCommit
 
   txLog :: TxLogQueue -> TableName -> TxId -> IO [TxLog RowData]
   txLog refTxLog tn tid = do
     txl <- readIORef refTxLog
-    case Map.lookup tid txl of
+    case M.lookup tid txl of
       Just txl' -> pure $ fromMaybe [] (traverse (traverse (fmap (view document) . _decodeRowData serial)) (filter (\(TxLog dom _ _) -> dom == toUserTable tn) txl'))
       Nothing -> pure []
 
@@ -110,183 +214,184 @@ mockPactDb serial = do
     txl <- readIORef refTxLog
     let
       userTab = toUserTable tn
-      subTxs = Map.filterWithKey (\(TxId i) txs -> i >= txId && isJust (find (\(TxLog dom _ _) -> dom == userTab) txs)) txl
-    pure (Map.keys subTxs)
+      subTxs = M.filterWithKey (\(TxId i) txs -> i >= txId && isJust (find (\(TxLog dom _ _) -> dom == userTab) txs)) txl
+    pure (M.keys subTxs)
 
   keys
-    :: forall k v
-    .  IORef (Map KeySetName KeySet)
-    -> IORef (Map ModuleName (ModuleData b i))
-    -> IORef (Map NamespaceName Namespace)
-    -> IORef (Map TableName (Map RowKey RowData))
-    -> IORef (Map DefPactId (Maybe DefPactExec))
+    :: PactTables b i
     -> Domain k v b i
     -> IO [k]
-  keys refKs refMod refNS refUsrTbl refPacts d = case d of
+  keys PactTables{..} d = case d of
     DKeySets -> do
-      r <- readIORef refKs
-      return (M.keys r)
+      MockSysTable r <- readIORef ptKeysets
+      -- Note: the parser only fails on null input, so
+      -- if this ever fails, then somehow the null key got into the keysets.
+      -- this is benign.
+      let getKeysetName = fromMaybe (KeySetName "" Nothing) . rightToMaybe . parseAnyKeysetName
+      return $ getKeysetName . _unRender <$> M.keys r
     DModules -> do
-      r <- readIORef refMod
-      return (M.keys r)
+      MockSysTable r <- readIORef ptModules
+      let getModuleName = parseModuleName . _unRender
+      return $ catMaybes $ getModuleName <$> M.keys r
     DUserTables tbl -> do
-      r <- readIORef refUsrTbl
---      let tblName = toUserTable tbl
-      case M.lookup tbl r of
+      MockUserTable r <- readIORef ptUser
+      let tblName = renderTableName tbl
+      case M.lookup tblName r of
         Just t -> return (M.keys t)
         Nothing -> throwIO (Errors.NoSuchTable tbl)
     DDefPacts -> do
-      r <- readIORef refPacts
-      return (M.keys r)
+      MockSysTable r <- readIORef ptDefPact
+      return $ DefPactId . _unRender <$> M.keys r
     DNamespaces -> do
-      r <- readIORef refNS
-      pure (M.keys r)
+      MockSysTable r <- readIORef ptNamespaces
+      pure $ NamespaceName . _unRender <$> M.keys r
 
   createUsrTable
-    :: IORef (Map TableName (Map RowKey RowData))
-    -> IORef TxId
-    -> TxLogQueue
+    :: PactTables b i
     -> TableName
     -> GasM (PactError i) b ()
-  createUsrTable refUsrTbl _refTxId _refTxLog tbl = do
-    let rd = RowData $ Map.singleton (Field "utModule")
-          (PObject $ Map.fromList
+  createUsrTable PactTables{..} tbl = do
+    let rd = RowData $ M.singleton (Field "utModule")
+          (PObject $ M.fromList
             [ (Field "namespace", maybe (PLiteral LUnit) (PString . _namespaceName) (_mnNamespace (_tableModuleName tbl)))
             , (Field "name", PString (_tableName tbl))
             ])
     _rdEnc <- _encodeRowData serial rd
-    ref <- liftIO $ readIORef refUsrTbl
-    case M.lookup tbl ref of
+    MockUserTable ref <- liftIO $ readIORef ptUser
+    let tblName = renderTableName tbl
+    case M.lookup tblName ref of
       Nothing -> do
         -- TODO: Do we need a TxLog when a usertable is created?
-        liftIO $ modifyIORef refUsrTbl (M.insert tbl mempty)
+        liftIO $ modifyIORef ptUser (\(MockUserTable m) -> MockUserTable (M.insert tblName mempty m))
         pure ()
       Just _ -> liftIO $ throwIO (Errors.TableAlreadyExists tbl)
 
   read'
     :: forall k v
-    .  IORef (Map KeySetName KeySet)
-    -> IORef (Map ModuleName (ModuleData b i))
-    -> IORef (Map NamespaceName Namespace)
-    -> IORef (Map TableName (Map RowKey RowData))
-    -> IORef (Map DefPactId (Maybe DefPactExec))
+    .  PactTables b i
     -> Domain k v b i
     -> k
     -> IO (Maybe v)
-  read' refKs refMod refNS refUsrTbl refPacts domain k = case domain of
-    DKeySets -> readKS refKs k
-    DModules -> readMod refMod k
+  read' PactTables{..} domain k = case domain of
+    DKeySets -> readSysTable ptKeysets k (Rendered . renderKeySetName) _decodeKeySet
+    DModules -> readSysTable ptModules k (Rendered . renderModuleName) _decodeModuleData
     DUserTables tbl ->
-      readRowData refUsrTbl tbl k
-    DDefPacts -> readPacts' refPacts k
-    DNamespaces -> readNS refNS k
+      readRowData ptUser tbl k
+    DDefPacts -> readSysTable ptDefPact k (Rendered . _defpactId) _decodeDefPactExec
+    DNamespaces ->
+      readSysTable ptNamespaces k (Rendered . _namespaceName) _decodeNamespace
 
-  checkTable :: forall m. MonadIO m => TableName -> IORef (Map TableName (Map RowKey RowData)) -> m ()
-  checkTable tbl ref = liftIO $ do
-    r <- readIORef ref
-    unless (isJust (M.lookup tbl r)) $ throwIO (Errors.NoSuchTable tbl)
+  checkTable :: MonadIO m => Rendered TableName -> TableName -> MockUserTable -> m ()
+  checkTable tbl tn (MockUserTable r) = liftIO $ do
+    unless (isJust (M.lookup tbl r)) $ throwIO (Errors.NoSuchTable tn)
 
   write
     :: forall k v
-    .  IORef (Map KeySetName KeySet)
-    -> IORef (Map ModuleName (ModuleData b i))
-    -> IORef (Map NamespaceName Namespace)
-    -> IORef (Map TableName (Map RowKey RowData))
-    -> IORef TxId
-    -> TxLogQueue
-    -> IORef (Map DefPactId (Maybe DefPactExec))
+    .  PactTables b i
     -> WriteType
     -> Domain k v b i
     -> k
     -> v
     -> GasM (PactError i) b ()
-  write refKs refMod refNS refUsrTbl refTxId refTxLog refPacts wt domain k v = case domain of
+  write pt wt domain k v = case domain of
     -- Todo : incrementally serialize other types
-    DKeySets -> liftIO $ writeKS refKs refTxId refTxLog k v
-    DModules -> liftIO $ writeMod refMod refTxId refTxLog v
-    DUserTables tbl -> writeRowData refUsrTbl refTxId refTxLog tbl wt k v
-    DDefPacts -> liftIO $ writePacts' refPacts refTxId refTxLog k v
-    DNamespaces -> liftIO $ writeNS refNS refTxId refTxLog k v
+    DKeySets -> liftIO $ writeSysTable pt domain k v (Rendered . renderKeySetName) _encodeKeySet
+    DModules -> liftIO $ writeSysTable pt domain k v (Rendered . renderModuleName) _encodeModuleData
+    DUserTables tbl -> writeRowData pt tbl wt k v
+    DDefPacts -> liftIO $ liftIO $ writeSysTable pt domain k v (Rendered . _defpactId) _encodeDefPactExec
+    DNamespaces -> liftIO $ liftIO $ writeSysTable pt domain k v (Rendered . _namespaceName) _encodeNamespace
 
   readRowData ref tbl k = do
-    -- let tblName = toUserTable tbl
-    checkTable tbl ref
-    r <- readIORef ref
-    pure (r ^? ix tbl . ix k)
+    let tblName = renderTableName tbl
+    mt@(MockUserTable usrTables) <- readIORef ref
+    checkTable tblName tbl mt
+    case usrTables ^? ix tblName . ix k of
+      Just bs -> case _decodeRowData serial bs of
+        Just doc -> pure (Just (view document doc))
+        Nothing -> throwM $ Errors.RowReadDecodeFailure (_rowKey k)
+      Nothing -> pure Nothing
 
   writeRowData
-    :: IORef (Map TableName (Map RowKey RowData))
-    -> IORef TxId
-    -> TxLogQueue
+    :: PactTables b i
     -> TableName
     -> WriteType
     -> RowKey
     -> RowData
     -> GasM (PactError i) b ()
-  writeRowData ref refTxId refTxLog tbl wt k v = checkTable tbl ref *> case wt of
-    Write -> do
-      encodedData <- _encodeRowData serial v
-      liftIO $ record refTxId refTxLog (TxLog (toUserTable tbl) (k ^. rowKey) encodedData)
-      liftIO $ modifyIORef' ref (M.insertWith M.union tbl (M.singleton k v))
-    Insert -> do
-      r <- liftIO $ readIORef ref
-      case M.lookup tbl r >>= M.lookup k of
-        Just _ -> liftIO $ throwIO Errors.WriteException
-        Nothing -> do
-          encodedData <- _encodeRowData serial v
-          liftIO $ record refTxId refTxLog (TxLog (toUserTable tbl) (k ^. rowKey) encodedData)
-          liftIO $ modifyIORef' ref (M.insertWith M.union tbl (M.singleton k v))
-    Update -> do
-      r <- liftIO $ readIORef ref
-      case M.lookup tbl r >>= M.lookup k of
-        Just (RowData m) -> do
-          let (RowData v') = v
-              nrd = RowData (M.union v' m)
-          encodedData <- _encodeRowData serial nrd
-          liftIO $ record refTxId refTxLog (TxLog (toUserTable tbl) (k ^. rowKey) encodedData)
-          liftIO $ modifyIORef' ref (M.insertWith M.union tbl (M.singleton k nrd))
-        Nothing -> liftIO $ throwIO Errors.WriteException
+  writeRowData pts@PactTables{..} tbl wt k v = do
+    let tblName = renderTableName tbl
+    mt@(MockUserTable usrTables) <- liftIO $ readIORef ptUser
+    checkTable tblName tbl mt
+    case wt of
+      Write -> do
+        encodedData <- _encodeRowData serial v
+        liftIO $ record pts (TxLog (toUserTable tbl) (k ^. rowKey) encodedData)
+        liftIO $ modifyIORef' ptUser
+          (\(MockUserTable m) -> (MockUserTable (M.adjust (M.insert k encodedData) tblName  m)))
+      Insert -> do
+        case M.lookup tblName usrTables >>= M.lookup k of
+          Just _ -> liftIO $ throwIO (Errors.RowFoundException tbl k)
+          Nothing -> do
+            encodedData <- _encodeRowData serial v
+            liftIO $ record pts (TxLog (toUserTable tbl) (k ^. rowKey) encodedData)
+            liftIO $ modifyIORef' ptUser
+              (\(MockUserTable m) -> (MockUserTable (M.adjust (M.insert k encodedData) tblName  m)))
+      Update -> do
+        case M.lookup tblName usrTables >>= M.lookup k of
+          Just bs -> case view document <$> _decodeRowData serial bs of
+            Just (RowData m) -> do
+              let (RowData v') = v
+                  nrd = RowData (M.union v' m)
+              encodedData <- _encodeRowData serial nrd
+              liftIO $ record pts (TxLog (toUserTable tbl) (k ^. rowKey) encodedData)
+              liftIO $ modifyIORef' ptUser $ \(MockUserTable mut) ->
+                MockUserTable (M.insertWith M.union tblName (M.singleton k encodedData) mut)
+            Nothing ->
+              liftIO $ throwIO (Errors.RowReadDecodeFailure (_rowKey k))
+          Nothing ->
+            liftIO $ throwIO (Errors.NoRowFound tbl k)
 
+  readSysTable
+    :: IORef (MockSysTable k v)
+    -> k
+    -> (k -> Rendered k)
+    -> (PactSerialise b i -> ByteString -> Maybe (Document v))
+    -> IO (Maybe v)
+  readSysTable ref rowkey renderKey decode = do
+    MockSysTable m <- readIORef ref
+    case M.lookup (renderKey rowkey) m of
+      Just bs -> case decode serial bs of
+        Just rd -> pure (Just (view document rd))
+        Nothing ->
+          throwM (Errors.RowReadDecodeFailure (_unRender (renderKey rowkey)))
+      Nothing -> pure Nothing
+  {-# INLINE readSysTable #-}
 
-  readKS ref ksn = do
-    m <- readIORef ref
-    pure (M.lookup ksn m)
+  writeSysTable
+    :: PactTables b i
+    -> Domain k v b i
+    -> k
+    -> v
+    -> (k -> Rendered k)
+    -> (PactSerialise b i -> v -> ByteString)
+    -> IO ()
+  writeSysTable pts domain rowkey value renderKey encode = do
+    case tableFromDomain domain pts of
+      TFDSys ref -> do
+        let encodedData = encode serial value
+        record pts (TxLog (T.toUpper (renderDomain domain)) (_unRender (renderKey rowkey)) encodedData)
+        modifyIORef' ref $ \(MockSysTable msys) ->
+            MockSysTable (M.insert (renderKey rowkey) encodedData msys)
+      TFDUser _ ->
+        -- noop, should not be used for user tables
+        pure ()
 
-  readNS ref ns = do
-    m <- readIORef ref
-    pure (M.lookup ns m)
+rightToMaybe :: Either e a -> Maybe a
+rightToMaybe = \case
+  Left{} -> Nothing
+  Right a -> Just a
 
-  writeKS :: IORef (Map KeySetName KeySet) -> IORef TxId -> TxLogQueue -> KeySetName -> KeySet -> IO ()
-  writeKS ref refTxId refTxLog ksn ks = do
-    modifyIORef' ref (M.insert ksn ks)
-    record refTxId refTxLog (TxLog "SYS:KEYSETS" (renderKeySetName ksn) (_encodeKeySet serial ks))
-
-  writeNS :: IORef (Map NamespaceName Namespace) -> IORef TxId -> TxLogQueue -> NamespaceName  -> Namespace -> IO ()
-  writeNS ref refTxId refTxLog nsn ns = do
-    modifyIORef' ref (M.insert nsn ns)
-    record refTxId refTxLog (TxLog "SYS:NAMESPACES" (_namespaceName nsn) (_encodeNamespace serial ns))
-
-  readMod ref mn = do
-    m <- readIORef ref
-    pure (M.lookup mn m)
-
-  writeMod :: IORef (Map ModuleName (ModuleData b i)) -> IORef TxId -> TxLogQueue -> ModuleData b i -> IO ()
-  writeMod ref refTxId refTxLog md = let
-    mname = view Persistence.mdModuleName md
-    in do
-         modifyIORef' ref (M.insert mname md)
-         record refTxId refTxLog (TxLog "SYS:MODULES" (renderModuleName mname) (_encodeModuleData serial md))
-
-  readPacts' ref pid = do
-    m <- readIORef ref
-    pure (M.lookup pid m)
-
-  writePacts' :: IORef (Map DefPactId (Maybe DefPactExec)) -> IORef TxId -> TxLogQueue -> DefPactId -> Maybe DefPactExec -> IO ()
-  writePacts' ref refTxId refTxLog pid pe = do
-    modifyIORef' ref (M.insert pid pe)
-    record refTxId refTxLog (TxLog "SYS:NAMESPACES" (renderDefPactId pid) (_encodeDefPactExec serial pe))
-
-record :: IORef TxId -> TxLogQueue -> TxLog ByteString -> IO ()
-record txId queue entry = do
-  txIdNow <- readIORef txId
-  modifyIORef queue $ \txMap -> Map.insertWith (<>) txIdNow [entry] txMap
+record :: PactTables b i -> TxLog ByteString -> IO ()
+record PactTables{..} entry = do
+  txIdNow <- readIORef ptTxId
+  modifyIORef ptTxLogQueue $ \txMap -> M.insertWith (<>) txIdNow [entry] txMap

--- a/pact/Pact/Core/Persistence/SQLite.hs
+++ b/pact/Pact/Core/Persistence/SQLite.hs
@@ -7,15 +7,17 @@
 
 module Pact.Core.Persistence.SQLite (
   withSqlitePactDb,
-  unsafeCreateSqlitePactDb
+  unsafeCreateSqlitePactDb,
+  unsafeCloseSqlitePactDb,
+  StmtCache(..)
 ) where
 
--- import Control.Monad.Trans.Control (MonadBaseControl)
+import Control.Monad
 import Control.Monad.Catch
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Data.IORef
 import Data.Text (Text)
-import Control.Lens (view)
+import Control.Lens
 import qualified Database.SQLite3 as SQL
 import qualified Database.SQLite3.Direct as Direct
 import Data.ByteString (ByteString)
@@ -46,10 +48,32 @@ withSqlitePactDb
   -> (PactDb b i -> m a)
   -> m a
 withSqlitePactDb serial connectionString act =
-  bracket connect cleanup (\db -> liftIO (initializePactDb serial db) >>= act)
+  bracket connect cleanup work
   where
-    connect = liftIO $ SQL.open connectionString
-    cleanup db = liftIO $ SQL.close db
+    work (_,(pdb, _)) = act pdb
+    connect = liftIO $ do
+      con <- SQL.open connectionString
+      forM_ fastNoJournalPragmas $ \p -> liftIO (SQL.exec con ("PRAGMA " <> p))
+
+      (con,) <$> initializePactDb serial con
+
+    cleanup (db, (_pdb, cache)) = liftIO $ do
+      cache' <- readIORef cache
+      _ <- finalizeUserTable (_stmtUserTbl cache')
+      finalizeStmt (_stmtNamespace cache')
+      finalizeStmt (_stmtKeyset cache')
+      finalizeStmt (_stmtModules cache')
+      finalizeStmt (_stmtDefPact cache')
+      SQL.close db
+
+    finalizeUserTable  = traverse finalizeStmt
+
+finalizeStmt :: TblStatements -> IO ()
+finalizeStmt (TblStatements i u rv rk) = do
+    SQL.finalize i
+    SQL.finalize u
+    SQL.finalize rv
+    SQL.finalize rk
 
 -- | Acquire the sqlite pact db, but do not close the connection
 -- NOTE: This functions is exposed for benchmarking, but should _not_ be used
@@ -58,44 +82,100 @@ unsafeCreateSqlitePactDb
   :: (MonadIO m)
   => PactSerialise b i
   -> Text
-  -> m (PactDb b i, SQL.Database)
-unsafeCreateSqlitePactDb serial connectionString  = do
-  db <- liftIO $ SQL.open connectionString
-  (,db) <$> liftIO (initializePactDb serial db)
+  -> m (PactDb b i, SQL.Database, IORef StmtCache)
+unsafeCreateSqlitePactDb serial connectionString = liftIO $ do
+  con <- SQL.open connectionString
+  (pdb, cache) <- initializePactDb serial con
+  pure (pdb, con, cache)
 
+unsafeCloseSqlitePactDb :: SQL.Database -> IORef StmtCache -> IO ()
+unsafeCloseSqlitePactDb db cache = liftIO $ do
+    cache' <- readIORef cache
+    _ <- traverse finalizeStmt (_stmtUserTbl cache')
+    finalizeStmt (_stmtNamespace cache')
+    finalizeStmt (_stmtKeyset cache')
+    finalizeStmt (_stmtModules cache')
+    finalizeStmt (_stmtDefPact cache')
+    SQL.close db
 
-createSysTables :: SQL.Database -> IO ()
+fastNoJournalPragmas :: [Text]
+fastNoJournalPragmas = [
+  "synchronous = OFF",
+  "journal_mode = MEMORY",
+  "locking_mode = EXCLUSIVE",
+  "temp_store = MEMORY",
+  "page_size = 1024"
+  ]
+
+createSysTables :: SQL.Database -> IO StmtCache
 createSysTables db = do
-  SQL.exec db (cStmt "SYS:KEYSETS")
-  SQL.exec db (cStmt "SYS:MODULES")
-  SQL.exec db (cStmt "SYS:PACTS")
-  SQL.exec db (cStmt "SYS:NAMESPACES")
+  ks <- mkTbl "SYS:KEYSETS"
+  mods <- mkTbl "SYS:MODULES"
+  pacts <- mkTbl "SYS:PACTS"
+  ns <- mkTbl "SYS:NAMESPACES"
+  pure $ StmtCache
+    { _stmtNamespace = ns
+    , _stmtKeyset = ks
+    , _stmtModules = mods
+    , _stmtDefPact = pacts
+    , _stmtUserTbl = Map.empty
+    }
+
   where
+    mkTbl tbl = do
+      SQL.exec db (cStmt tbl)
+      mkTblStatement db tbl
     cStmt tbl = "CREATE TABLE IF NOT EXISTS \"" <> tbl <> "\" \
                 \ (txid UNSIGNED BIG INT, \
                 \  rowkey TEXT, \
                 \  rowdata BLOB, \
                 \  UNIQUE (txid, rowkey))"
 
+data TblStatements
+  = TblStatements
+  { _tblInsert :: SQL.Statement
+  , _tblInsertOrUpdate :: SQL.Statement
+  , _tblReadValue :: SQL.Statement
+  , _tblReadKeys :: SQL.Statement
+  }
+
+mkTblStatement :: SQL.Database -> Text -> IO TblStatements
+mkTblStatement db tbl = do
+      insertStmt <- SQL.prepare db ("INSERT INTO \"" <> tbl <> "\" (txid, rowkey, rowdata) VALUES (?,?,?)")
+      insertOrUpdateStmt <- SQL.prepare db ("INSERT OR REPLACE INTO \"" <> tbl <> "\" (txid, rowkey, rowdata) VALUES (?,?,?)")
+      readValueStmt <- SQL.prepare db ("SELECT rowdata FROM \""<> tbl <> "\" WHERE rowkey = ? ORDER BY txid DESC LIMIT 1")
+      readKeysStmt <-  SQL.prepare db ("SELECT rowkey FROM \""<> tbl <> "\" ORDER BY txid DESC")
+      pure $ TblStatements insertStmt insertOrUpdateStmt readValueStmt readKeysStmt
+
+
+data StmtCache
+  = StmtCache
+  { _stmtNamespace :: TblStatements
+  , _stmtKeyset    :: TblStatements
+  , _stmtModules   :: TblStatements
+  , _stmtDefPact   :: TblStatements
+  , _stmtUserTbl   :: Map.Map TableName TblStatements
+  }
+
 -- | Create all tables that should exist in a fresh pact db,
 --   or ensure that they are already created.
-initializePactDb :: PactSerialise b i -> SQL.Database  -> IO (PactDb b i)
+initializePactDb :: PactSerialise b i -> SQL.Database  -> IO (PactDb b i, IORef StmtCache)
 initializePactDb serial db = do
-  createSysTables db
+  stmtsCache <- newIORef =<< createSysTables db
   txId <- newIORef (TxId 0)
   txLog <- newIORef []
-  pure $ PactDb
+  pure (PactDb
     { _pdbPurity = PImpure
-    , _pdbRead = read' serial db
-    , _pdbWrite = write' serial db txId txLog
-    , _pdbKeys = readKeys db
-    , _pdbCreateUserTable = \tn -> createUserTable serial db txLog tn
+    , _pdbRead = read' serial db stmtsCache
+    , _pdbWrite = write' serial db txId txLog stmtsCache
+    , _pdbKeys = readKeys db stmtsCache
+    , _pdbCreateUserTable = createUserTable serial db txLog stmtsCache
     , _pdbBeginTx = beginTx txId db txLog
     , _pdbCommitTx = commitTx txId db txLog
     , _pdbRollbackTx = rollbackTx db txLog
     , _pdbTxIds = listTxIds db
     , _pdbGetTxLog = getTxLog serial db txId txLog
-    }
+    }, stmtsCache)
 
 getTxLog :: PactSerialise b i -> SQL.Database -> IORef TxId -> IORef [TxLog ByteString] -> TableName -> TxId -> IO [TxLog RowData]
 getTxLog serial db currTxId txLog tab txId = do
@@ -109,48 +189,60 @@ getTxLog serial db currTxId txLog tab txId = do
     case env of
       Nothing -> fail "undexpected decoding error"
       Just xs -> pure xs
-    else withStmt db ("SELECT rowkey,rowdata FROM \"" <> toUserTable tab <> "\" WHERE txid = ?") $ \stmt -> do
-                         let TxId i = txId
-                         SQL.bind stmt [SQL.SQLInteger $ fromIntegral i]
-                         txLogBS <- collect stmt []
-                         case traverse (traverse (fmap (view document) . _decodeRowData serial)) txLogBS of
-                           Nothing -> fail "unexpected decoding error"
-                           Just txl -> pure txl
-  where
+    else withStmtClear (SQL.prepare db $ "SELECT rowkey,rowdata FROM \"" <> toUserTable tab <> "\" WHERE txid = ?") $ \stmt -> do
+       let TxId i = txId
+       SQL.clearBindings stmt
+       SQL.bind stmt [SQL.SQLInteger $ fromIntegral i]
+       txLogBS <- collect stmt []
+       case traverse (traverse (fmap (view document) . _decodeRowData serial)) txLogBS of
+         Nothing -> fail "unexpected decoding error"
+         Just txl -> pure txl
+   where
     collect stmt acc = SQL.step stmt >>= \case
-        SQL.Done -> pure acc
+        SQL.Done -> SQL.reset stmt >> pure acc
         SQL.Row -> do
           [SQL.SQLText key, SQL.SQLBlob value] <- SQL.columns stmt
           collect stmt (TxLog (toUserTable tab) key value:acc)
 
-readKeys :: forall k v b i. SQL.Database -> Domain k v b i -> IO [k]
-readKeys db = \case
-  DKeySets -> withStmt db "SELECT rowkey FROM \"SYS:KEYSETS\" ORDER BY txid DESC" $ \stmt -> do
+readKeys :: forall k v b i. SQL.Database -> IORef StmtCache -> Domain k v b i -> IO [k]
+readKeys _db stmtCache = \case
+  DKeySets -> withStmt (_tblReadKeys . _stmtKeyset <$> readIORef stmtCache) $ \stmt -> do
     parsedKS <- fmap parseAnyKeysetName <$> collect stmt []
     case sequence parsedKS of
       Left _ -> fail "unexpected decoding"
       Right v -> pure v
-  DModules -> withStmt db "SELECT rowkey FROM \"SYS:MODULES\" ORDER BY txid DESC" $ \stmt -> fmap parseModuleName <$> collect stmt [] >>= \mns -> case sequence mns of
-    Nothing -> fail "unexpected decoding"
-    Just mns' -> pure mns'
-  DDefPacts -> withStmt db "SELECT rowkey FROM \"SYS:PACTS\" ORDER BY txid DESC" $ \stmt -> fmap DefPactId <$> collect stmt []
-  DNamespaces -> withStmt db "SELECT rowkey FROM \"SYS:NAMESPACES\" ORDER BY txid DESC" $ \stmt -> fmap NamespaceName <$> collect stmt []
-  DUserTables tbl -> withStmt db ("SELECT rowkey FROM \"" <> toUserTable tbl <> "\" ORDER BY txid DESC") $ \stmt -> fmap RowKey <$> collect stmt []
+
+  DModules -> withStmt (_tblReadKeys . _stmtModules <$> readIORef stmtCache) $ \stmt ->
+     fmap parseModuleName <$> collect stmt [] >>= \mns -> case sequence mns of
+      Nothing -> fail "unexpected decoding"
+      Just mns' -> pure mns'
+
+  DDefPacts -> withStmt (_tblReadKeys . _stmtDefPact <$> readIORef stmtCache) $ \stmt ->
+     fmap DefPactId <$> collect stmt []
+
+  DNamespaces -> withStmt (_tblReadKeys . _stmtNamespace <$> readIORef stmtCache) $ \stmt ->
+     fmap NamespaceName <$> collect stmt []
+
+
+  DUserTables tbl -> do
+     tblCache <- _stmtUserTbl <$> readIORef stmtCache
+     case Map.lookup tbl tblCache of
+       Nothing -> fail "invariant failure: table unknown"
+       Just stmt -> withStmt (pure $ _tblReadKeys stmt) $ \s -> fmap RowKey <$> collect s []
   where
     collect stmt acc = SQL.step stmt >>= \case
-        SQL.Done -> pure acc
-        SQL.Row -> do
+       SQL.Done -> SQL.reset stmt >> pure acc
+       SQL.Row -> do
           [SQL.SQLText value] <- SQL.columns stmt
           collect stmt (value:acc)
 
-
 listTxIds :: SQL.Database -> TableName -> TxId -> IO [TxId]
-listTxIds db tbl (TxId minTxId) = withStmt db ("SELECT txid FROM \"" <> toUserTable tbl <> "\" WHERE txid >= ? ORDER BY txid ASC") $ \stmt -> do
-  SQL.bind stmt [SQL.SQLInteger $ fromIntegral minTxId]
-  collect stmt []
+listTxIds db tbl (TxId minTxId) = withStmtClear (SQL.prepare db $ "SELECT txid FROM \"" <> toUserTable tbl <> "\" WHERE txid >= ? ORDER BY txid ASC") $ \stmt -> do
+    SQL.bind stmt [SQL.SQLInteger $ fromIntegral minTxId]
+    collect stmt []
   where
     collect stmt acc = SQL.step stmt >>= \case
-        SQL.Done -> pure acc
+        SQL.Done -> SQL.reset stmt >>pure acc
         SQL.Row -> do
           [SQL.SQLInteger value] <- SQL.columns stmt
           -- Here we convert the Int64 received from SQLite into Word64
@@ -177,8 +269,14 @@ rollbackTx db txLog = do
   SQL.exec db "ROLLBACK TRANSACTION"
   writeIORef txLog []
 
-createUserTable :: PactSerialise b i -> SQL.Database -> IORef [TxLog ByteString] -> TableName -> GasM (PactError i) b ()
-createUserTable serial db txLog tbl = do
+createUserTable
+  :: PactSerialise b i
+  -> SQL.Database
+  -> IORef [TxLog ByteString]
+  -> IORef StmtCache
+  -> TableName
+  -> GasM (PactError i) b ()
+createUserTable serial db txLog stmtCache tbl = do
   let
     rd = RowData $ Map.singleton (Field "utModule")
          (PObject $ Map.fromList
@@ -186,16 +284,24 @@ createUserTable serial db txLog tbl = do
           , (Field "name", PString (_tableName tbl))
           ])
   rdEnc <- _encodeRowData serial rd
-  liftIO $ SQL.exec db stmt
-  liftIO $ modifyIORef' txLog (TxLog "SYS:usertables" (_tableName tbl) rdEnc :)
-
+  liftIO $ do
+    SQL.exec db stmt
+    modifyIORef' txLog (TxLog "SYS:usertables" (_tableName tbl) rdEnc :)
+    stmts <- mkTblStatement db tblName
+    cache <- readIORef stmtCache
+    let insert = modifyIORef' stmtCache (\c -> c{_stmtUserTbl = Map.insert tbl stmts (_stmtUserTbl c)})
+    case Map.lookup tbl (_stmtUserTbl cache) of
+      Nothing -> insert
+      Just old -> do
+        finalizeStmt old
+        insert
   where
-    stmt = "CREATE TABLE IF NOT EXISTS " <> tblName <> " \
+    stmt = "CREATE TABLE IF NOT EXISTS \"" <> tblName <> "\" \
            \ (txid UNSIGNED BIG INT, \
            \  rowkey TEXT, \
            \  rowdata BLOB, \
            \  UNIQUE (txid, rowkey))"
-    tblName = "\"" <> toUserTable tbl <> "\""
+    tblName = toUserTable tbl
 
 write'
   :: forall k v b i
@@ -203,22 +309,26 @@ write'
   -> SQL.Database
   -> IORef TxId
   -> IORef [TxLog ByteString]
+  -> IORef StmtCache
   -> WriteType
   -> Domain k v b i
   -> k
   -> v
   -> GasM (PactError i) b ()
-write' serial db txId txLog wt domain k v = do
+write' serial db txId txLog stmtCache wt domain k v =
   case domain of
     DUserTables tbl -> liftIO (checkInsertOk tbl k) >>= \case
       Nothing -> do
         encoded <- _encodeRowData serial v
-        liftIO $ withStmt db ("INSERT INTO \"" <> toUserTable tbl <> "\" (txid, rowkey, rowdata) VALUES (?,?,?)") $ \stmt -> do
-          let
-            RowKey k' = k
-          TxId i <- readIORef txId
-          SQL.bind stmt [SQL.SQLInteger (fromIntegral i), SQL.SQLText k', SQL.SQLBlob encoded]
-          doWrite stmt (TxLog (_tableName tbl) k' encoded:)
+        liftIO $ do
+          tblCache <-_stmtUserTbl <$> readIORef stmtCache
+          case Map.lookup tbl tblCache of
+            Nothing -> fail "invariant failure: table unknown"
+            Just tblStmts -> withStmt (pure $ _tblInsert tblStmts) $ \stmt -> do
+              let RowKey k' = k
+              TxId i <- readIORef txId
+              SQL.bind stmt [SQL.SQLInteger (fromIntegral i), SQL.SQLText k', SQL.SQLBlob encoded]
+              doWrite stmt (TxLog (_tableName tbl) k' encoded:)
 
       Just old -> do
         let
@@ -226,44 +336,47 @@ write' serial db txId txLog wt domain k v = do
           RowData v' = v
           new = RowData (Map.union v' old')
         encoded <- _encodeRowData serial new
-        liftIO $ withStmt db ("INSERT OR REPLACE INTO \"" <> toUserTable tbl <> "\" (txid, rowkey, rowdata) VALUES (?,?,?)") $ \stmt -> do
-          let
-            RowKey k' = k
-          TxId i <- readIORef txId
-          SQL.bind stmt [SQL.SQLInteger (fromIntegral i), SQL.SQLText k', SQL.SQLBlob encoded]
-          doWrite stmt (TxLog (_tableName tbl) k' encoded:)
+        liftIO $ do
+          tblCache <-_stmtUserTbl <$> readIORef stmtCache
+          case Map.lookup tbl tblCache of
+            Nothing -> fail "invariant failure: table unknown"
+            Just tblStmts -> withStmt (pure $ _tblInsertOrUpdate tblStmts) $ \stmt -> do
+              let RowKey k' = k
+              TxId i <- readIORef txId
+              SQL.bind stmt [SQL.SQLInteger (fromIntegral i), SQL.SQLText k', SQL.SQLBlob encoded]
+              doWrite stmt (TxLog (_tableName tbl) k' encoded:)
 
-    DKeySets -> liftIO $ withStmt db "INSERT OR REPLACE INTO \"SYS:KEYSETS\" (txid, rowkey, rowdata) VALUES (?,?,?)" $ \stmt -> do
+    DKeySets -> liftIO $ withStmt (_tblInsertOrUpdate . _stmtKeyset <$> readIORef stmtCache) $ \stmt -> do
       let encoded = _encodeKeySet serial v
       TxId i <- readIORef txId
+      SQL.clearBindings stmt
       SQL.bind stmt [SQL.SQLInteger (fromIntegral i), SQL.SQLText (renderKeySetName k), SQL.SQLBlob encoded]
       doWrite stmt (TxLog "SYS:KEYSETS" (renderKeySetName k) encoded:)
 
-    DModules -> liftIO $ withStmt db "INSERT OR REPLACE INTO \"SYS:MODULES\" (txid, rowkey, rowdata) VALUES (?,?,?)" $ \stmt -> do
+    DModules -> liftIO $ withStmt (_tblInsertOrUpdate . _stmtModules <$> readIORef stmtCache) $ \stmt -> do
       let encoded = _encodeModuleData serial v
       TxId i <- readIORef txId
       SQL.bind stmt [SQL.SQLInteger (fromIntegral i), SQL.SQLText (renderModuleName k), SQL.SQLBlob encoded]
       doWrite stmt (TxLog "SYS:MODULES" (renderModuleName k) encoded:)
 
-    DDefPacts -> liftIO $ withStmt db "INSERT OR REPLACE INTO \"SYS:PACTS\" (txid, rowkey, rowdata) VALUES (?,?,?)" $ \stmt -> do
-      let
-        encoded = _encodeDefPactExec serial v
-        DefPactId k' = k
-      TxId i <- readIORef txId
-      SQL.bind stmt [SQL.SQLInteger (fromIntegral i), SQL.SQLText k', SQL.SQLBlob encoded]
-      doWrite stmt (TxLog "SYS:PACTS" k' encoded:)
+    DDefPacts -> liftIO $ withStmt (_tblInsertOrUpdate . _stmtDefPact <$> readIORef stmtCache) $ \stmt -> do
+       let encoded = _encodeDefPactExec serial v
+           DefPactId k' = k
+       TxId i <- readIORef txId
+       SQL.bind stmt [SQL.SQLInteger (fromIntegral i), SQL.SQLText k', SQL.SQLBlob encoded]
+       doWrite stmt (TxLog "SYS:PACTS" k' encoded:)
 
-    DNamespaces -> liftIO $ withStmt db "INSERT OR REPLACE INTO \"SYS:NAMESPACES\" (txid, rowkey, rowdata) VALUES (?,?,?)" $ \stmt -> do
-      let
-        encoded = _encodeNamespace serial v
-        NamespaceName k' = k
+    DNamespaces ->
+      liftIO $ withStmt (_tblInsertOrUpdate . _stmtNamespace <$> readIORef stmtCache) $ \stmt -> do
+      let encoded = _encodeNamespace serial v
+          NamespaceName k' = k
       TxId i <- readIORef txId
       SQL.bind stmt [SQL.SQLInteger (fromIntegral i), SQL.SQLText k', SQL.SQLBlob encoded]
       doWrite stmt  (TxLog "SYS:NAMESPACES" k' encoded:)
   where
     checkInsertOk ::  TableName -> RowKey -> IO (Maybe RowData)
     checkInsertOk tbl rk = do
-      curr <- read' serial db (DUserTables tbl) rk
+      curr <- read' serial db stmtCache (DUserTables tbl) rk
       case (curr, wt) of
         (Nothing, Insert) -> return Nothing
         (Just _, Insert) -> throwIO (E.RowFoundException tbl rk)
@@ -273,43 +386,52 @@ write' serial db txId txLog wt domain k v = do
         (Nothing, Update) -> throwIO (E.NoRowFound tbl rk)
 
     doWrite stmt txlog = Direct.stepNoCB stmt >>= \case
-          Left _ -> throwIO E.WriteException
+          Left _ ->  throwIO E.WriteException
           Right res
-            | res == SQL.Done -> modifyIORef' txLog txlog
+            | res == SQL.Done -> do
+                SQL.reset stmt
+                modifyIORef' txLog txlog
             | otherwise -> throwIO E.MultipleRowsReturnedFromSingleWrite
 
-read' :: forall k v b i. PactSerialise b i -> SQL.Database -> Domain k v b i -> k -> IO (Maybe v)
-read' serial db domain k = case domain of
-  DKeySets -> withStmt db (selStmt "SYS:KEYSETS")
-    (doRead (renderKeySetName k) (\v -> pure (view document <$> _decodeKeySet serial v)))
+read' :: forall k v b i. PactSerialise b i -> SQL.Database -> IORef StmtCache -> Domain k v b i -> k -> IO (Maybe v)
+read' serial _db stmtCache domain k = case domain of
+  DKeySets -> withStmt (_tblReadValue . _stmtKeyset <$> readIORef stmtCache) $
+    doRead (renderKeySetName k) (\v -> pure (view document <$> _decodeKeySet serial v))
 
-  DModules -> withStmt db (selStmt "SYS:MODULES")
-    (doRead (renderModuleName k) (\v -> pure (view document <$> _decodeModuleData serial v)))
+  DModules -> withStmt (_tblReadValue . _stmtModules <$> readIORef stmtCache) $
+    doRead (renderModuleName k) (\v -> pure (view document <$> _decodeModuleData serial v))
 
-  DUserTables tbl ->  withStmt db (selStmt $ toUserTable tbl)
-    (doRead (_rowKey k) (\v -> pure (view document <$> _decodeRowData serial v)))
+  DUserTables tbl -> do
+    tblCache <- _stmtUserTbl <$> readIORef stmtCache
+    case Map.lookup tbl tblCache of
+      Nothing -> fail "invariant failure: table unknown"
+      Just stmt -> withStmt (pure $ _tblReadValue stmt) $ doRead (_rowKey k) (\v -> pure (view document <$> _decodeRowData serial v))
 
-  DDefPacts -> withStmt db (selStmt "SYS:PACTS")
-    (doRead (renderDefPactId k) (\v -> pure (view document <$> _decodeDefPactExec serial v)))
+  DDefPacts -> do
+    withStmt (_tblReadValue . _stmtDefPact <$> readIORef stmtCache) $
+      doRead (renderDefPactId k) (\v -> pure (view document <$> _decodeDefPactExec serial v))
 
-  DNamespaces -> withStmt db (selStmt "SYS:NAMESPACES")
+  DNamespaces ->
+    withStmt (_tblReadValue . _stmtNamespace <$> readIORef stmtCache)
     (doRead (_namespaceName k) (\v -> pure (view document <$> _decodeNamespace serial v)))
 
   where
-    selStmt tbl = "SELECT rowdata FROM \""<> tbl <> "\" WHERE rowkey = ? ORDER BY txid DESC LIMIT 1"
+    doRead :: forall a. Text -> (ByteString -> IO (Maybe a)) -> SQL.Statement -> IO (Maybe a)
     doRead k' f stmt = do
-      SQL.bind stmt [SQL.SQLText k']
-      SQL.step stmt >>= \case
-        SQL.Done -> pure Nothing
-        SQL.Row -> do
-          1 <- SQL.columnCount stmt
-          [SQL.SQLBlob value] <- SQL.columns stmt
-          SQL.Done <- SQL.step stmt
-          f value
+       SQL.bind stmt [SQL.SQLText k']
+       SQL.step stmt >>= \case
+         SQL.Done -> do
+           SQL.reset stmt
+           pure Nothing
+         SQL.Row -> do
+           [SQL.SQLBlob value] <- SQL.columns stmt
+           SQL.Done <- SQL.step stmt
+           SQL.reset stmt
+           f value
 
+-- -- Utility functions
+withStmt :: IO SQL.Statement -> (SQL.Statement -> IO a) -> IO a
+withStmt stmt = bracket stmt SQL.clearBindings
 
--- Utility functions
-withStmt :: SQL.Database -> Text -> (SQL.Statement -> IO a) -> IO a
-withStmt conn sql = bracket (SQL.prepare conn sql) SQL.finalize
-
-
+withStmtClear :: IO SQL.Statement -> (SQL.Statement -> IO a) -> IO a
+withStmtClear stmt = bracket stmt SQL.finalize

--- a/pact/Pact/Core/Persistence/Types.hs
+++ b/pact/Pact/Core/Persistence/Types.hs
@@ -32,6 +32,7 @@ module Pact.Core.Persistence.Types
  , toUserTable
  , objectDataToRowData
  , rowDataToObjectData
+ , renderDomain
  ) where
 
 import Control.Applicative((<|>))
@@ -238,3 +239,11 @@ instance Default (Loaded b i) where
 --   to avoid conflicts with any system tables).
 toUserTable :: TableName -> Text
 toUserTable (TableName tbl mn) = "USER_" <> renderModuleName mn <> "_" <> tbl
+
+renderDomain :: Domain k v b i -> Text
+renderDomain = \case
+  DUserTables tbl -> toUserTable tbl
+  DKeySets -> "SYS:KeySets"
+  DModules -> "SYS:Modules"
+  DNamespaces -> "SYS:Namespaces"
+  DDefPacts -> "SYS:Pacts"

--- a/pact/Pact/Core/Persistence/Utils.hs
+++ b/pact/Pact/Core/Persistence/Utils.hs
@@ -1,6 +1,7 @@
 module Pact.Core.Persistence.Utils where
 
-import Control.Exception(throwIO)
+import Control.Lens
+import Control.Exception.Safe
 import Control.Monad
 import Control.Monad.Reader
 import Control.Monad.Error.Class (throwError)
@@ -22,28 +23,28 @@ import Pact.Core.Persistence.Types
 readModule :: PactDb b i -> ModuleName -> IO (Maybe (ModuleData b i))
 readModule pdb = _pdbRead pdb DModules
 
-writeModule :: (MonadEval b i m) => i -> PactDb b i -> WriteType -> ModuleName -> ModuleData b i -> m ()
+writeModule :: i -> PactDb b i -> WriteType -> ModuleName -> ModuleData b i -> EvalM e b i ()
 writeModule info pdb wt mn md = do
   liftGasM info $ _pdbWrite pdb wt DModules mn md
 
 readKeySet :: PactDb b i -> KeySetName -> IO (Maybe KeySet)
 readKeySet pdb = _pdbRead pdb DKeySets
 
-writeKeySet :: (MonadEval b i m) =>  i -> PactDb b i -> WriteType -> KeySetName -> KeySet -> m ()
+writeKeySet :: i -> PactDb b i -> WriteType -> KeySetName -> KeySet -> EvalM e b i ()
 writeKeySet info pdb wt ksn ks = do
   liftGasM info $ _pdbWrite pdb wt DKeySets ksn ks
 
 readDefPacts :: PactDb b i -> DefPactId -> IO (Maybe (Maybe DefPactExec))
 readDefPacts pdb = _pdbRead pdb DDefPacts
 
-writeDefPacts :: (MonadEval b i m) => i -> PactDb b i -> WriteType -> DefPactId -> Maybe DefPactExec -> m ()
+writeDefPacts :: i -> PactDb b i -> WriteType -> DefPactId -> Maybe DefPactExec -> EvalM e b i ()
 writeDefPacts info pdb wt defpactId defpactExec =
   liftGasM info $ _pdbWrite pdb wt DDefPacts defpactId defpactExec
 
 readNamespace :: PactDb b i -> NamespaceName -> IO (Maybe Namespace)
 readNamespace pdb = _pdbRead pdb DNamespaces
 
-writeNamespace :: (MonadEval b i m) => i -> PactDb b i -> WriteType -> NamespaceName -> Namespace -> m ()
+writeNamespace :: i -> PactDb b i -> WriteType -> NamespaceName -> Namespace -> EvalM e b i ()
 writeNamespace info pdb wt namespaceName namespace =
   liftGasM info $ _pdbWrite pdb wt DNamespaces namespaceName namespace
 
@@ -52,14 +53,19 @@ dbOpDisallowed :: MonadIO m => m a
 dbOpDisallowed = liftIO $ throwIO OpDisallowed
 
 -- | A utility function that lifts a `GasM` action into a `MonadEval` action.
-liftGasM :: MonadEval b i m => i -> GasM (PactError i) b a -> m a
+liftGasM :: i -> GasM (PactError i) b a -> EvalM e b i a
 liftGasM info action = do
-  stack <- useEvalState esStack
+  stack <- use esStack
   gasRef <- viewEvalEnv eeGasRef
   let chargeGas = gasMChargeGas' stack info gasRef
   gasModel <- viewEvalEnv eeGasModel
-  either throwError pure =<<
-    liftIO (runGasM stack info (GasMEnv chargeGas gasModel) action)
+  caught <- try $ liftIO (runGasM stack info (GasMEnv chargeGas gasModel) action)
+  case caught of
+    Right e -> either throwError pure e
+    Left err ->
+      throwExecutionError info (DbOpFailure err)
+
+
 
 
 

--- a/pact/Pact/Core/Repl/Compile.hs
+++ b/pact/Pact/Core/Repl/Compile.hs
@@ -146,7 +146,7 @@ interpretEvalDirect =
   evalDirect purity term =
     Direct.eval purity Direct.replBuiltinEnv term
   interpretGuardDirect info g =
-    PBool <$> Direct.interpretGuard info Direct.replBuiltinEnv g
+    Direct.interpretGuard info Direct.replBuiltinEnv g
 
 
 interpretReplProgram

--- a/pact/Pact/Core/Repl/UserDocs.hs
+++ b/pact/Pact/Core/Repl/UserDocs.hs
@@ -1,6 +1,5 @@
 module Pact.Core.Repl.UserDocs where
 
-import Control.Lens
 import qualified Data.Map.Strict as M
 import Pact.Core.Builtin
 import Pact.Core.Repl.Utils
@@ -22,5 +21,5 @@ functionDocs = \case
   where
   addModuleDoc mn d = do
     let qualName = QualifiedName (Lisp.defName d) mn
-    traverse_ (\docs -> replUserDocs  %= M.insert qualName docs) (Lisp.defDocs d)
-    replTLDefPos %= M.insert qualName (Lisp.defInfo d)
+    traverse_ (\docs -> replUserDocs %== M.insert qualName docs) (Lisp.defDocs d)
+    replTLDefPos %== M.insert qualName (Lisp.defInfo d)

--- a/pact/Pact/Core/Serialise/LegacyPact.hs
+++ b/pact/Pact/Core/Serialise/LegacyPact.hs
@@ -80,7 +80,9 @@ runTranslateM a = runExcept (evalStateT (runReaderT a 0) [])
 decodeModuleData :: ByteString -> Maybe (ModuleData CoreBuiltin ())
 decodeModuleData bs = do
   obj <- JD.decodeStrict' bs
-  either (const Nothing) Just (runTranslateM (fromLegacyModuleData obj))
+  case runTranslateM (fromLegacyModuleData obj) of
+    Left _ -> Nothing
+    Right v -> Just v
 
 fromLegacyModuleData
   :: Legacy.ModuleData (Legacy.Ref' Legacy.PersistDirect)

--- a/pact/Pact/Core/Syntax/ParseTree.hs
+++ b/pact/Pact/Core/Syntax/ParseTree.hs
@@ -12,6 +12,7 @@ import Data.Foldable(fold)
 import Data.Text(Text)
 import Data.List.NonEmpty(NonEmpty(..))
 import Data.List(intersperse)
+import GHC.Generics
 
 import qualified Data.List.NonEmpty as NE
 
@@ -20,6 +21,7 @@ import Pact.Core.Names
 import Pact.Core.Pretty
 import Pact.Core.Type(PrimType(..))
 import Pact.Core.Guards
+import Control.DeepSeq
 
 
 data Operator
@@ -27,7 +29,9 @@ data Operator
   | OrOp
   | EnforceOp
   | EnforceOneOp
-  deriving (Show, Eq, Enum, Bounded)
+  deriving (Show, Eq, Enum, Bounded, Generic)
+
+instance NFData Operator
 
 renderOp :: Operator -> Text
 renderOp = \case
@@ -55,7 +59,9 @@ data Type
   | TyTable ParsedTyName
   | TyPolyObject
   | TyAny
-  deriving (Show, Eq)
+  deriving (Show, Eq, Generic)
+
+instance NFData Type
 
 pattern TyInt :: Type
 pattern TyInt = TyPrim PrimInt
@@ -100,14 +106,16 @@ data Arg i
   { _argName :: Text
   , _argType :: Type
   , _argInfo :: i
-  } deriving (Show, Functor)
+  } deriving (Show, Functor, Generic)
 
 data MArg i
   = MArg
   { _margName :: Text
   , _margType :: Maybe Type
   , _margInfo :: i
-  } deriving (Eq, Show, Functor)
+  } deriving (Eq, Show, Functor, Generic)
+
+instance NFData i => NFData (MArg i)
 
 defName :: Def i -> Text
 defName = \case
@@ -146,7 +154,7 @@ data Defun i
   , _dfunDocs :: Maybe Text
   , _dfunModel :: [PropertyExpr i]
   , _dfunInfo :: i
-  } deriving (Show, Functor)
+  } deriving (Show, Functor, Generic)
 
 data DefConst i
   = DefConst
@@ -155,7 +163,7 @@ data DefConst i
   , _dcTerm :: Expr i
   , _dcDocs :: Maybe Text
   , _dcInfo :: i
-  } deriving (Show, Functor)
+  } deriving (Show, Functor, Generic)
 
 data DCapMeta
   = DefEvent
@@ -172,7 +180,7 @@ data DefCap i
   , _dcapModel :: [PropertyExpr i]
   , _dcapMeta :: Maybe DCapMeta
   , _dcapInfo :: i
-  } deriving (Show, Functor)
+  } deriving (Show, Functor, Generic)
 
 data DefSchema i
   = DefSchema
@@ -181,7 +189,7 @@ data DefSchema i
   , _dscDocs :: Maybe Text
   , _dscModel :: [PropertyExpr i]
   , _dscInfo :: i
-  } deriving (Show, Functor)
+  } deriving (Show, Functor, Generic)
 
 data DefTable i
   = DefTable
@@ -189,12 +197,12 @@ data DefTable i
   , _dtSchema :: ParsedName
   , _dtDocs :: Maybe Text
   , _dtInfo :: i
-  } deriving (Show, Functor)
+  } deriving (Show, Functor, Generic)
 
 data PactStep i
   = Step (Expr i) [PropertyExpr i]
   | StepWithRollback (Expr i) (Expr i) [PropertyExpr i]
-  deriving (Show, Functor)
+  deriving (Show, Functor, Generic)
 
 data DefPact i
   = DefPact
@@ -205,7 +213,7 @@ data DefPact i
   , _dpDocs :: Maybe Text
   , _dpModel :: [PropertyExpr i]
   , _dpInfo :: i
-  } deriving (Show, Functor)
+  } deriving (Show, Functor, Generic)
 
 data Managed
   = AutoManaged
@@ -219,7 +227,7 @@ data Def i
   | DSchema (DefSchema i)
   | DTable (DefTable i)
   | DPact (DefPact i)
-  deriving (Show, Functor)
+  deriving (Show, Functor, Generic)
 
 data Import
   = Import
@@ -243,14 +251,14 @@ data Module i
   , _mDoc :: Maybe Text
   , _mModel :: [PropertyExpr i]
   , _mInfo :: i
-  } deriving (Show, Functor)
+  } deriving (Show, Functor, Generic)
 
 data TopLevel i
   = TLModule (Module i)
   | TLInterface (Interface i)
   | TLTerm (Expr i)
   | TLUse Import i
-  deriving (Show, Functor)
+  deriving (Show, Functor, Generic)
 
 data Interface i
   = Interface
@@ -260,7 +268,7 @@ data Interface i
   , _ifDocs :: Maybe Text
   , _ifModel :: [PropertyExpr i]
   , _ifInfo :: i
-  } deriving (Show, Functor)
+  } deriving (Show, Functor, Generic)
 
 data IfDefun i
   = IfDefun
@@ -270,7 +278,7 @@ data IfDefun i
   , _ifdDocs :: Maybe Text
   , _ifdModel :: [PropertyExpr i]
   , _ifdInfo :: i
-  } deriving (Show, Functor)
+  } deriving (Show, Functor, Generic)
 
 data IfDefCap i
   = IfDefCap
@@ -281,7 +289,7 @@ data IfDefCap i
   , _ifdcModel :: [PropertyExpr i]
   , _ifdcMeta :: Maybe DCapMeta
   , _ifdcInfo :: i
-  } deriving (Show, Functor)
+  } deriving (Show, Functor, Generic)
 
 data IfDefPact i
   = IfDefPact
@@ -291,7 +299,7 @@ data IfDefPact i
   , _ifdpDocs :: Maybe Text
   , _ifdpModel :: [PropertyExpr i]
   , _ifdpInfo :: i
-  } deriving (Show, Functor)
+  } deriving (Show, Functor, Generic)
 
 data PropKeyword
   = KwLet
@@ -325,7 +333,7 @@ data PropertyExpr i
   | PropDelim PropDelim i
   | PropSequence [PropertyExpr i] i
   | PropConstant Literal i
-  deriving (Show, Functor)
+  deriving (Show, Functor, Generic)
 
 
 -- Interface definitions may be one of:
@@ -340,7 +348,7 @@ data IfDef i
   | IfDCap (IfDefCap i)
   | IfDSchema (DefSchema i)
   | IfDPact (IfDefPact i)
-  deriving (Show, Functor)
+  deriving (Show, Functor, Generic)
 
 instance Pretty (DefConst i) where
   pretty (DefConst (MArg dcn dcty _) term _ _) =
@@ -363,7 +371,9 @@ instance Pretty (Defun i) where
 
 data Binder i =
   Binder Text (Maybe Type) (Expr i)
-  deriving (Show, Eq, Functor)
+  deriving (Show, Eq, Functor, Generic)
+
+instance NFData i => NFData (Binder i)
 
 instance Pretty (Binder i) where
   pretty (Binder ident ty e) =
@@ -372,7 +382,9 @@ instance Pretty (Binder i) where
 data CapForm i
   = WithCapability (Expr i) (Expr i)
   | CreateUserGuard ParsedName [Expr i]
-  deriving (Show, Eq, Functor)
+  deriving (Show, Eq, Functor, Generic)
+
+instance NFData i => NFData (CapForm i)
 
 data Expr i
   = Var ParsedName i
@@ -389,7 +401,9 @@ data Expr i
   | Object [(Field, Expr i)] i
   | Binding [(Field, MArg i)] [Expr i] i
   | CapabilityForm (CapForm i) i
-  deriving (Show, Eq, Functor)
+  deriving (Show, Eq, Functor, Generic)
+
+instance (NFData i) => NFData (Expr i)
 
 data ReplSpecialForm i
   = ReplLoad Text Bool i

--- a/profile-tx/ProfileTx.hs
+++ b/profile-tx/ProfileTx.hs
@@ -1,0 +1,302 @@
+
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
+module Main where
+
+import Control.Lens
+import Control.Monad
+import Control.Exception
+import Data.Text(Text)
+import Data.Default
+import System.FilePath
+import NeatInterpolation (text)
+import Control.Monad.Except
+import Data.IORef
+import Data.Map.Strict(Map)
+import Data.Set(Set)
+import System.ProgressBar
+import qualified Data.Map.Strict as M
+import qualified Data.Set as S
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+
+import Pact.Core.Environment
+import Pact.Core.Names
+import Pact.Core.Capabilities
+import Pact.Core.PactValue
+import Pact.Core.Guards
+import Pact.Core.IR.Desugar
+import Pact.Core.Compile
+import Pact.Core.Evaluate
+import Pact.Core.Hash
+import Pact.Core.Persistence
+import Pact.Core.Builtin
+import Pact.Core.SPV
+import qualified Pact.Core.Syntax.Parser as Lisp
+import qualified Pact.Core.Syntax.Lexer as Lisp
+import qualified Pact.Core.Syntax.LexUtils as Lisp
+import qualified Pact.Core.IR.Eval.CEK as CEK
+import qualified Pact.Core.IR.Eval.CoreBuiltin as CEK
+import qualified Pact.Core.IR.Eval.Direct.Evaluator as Direct
+import Pact.Core.Gas.TableGasModel
+import Pact.Core.Gas
+import Pact.Core.Namespace
+import Pact.Core.IR.Term
+import Pact.Core.Serialise
+import Pact.Core.Persistence.MockPersistence
+
+import Pact.Core.Info
+import Pact.Core.Errors
+import Pact.Core.Interpreter
+import Pact.Core.Persistence.SQLite
+import Data.Decimal
+import Pact.Core.Pretty
+import Pact.Core.Literal
+import qualified Data.Text.Encoding as T
+
+parseOnlyExpr :: Text -> Either PactErrorI Lisp.ParsedExpr
+parseOnlyExpr =
+  Lisp.lexer >=> Lisp.parseExpr
+
+contractsPath :: FilePath
+contractsPath = "gasmodel" </> "contracts"
+
+-- | Create a single-key keyset
+mkKs :: PublicKeyText -> PactValue
+mkKs a = PGuard $ GKeyset $ KeySet (S.singleton a) KeysAll
+
+interpretBigStep :: Interpreter ExecRuntime CoreBuiltin SpanInfo
+interpretBigStep =
+  Interpreter runGuard runTerm
+  where
+  runTerm purity term = CEK.eval purity eEnv term
+  runGuard info g = CEK.interpretGuard info eEnv g
+  eEnv = CEK.coreBuiltinEnv @ExecRuntime @CEK.CEKBigStep
+
+
+interpretDirect :: Interpreter ExecRuntime CoreBuiltin SpanInfo
+interpretDirect =
+  Interpreter runGuard runTerm
+  where
+  runTerm purity term = Direct.eval purity eEnv term
+  runGuard info g = Direct.interpretGuard info eEnv g
+  eEnv = Direct.coreBuiltinEnv
+
+
+data CoinBenchSenders
+  = CoinBenchSenderA
+  | CoinBenchSenderB
+  | CoinBenchSenderC
+  | CoinBenchSenderD
+  deriving Show
+
+getSender :: CoinBenchSenders -> String
+getSender = drop 9 . show
+
+pubKeyFromSenderRaw :: CoinBenchSenders -> Text
+pubKeyFromSenderRaw = \case
+  CoinBenchSenderA -> senderKeyA
+  CoinBenchSenderB -> senderKeyB
+  CoinBenchSenderC -> senderKeyC
+  CoinBenchSenderD -> senderKeyD
+
+kColonFromSender :: CoinBenchSenders -> Text
+kColonFromSender = ("k:" <>) . pubKeyFromSenderRaw
+
+pubKeyFromSender :: CoinBenchSenders -> PublicKeyText
+pubKeyFromSender = PublicKeyText . pubKeyFromSenderRaw
+
+coinTableName :: TableName
+coinTableName = TableName "coin-table" (ModuleName "coin" Nothing)
+
+prePopulateCoinEntries :: Default i => PactDb b i -> IO ()
+prePopulateCoinEntries pdb = do
+  let style = defStyle {stylePrefix = msg "Pre-filling the coin table"}
+  putStrLn "Setting up the coin table"
+  pbar <- newProgressBar style 10 (Progress 0 1_000 ())
+  forM_ [1 :: Integer .. 1_000] $ \i -> do
+    let n = renderCompactText $ pactHash $ T.encodeUtf8 $ T.pack (show i)
+    let obj = M.fromList [(Field "balance", PDecimal 100), (Field "guard", PGuard (GKeyset (KeySet (S.singleton (PublicKeyText n)) KeysAll)))]
+    ignoreGas def $ _pdbWrite pdb Write (DUserTables coinTableName) (RowKey n) (RowData obj)
+    incProgress pbar 1
+
+
+senderKeyA :: Text
+senderKeyA = T.replicate 64 "a"
+senderKeyB :: Text
+senderKeyB = T.replicate 63 "a" <> "b"
+senderKeyC :: Text
+senderKeyC = T.replicate 63 "a" <> "c"
+senderKeyD :: Text
+senderKeyD = T.replicate 63 "a" <> "d"
+
+coinInitData :: PactValue
+coinInitData = PObject $ M.fromList $
+  [ (Field "a", mkKs (pubKeyFromSender CoinBenchSenderA))
+  , (Field "b", mkKs (pubKeyFromSender CoinBenchSenderB))
+  , (Field "c", mkKs (pubKeyFromSender CoinBenchSenderC))
+  , (Field "d", mkKs (pubKeyFromSender CoinBenchSenderD))
+  ]
+
+coinInitSigners :: M.Map PublicKeyText (Set (CapToken QualifiedName PactValue))
+coinInitSigners = M.fromList $ fmap (over _1 PublicKeyText) $
+  [ (senderKeyA, mempty)
+  , (senderKeyB, mempty)
+  , (senderKeyC, mempty)
+  , (senderKeyD, mempty)
+  ]
+
+benchmarkSqliteFile :: String
+benchmarkSqliteFile = "profile-tx.sqlite"
+
+transferCapFromSender :: CoinBenchSenders -> CoinBenchSenders -> Decimal -> CapToken QualifiedName PactValue
+transferCapFromSender sender receiver amount =
+  CapToken (QualifiedName "TRANSFER" (ModuleName "coin" Nothing))
+    [ PString (kColonFromSender sender)
+    , PString (kColonFromSender receiver)
+    , PDecimal amount]
+
+runPactTxFromSource
+  :: EvalEnv CoreBuiltin SpanInfo
+  -> Text
+  -> Interpreter ExecRuntime CoreBuiltin SpanInfo
+  -> IO (Either (PactError SpanInfo) [CompileValue SpanInfo],EvalState CoreBuiltin SpanInfo)
+runPactTxFromSource ee source interpreter = runEvalM (ExecEnv ee) def $ do
+  program <- liftEither $ parseOnlyProgram source
+  traverse (interpretTopLevel interpreter) program
+
+setupBenchEvalEnv
+  :: PactDb CoreBuiltin i
+  -> Map PublicKeyText (Set (CapToken QualifiedName PactValue))
+  -> PactValue -> IO (EvalEnv CoreBuiltin i)
+setupBenchEvalEnv pdb signers mBody = do
+  gasRef <- newIORef mempty
+  pure $ EvalEnv
+    { _eeMsgSigs = signers
+    , _eeMsgVerifiers = mempty
+    , _eePactDb = pdb
+    , _eeMsgBody = mBody
+    , _eeHash = defaultPactHash
+    , _eePublicData = def
+    , _eeDefPactStep = Nothing
+    , _eeMode = Transactional
+    , _eeFlags = S.fromList [FlagEnforceKeyFormats, FlagRequireKeysetNs]
+    , _eeNatives = coreBuiltinMap
+    , _eeNamespacePolicy = SimpleNamespacePolicy
+    , _eeGasRef = gasRef
+    , _eeGasModel = tableGasModel (MilliGasLimit (MilliGas 200_000_000))
+    , _eeSPVSupport = noSPVSupport
+    }
+
+
+setupCoinTxs :: PactDb CoreBuiltin SpanInfo -> IO ()
+setupCoinTxs pdb = do
+  putStrLn "Setting up the coin contract and the default funds"
+  source <- T.readFile (contractsPath </> "coin-v5-create.pact")
+  ee <- setupBenchEvalEnv pdb coinInitSigners coinInitData
+  () <$ runPactTxFromSource ee source evalDirectInterpreter
+
+
+_run :: IO ()
+_run = do
+  pdb <- mockPactDb serialisePact_raw_spaninfo
+  setupCoinTxs pdb >>= print
+
+coinTransferTxRaw :: Text -> Text -> Text
+coinTransferTxRaw sender receiver =
+  [text| (coin.transfer "$sender" "$receiver" 200.0) |]
+
+coinTransferCreateTxRaw :: Text -> Text -> Text -> Text
+coinTransferCreateTxRaw sender receiver receiverKs =
+  [text| (coin.transfer-create "$sender" "$receiver" (read-keyset "$receiverKs") 200.0) |]
+
+factorialNTXRaw :: Int -> Text
+factorialNTXRaw n =
+  [text| (fold (*) 1 (enumerate 1 ${n'})) |]
+  where
+  n' = T.pack (show n)
+
+deepLetTXRaw :: Int -> Text
+deepLetTXRaw n =
+  [text| (let* ($nestedLets) $lastVar) |]
+  where
+  initial = "(x1 1)"
+  nestedLets = T.concat $ initial :
+    [ [text| (x$ncurr (* $ncurr x${nprev})) |] | (prev, curr) <- zip [1..n] [2..n]
+    , let nprev = T.pack (show prev)
+    , let ncurr = T.pack (show curr)]
+  lastVar = "x" <> T.pack (show n)
+
+getRightIO :: Exception e => Either e a -> IO a
+getRightIO = either throwIO pure
+
+resetEEGas :: EvalEnv b i -> IO ()
+resetEEGas ee =
+  writeIORef (_eeGasRef ee) mempty
+
+
+transferSigners :: CoinBenchSenders -> CoinBenchSenders -> Map PublicKeyText (Set (CapToken QualifiedName PactValue))
+transferSigners sender receiver =
+  M.singleton (pubKeyFromSender sender) (S.singleton (transferCapFromSender sender receiver 200.0))
+
+_testCoinTransfer :: IO ()
+_testCoinTransfer = withSqlitePactDb serialisePact_raw_spaninfo (T.pack benchmarkSqliteFile) $ \pdb -> do
+  _ <- _pdbBeginTx pdb Transactional
+  p <- setupCoinTxs pdb
+  print p
+  _ <- _pdbCommitTx pdb *> _pdbBeginTx pdb Transactional
+  ee <- setupBenchEvalEnv pdb (transferSigners CoinBenchSenderA CoinBenchSenderB) (PObject mempty)
+  let termText = coinTransferTxRaw (kColonFromSender CoinBenchSenderA) (kColonFromSender CoinBenchSenderB)
+  print termText
+  -- note, we will return this eval state, as it definitely contains the loaded coin contract here.
+  (eterm, es) <- runEvalM (ExecEnv ee) def $ do
+    t <- liftEither $ parseOnlyExpr termText
+    _dsOut <$> runDesugarTerm t
+  term <- getRightIO eterm
+  (out, _) <- runEvalM (ExecEnv ee) es (eval interpretDirect PImpure term)
+  print out
+
+unsafeModuleHash :: Text -> Hash
+unsafeModuleHash e =
+  let (Just (ModuleHash e')) = parseModuleHash e
+  in e'
+
+withTx :: PactDb b i -> IO a -> IO a
+withTx pdb act = do
+  () <$ _pdbBeginTx pdb Transactional
+  v <- act
+  _ <- _pdbCommitTx pdb
+  pure v
+
+
+runCoinXferDirect :: PactDb CoreBuiltin SpanInfo -> IO ()
+runCoinXferDirect pdb =  do
+  ee <- setupBenchEvalEnv pdb (transferSigners CoinBenchSenderA CoinBenchSenderB) (PObject mempty)
+  (m, es) <- runEvalM (ExecEnv ee) def $ getModule def pdb (ModuleName "coin" Nothing)
+  _ <- getRightIO m
+  let es' = def {_esLoaded=_esLoaded es}
+  forM_ [1 :: Integer .. 1000] $ \_ -> withTx pdb $ do
+    (out, _) <- runEvalM (ExecEnv ee) es' $ eval interpretBigStep PImpure term
+    writeIORef (_eeGasRef ee) mempty
+    either throw print out
+  pure ()
+  where
+  term = App (Var (mkCoinIdent "transfer") def)
+    [ Constant (LString (kColonFromSender CoinBenchSenderA)) def
+    , Constant (LString (kColonFromSender CoinBenchSenderB)) def
+    , Constant (LDecimal 200) def] def
+
+
+mkCoinIdent :: Text -> Name
+mkCoinIdent n = Name n (NTopLevel (ModuleName "coin" Nothing) (ModuleHash {_mhHash = unsafeModuleHash "DFsR46Z3vJzwyd68i0MuxIF0JxZ_OJfIaMyFFgAyI4w"}))
+
+main :: IO ()
+main = withSqlitePactDb serialisePact_raw_spaninfo (T.pack benchmarkSqliteFile) $ \pdb -> do
+  withTx pdb $ setupCoinTxs pdb
+  withTx pdb $ prePopulateCoinEntries pdb
+  runCoinXferDirect pdb


### PR DESCRIPTION
This PR adds pact-5 benchmarks for common contracts like coin, and marmalade.

As a result of the benchmarking, this PR monomorphizes types across the repo for a significant speed improvement, as seen in the following:  
Before single monad: 
```
benchmarking PactBenchmarks/CoinTransfer/EvalOnly(transfer) from SenderA to SenderB using: CEK
time                 293.8 μs   (293.5 μs .. 294.0 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 293.7 μs   (293.6 μs .. 293.9 μs)
std dev              544.2 ns   (457.3 ns .. 674.9 ns)

benchmarking PactBenchmarks/CoinTransfer/EvalOnly(transfer) from SenderA to SenderB using: CEKSpec
time                 92.43 μs   (92.32 μs .. 92.52 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 92.30 μs   (92.24 μs .. 92.38 μs)
std dev              218.7 ns   (172.5 ns .. 268.0 ns)
```
After:
```
benchmarking PactBenchmarks/CoinTransfer/EvalOnly(transfer) from SenderA to SenderB using: CEK
time                 56.43 μs   (56.37 μs .. 56.49 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 56.51 μs   (56.45 μs .. 56.57 μs)
std dev              175.0 ns   (142.5 ns .. 244.3 ns)
```

Checklist:
- [x] Coin contract setup
- [x] Coin DB pre-population
- [x] `coin.transfer` benchmarks: CEK and Direct-style
- [x] Monad monomorphization
- [ ]  `coin.transfer-create` benchmarks.

TODO: Other contract benchmarks.