### PR TITLE
fix pact version for CI

### DIFF
--- a/pact-tng.cabal
+++ b/pact-tng.cabal
@@ -195,7 +195,9 @@ library
     cbits/musl/sqrt_data.c
 
   other-modules:
-    PackageInfo_pact_tng
+    -- TODO: Uncomment once this is finally fixed
+    -- and stops crapping out both LSP and our CI:
+    -- PackageInfo_pact_tng
     Paths_pact_tng
 
   exposed-modules:
@@ -270,6 +272,7 @@ library
     Pact.Core.IR.ConstEval
 
     Pact.Core.Trans.TOps
+    Pact.Core.Version
 
     -- Repl
     Pact.Core.Repl.Utils
@@ -371,7 +374,9 @@ executable pact
 
   -- beware of the autogen modules. Remember to `cabal clean`!
   other-modules:
-    PackageInfo_pact_tng
+    -- TODO: Uncomment once this is finally fixed
+    -- and stops crapping out both LSP and our CI,
+    -- PackageInfo_pact_tng
     Paths_pact_tng
 
 benchmark bench

--- a/pact/Pact/Core/Errors.hs
+++ b/pact/Pact/Core/Errors.hs
@@ -45,7 +45,7 @@ import Data.Set(Set)
 import Data.Word
 import Numeric (showHex)
 import qualified Data.Version as V
-import qualified PackageInfo_pact_tng as PI
+import qualified Pact.Core.Version as PI
 import qualified Data.Set as S
 import qualified Data.Text as T
 import qualified Data.Text.Read as T

--- a/pact/Pact/Core/IR/Eval/Direct/ReplBuiltin.hs
+++ b/pact/Pact/Core/IR/Eval/Direct/ReplBuiltin.hs
@@ -43,7 +43,7 @@ import Pact.Core.Namespace
 import Pact.Core.ModRefs
 import qualified Pact.Core.Legacy.LegacyPactValue as Legacy
 
-import qualified PackageInfo_pact_tng as PI
+import qualified Pact.Core.Version as PI
 import qualified Data.Version as V
 import qualified Data.Attoparsec.Text as A
 

--- a/pact/Pact/Core/Repl/Runtime/ReplBuiltin.hs
+++ b/pact/Pact/Core/Repl/Runtime/ReplBuiltin.hs
@@ -43,7 +43,7 @@ import Pact.Core.Info
 import Pact.Core.Namespace
 import qualified Pact.Core.Legacy.LegacyPactValue as Legacy
 
-import qualified PackageInfo_pact_tng as PI
+import qualified Pact.Core.Version as PI
 import qualified Data.Version as V
 import qualified Data.Attoparsec.Text as A
 

--- a/pact/Pact/Core/Version.hs
+++ b/pact/Pact/Core/Version.hs
@@ -1,5 +1,5 @@
 -- |
--- Module      :  Pact.Core.IR.Typecheck
+-- Module      :  Pact.Core.Version
 -- Copyright   :  (C) 2022 Kadena
 -- License     :  BSD-style (see the file LICENSE)
 -- Maintainer  :  Jose Cardona <jose@kadena.io>

--- a/pact/Pact/Core/Version.hs
+++ b/pact/Pact/Core/Version.hs
@@ -1,0 +1,32 @@
+-- |
+-- Module      :  Pact.Core.IR.Typecheck
+-- Copyright   :  (C) 2022 Kadena
+-- License     :  BSD-style (see the file LICENSE)
+-- Maintainer  :  Jose Cardona <jose@kadena.io>
+--
+-- Workaround module replacing PackageInfo_pact_tng
+-- to fix the wonky shit in cabal 3.12
+--
+
+
+module Pact.Core.Version (
+    name,
+    version,
+    synopsis,
+    copyright,
+    homepage,
+  ) where
+
+import Data.Version (Version(..))
+
+name :: String
+name = "pact_tng"
+version :: Version
+version = Version [5,0] []
+
+synopsis :: String
+synopsis = "Smart contract language library and REPL"
+copyright :: String
+copyright = "Copyright (C) 2022 Kadena"
+homepage :: String
+homepage = "https://github.com/kadena-io/pact-5"

--- a/repl/Main.hs
+++ b/repl/Main.hs
@@ -10,7 +10,7 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
 import Control.Applicative ((<|>))
 
-import qualified PackageInfo_pact_tng as PI
+import qualified Pact.Core.Version as PI
 import Data.Version (showVersion)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T


### PR DESCRIPTION
This PR simply creates a static version of the autogenerated `PackageInfo_pact_tng`, while we fix our CI.