### PR TITLE
remove compiler warnings

### DIFF
--- a/cbits/musl/endian.h
+++ b/cbits/musl/endian.h
@@ -28,7 +28,7 @@ static __inline uint32_t __bswap32(uint32_t __x)
 
 static __inline uint64_t __bswap64(uint64_t __x)
 {
-	return __bswap32(__x)+0ULL<<32 | __bswap32(__x>>32);
+	return (__bswap32(__x)+0ULL)<<32 | __bswap32(__x>>32);
 }
 
 #if __BYTE_ORDER == __LITTLE_ENDIAN


### PR DESCRIPTION
This Pr removes the annoying compiler warning regarding the `endian.h` file.

PR checklist:

* [ ] Test coverage for the proposed changes
* [ ] PR description contains example output from repl interaction or a snippet from unit test output
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact-core/blob/master/CHANGELOG.md)

Additionally, please justify why you should or should not do the following:

* [ ] Confirm replay/back compat
* [ ] Benchmark regressions
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
