### PR TITLE
Add cabal build via GH actions

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -1,0 +1,66 @@
+name: Build application binaries via cabal
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '**'
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc: ['9.6.6', '9.8.2', '9.10.1']
+        cabal: ['3.12']
+        # 'macos-14' is an M1 runner
+        os: ['ubuntu-20.04', 'ubuntu-22.04', 'macos-14']
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set permissions for .ghcup (ubuntu)
+        if: startsWith(matrix.os, 'ubuntu-')
+        run: sudo chown -R $USER /usr/local/.ghcup
+
+      - name: Install GHC and Cabal
+        uses: haskell-actions/setup@v2
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: ${{ matrix.cabal }}
+
+      - name: Confirm GHC and Cabal installation
+        run: |
+          ghc --version
+          cabal --version
+
+      - name: Update Cabal package database
+        run: cabal update
+
+      - name: Display outdated packages
+        run: cabal outdated
+
+      - name: Configure build
+        run: |
+          cabal build --dry-run
+          cabal freeze
+
+      - name: Sync with Cabal cache
+        uses: larskuhtz/cabal-cache-action@4b537195b33898fcd9adc62cee2a44986fd7b1b6
+        with:
+          bucket: "kadena-cabal-cache"
+          region: "us-east-1"
+          folder: "packages/${{ matrix.os }}"
+          aws_access_key_id: "${{ secrets.kadena_cabal_cache_aws_access_key_id }}"
+          aws_secret_access_key: "${{ secrets.kadena_cabal_cache_aws_secret_access_key }}"
+
+      - name: Build only dependencies
+        run: cabal build --only-dependencies
+
+      - name: Build application
+        run: cabal build
+
+      - name: Run Tests
+        run: cabal run tests


### PR DESCRIPTION
The freshly triggered CI should fail for all builds except `cabal 3.6.6`.


PR checklist:

* [ ] Test coverage for the proposed changes
* [ ] PR description contains example output from repl interaction or a snippet from unit test output
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact-core/blob/master/CHANGELOG.md)

Additionally, please justify why you should or should not do the following:

* [ ] Confirm replay/back compat
* [ ] Benchmark regressions
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
