### PR TITLE
Core: Improve Gasmodel charging, monomorphize to gas table.

### DIFF
--- a/gasmodel/Pact/Core/GasModel/ContractBench.hs
+++ b/gasmodel/Pact/Core/GasModel/ContractBench.hs
@@ -110,7 +110,7 @@ pubKeyFromSender = PublicKeyText . pubKeyFromSenderRaw
 coinTableName :: TableName
 coinTableName = TableName "coin-table" (ModuleName "coin" Nothing)
 
-prePopulateCoinEntries :: Default i => PactDb b i -> IO ()
+prePopulateCoinEntries :: Default i => PactDb CoreBuiltin i -> IO ()
 prePopulateCoinEntries pdb = do
   let style = defStyle {stylePrefix = msg "Pre-filling the coin table"}
   putStrLn "Setting up the coin table"
@@ -172,11 +172,10 @@ setupBenchEvalEnv
   -> PactValue -> IO (EvalEnv CoreBuiltin i)
 setupBenchEvalEnv pdb signers mBody = do
   gasRef <- newIORef mempty
-  gasLogRef <- newIORef Nothing
   let
     gasEnv = GasEnv
       { _geGasRef = gasRef
-      , _geGasLogRef = gasLogRef
+      , _geGasLog = Nothing
       , _geGasModel = tableGasModel (MilliGasLimit (MilliGas 200_000_000))
       }
   pure $ EvalEnv

--- a/gasmodel/Pact/Core/GasModel/Serialization.hs
+++ b/gasmodel/Pact/Core/GasModel/Serialization.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE TypeApplications #-}
 module Pact.Core.GasModel.Serialization
   (benchmarks) where
 

--- a/gasmodel/Pact/Core/GasModel/Serialization.hs
+++ b/gasmodel/Pact/Core/GasModel/Serialization.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeApplications #-}
 module Pact.Core.GasModel.Serialization
   (benchmarks) where
 

--- a/pact-tests/Pact/Core/Test/GasGolden.hs
+++ b/pact-tests/Pact/Core/Test/GasGolden.hs
@@ -27,7 +27,6 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Text.IO as T
 import Data.List (sort)
-import Pact.Core.Gas.TableGasModel
 import Control.Lens
 
 type InterpretPact = SourceCode -> (ReplCompileValue -> ReplM ReplCoreBuiltin ()) -> ReplM ReplCoreBuiltin [ReplCompileValue]
@@ -112,7 +111,7 @@ runGasTest file interpret = do
   pdb <- mockPactDb serialisePact_repl_spaninfo
   gasLog <- newIORef Nothing
   ee <- defaultEvalEnv pdb replBuiltinMap
-  let ee' = ee & eeGasEnv . geGasModel .~ replTableGasModel (maxBound :: MilliGasLimit)
+  let ee' = ee & eeGasEnv . geGasModel .~ replTableGasModel (Just (maxBound :: MilliGasLimit))
       gasRef = ee' ^. eeGasEnv . geGasRef
   let source = SourceCode file src
   let rstate = ReplState

--- a/pact-tests/pact-tests/modref-recursion.repl
+++ b/pact-tests/pact-tests/modref-recursion.repl
@@ -29,4 +29,5 @@
 (env-gasmodel "table")
 (env-gaslimit 10) ; ensures test does not run forever in case recursion breaks
 
+
 (expect-failure "Recursion should fail @ runtime" (knot2.callF knot1))

--- a/pact-tng.cabal
+++ b/pact-tng.cabal
@@ -85,6 +85,7 @@ common pact-common
     , unordered-containers
     , deriving-compat
     , ghc-bignum
+    , primitive
     -- Legacy pact decoding
     , bound
     , aeson

--- a/pact/Pact/Core/Builtin.hs
+++ b/pact/Pact/Core/Builtin.hs
@@ -950,3 +950,4 @@ instance (Pretty b) => Pretty (ReplBuiltin b) where
     RBuiltinRepl t -> pretty (replBuiltinsToText t)
 
 deriveConstrInfo ''CoreBuiltin
+deriveConstrInfo ''ReplOnlyBuiltin

--- a/pact/Pact/Core/Compile.hs
+++ b/pact/Pact/Core/Compile.hs
@@ -42,7 +42,6 @@ import Pact.Core.Imports
 import Pact.Core.Namespace
 import Pact.Core.PactValue
 import Pact.Core.Hash
-import Pact.Core.IR.Eval.Runtime
 import Pact.Core.Interpreter
 
 import qualified Pact.Core.IR.ModuleHashing as MHash

--- a/pact/Pact/Core/Environment/Types.hs
+++ b/pact/Pact/Core/Environment/Types.hs
@@ -102,7 +102,7 @@ import Pact.Core.Names
 import Pact.Core.DefPacts.Types
 import Pact.Core.ChainData
 import Pact.Core.Errors
-import Pact.Core.Gas
+import Pact.Core.Gas.Types
 import Pact.Core.Namespace
 import Pact.Core.StackFrame
 import Pact.Core.SPV
@@ -252,10 +252,12 @@ instance HasLoaded (EvalState b i) b i where
 
 -- | A default evaluation environment meant for
 --   uses such as the repl
-defaultEvalEnv :: PactDb b i -> M.Map Text b -> IO (EvalEnv b i)
+defaultEvalEnv
+  :: PactDb b i
+  -> M.Map Text b
+  -> IO (EvalEnv b i)
 defaultEvalEnv pdb m = do
   gasRef <- newIORef mempty
-  gasLogRef <- newIORef Nothing
   pure $ EvalEnv
     { _eeMsgSigs = mempty
     , _eeMsgVerifiers = mempty
@@ -271,7 +273,7 @@ defaultEvalEnv pdb m = do
     , _eeSPVSupport = noSPVSupport
     , _eeGasEnv = GasEnv
       { _geGasRef = gasRef
-      , _geGasLogRef = gasLogRef
+      , _geGasLog = Nothing
       , _geGasModel = freeGasModel
       }
     }

--- a/pact/Pact/Core/Evaluate.hs
+++ b/pact/Pact/Core/Evaluate.hs
@@ -150,10 +150,9 @@ setupEvalEnv
   -> IO (EvalEnv CoreBuiltin a)
 setupEvalEnv pdb mode msgData gasModel' np spv pd efs = do
   gasRef <- newIORef mempty
-  gasLogRef <- newIORef Nothing
   let gasEnv = GasEnv
         { _geGasRef = gasRef
-        , _geGasLogRef = gasLogRef
+        , _geGasLog = Nothing
         , _geGasModel = gasModel'
         }
   pure $ EvalEnv

--- a/pact/Pact/Core/Gas.hs
+++ b/pact/Pact/Core/Gas.hs
@@ -5,7 +5,9 @@
 module Pact.Core.Gas
  ( module Pact.Core.Gas.Types
  , module Pact.Core.Gas.Utils
+ , module Pact.Core.Gas.TableGasModel
  ) where
 
 import Pact.Core.Gas.Types
 import Pact.Core.Gas.Utils
+import Pact.Core.Gas.TableGasModel

--- a/pact/Pact/Core/Gas/Utils.hs
+++ b/pact/Pact/Core/Gas/Utils.hs
@@ -1,33 +1,55 @@
-{-# language RecordWildCards #-}
+{-# LANGUAGE RecordWildCards #-}
 
-module Pact.Core.Gas.Utils (chargeGasArgsM) where
+module Pact.Core.Gas.Utils
+  ( chargeGasArgsM
+  , chargeGasArgs
+  , chargeFlatNativeGas
+  ) where
 
+import Control.Lens
+import Control.Monad.Except
+import Control.Monad.State.Strict
 import Data.Foldable
 import Data.IORef
 import Pact.Core.StackFrame
 import Pact.Core.Errors
 import Pact.Core.Gas.Types
+import Pact.Core.Gas.TableGasModel
+import Pact.Core.Environment
 
 chargeGasArgsM
   :: GasEnv b i -> i -> [StackFrame i] -> GasArgs b -> IO (Either (PactError i) ())
 chargeGasArgsM GasEnv{..} info stack gasArgs = do
-  let !milliGasCost = _gmRunModel _geGasModel gasArgs
-  newGasTotal <- do
-    !currGasTotal <- readIORef _geGasRef
-    -- calculate new gas total
-    let !newGasTotal = currGasTotal <> milliGasCost
-    -- add a gas log entry if the gas log is enabled
-    maybeGasLog <- readIORef _geGasLogRef
-    forM_ maybeGasLog $ \gasLog -> do
-      -- TODO: make info stack stricter
-      writeIORef _geGasLogRef $ Just
-        (GasLogEntry { _gleArgs = gasArgs, _gleInfo = info, _gleInfoStack = _sfInfo <$> stack, _gleThisUsed = milliGasCost } : gasLog)
-
-    writeIORef _geGasRef newGasTotal
-    return newGasTotal
+  let !milliGasCost = runTableModel (_gmNativeTable _geGasModel) gasArgs
   case _gmGasLimit _geGasModel of
-    Just (MilliGasLimit milliGasLimit) | newGasTotal > milliGasLimit ->
-      return $ Left $ PEExecutionError
-        GasExceeded
-        stack info
+    Just (MilliGasLimit milliGasLimit) -> do
+      newGasTotal <- do
+        !currGasTotal <- readIORef _geGasRef
+        -- calculate new gas total
+        let !newGasTotal = currGasTotal <> milliGasCost
+        -- add a gas log entry if the gas log is enabled
+        forM_ _geGasLog $ \ref -> do
+          -- TODO: make info stack stricter
+          modifyIORef' ref $
+            (GasLogEntry { _gleArgs = gasArgs, _gleInfo = info, _gleInfoStack = _sfInfo <$> stack, _gleThisUsed = milliGasCost } :)
+
+        writeIORef _geGasRef newGasTotal
+        return newGasTotal
+      if milliGasLimit >= newGasTotal then pure (Right ())
+      else return $ Left $ PEExecutionError GasExceeded stack info
     _ -> return $ Right ()
+{-# INLINE chargeGasArgsM #-}
+
+
+chargeGasArgs :: i -> GasArgs b -> EvalM e b i ()
+chargeGasArgs info gasArgs = do
+  stack <- use esStack
+  gasEnv <- viewEvalEnv eeGasEnv
+  either throwError return =<<
+    liftIO (chargeGasArgsM gasEnv info stack gasArgs)
+{-# INLINABLE chargeGasArgs #-}
+
+chargeFlatNativeGas :: i -> b -> EvalM e b i ()
+chargeFlatNativeGas info nativeArg =
+  chargeGasArgs info (GNative nativeArg)
+{-# INLINABLE chargeFlatNativeGas #-}

--- a/pact/Pact/Core/IR/Eval/CoreBuiltin.hs
+++ b/pact/Pact/Core/IR/Eval/CoreBuiltin.hs
@@ -34,8 +34,6 @@ import Data.Bits
 import Data.Either(isLeft, isRight)
 import Data.Foldable
 import Data.Decimal(roundTo', Decimal, DecimalRaw(..))
-import Data.Vector(Vector)
-import Data.Maybe(maybeToList)
 import Numeric(showIntAtBase)
 import qualified Data.Vector as V
 import qualified Data.Vector.Algorithms.Intro as V
@@ -80,7 +78,6 @@ import Pact.Core.IR.Eval.CEK
 import Pact.Core.SizeOf
 import Pact.Core.SPV
 
-import qualified Pact.Core.Pretty as Pretty
 import qualified Pact.Core.Principal as Pr
 import qualified Pact.Core.Trans.TOps as Musl
 
@@ -388,11 +385,7 @@ rawSqrt info b cont handler _env = \case
     returnCEKValue cont handler (VLiteral (LDecimal (f2Dec result)))
   args -> argsError info b args
 
-renderPactValue :: i -> PactValue -> EvalM e b i  T.Text
-renderPactValue info pv = do
-  sz <- sizeOf info SizeOfV0 pv
-  chargeGasArgs info $ GConcat $ TextConcat $ GasTextLength $ fromIntegral sz
-  pure $ Pretty.renderCompactText pv
+
 
 rawShow :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 rawShow info b cont handler _env = \case
@@ -660,31 +653,6 @@ coreEnumerate info b cont handler _env = \case
     returnCEKValue cont handler (VList (PLiteral . LInteger <$> v))
   args -> argsError info b args
 
-createEnumerateList
-  :: i
-  -- ^ info
-  -> Integer
-  -- ^ from
-  -> Integer
-  -- ^ to
-  -> Integer
-  -- ^ Step
-  -> EvalM e b i (Vector Integer)
-createEnumerateList info from to inc
-  | from == to = do
-    fromSize <- sizeOf info SizeOfV0 from
-    chargeGasArgs info (GMakeList 1 fromSize)
-    pure (V.singleton from)
-  | inc == 0 = pure mempty -- note: covered by the flat cost
-  | from < to, from + inc < from =
-    throwExecutionError info (EnumerationError "enumerate: increment diverges below from interval bounds.")
-  | from > to, from + inc > from =
-    throwExecutionError info (EnumerationError "enumerate: increment diverges above from interval bounds.")
-  | otherwise = do
-    let len = succ (abs (from - to) `div` abs inc)
-    listSize <- sizeOf info SizeOfV0 (max (abs from) (abs to))
-    chargeGasArgs info (GMakeList len listSize)
-    pure $ V.enumFromStepN from inc (fromIntegral len)
 
 coreEnumerateStepN :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreEnumerateStepN info b cont handler _env = \case
@@ -986,45 +954,7 @@ coreReadString info b cont handler _env = \case
       _ -> throwReadError info cont handler b
   args -> argsError info b args
 
-readKeyset' :: i -> T.Text -> EvalM e b i (Maybe KeySet)
-readKeyset' info ksn = do
-  viewEvalEnv eeMsgBody >>= \case
-    PObject envData -> do
-      chargeGasArgs info $ GObjOp $ ObjOpLookup ksn $ M.size envData
-      case M.lookup (Field ksn) envData of
-        Just (PGuard (GKeyset ks)) -> pure (Just ks)
-        Just (PObject dat) -> do
-          chargeGasArgs info $ GObjOp $ ObjOpLookup "keys" objSize
-          chargeGasArgs info $ GObjOp $ ObjOpLookup "pred" objSize
-          case parseObj dat of
-            Nothing -> pure Nothing
-            Just (ks, p) -> do
-              chargeGasArgs info $ GStrOp $ StrOpParse $ T.length p
-              pure $ KeySet ks <$> readPredicate p
-          where
-          objSize = M.size dat
-          parseObj d = do
-            keys <- M.lookup (Field "keys") d
-            keyText <- preview _PList keys >>= traverse (fmap PublicKeyText . preview (_PLiteral . _LString))
-            predRaw <- M.lookup (Field "pred") d
-            p <- preview (_PLiteral . _LString) predRaw
-            let ks = S.fromList (V.toList keyText)
-            pure (ks, p)
-          readPredicate = \case
-            "keys-any" -> pure KeysAny
-            "keys-2" -> pure Keys2
-            "keys-all" -> pure KeysAll
-            n | Just pn <- parseParsedTyName n -> pure (CustomPredicate pn)
-            _ -> Nothing
-        Just (PList li) ->
-          case parseKeyList li of
-            Just ks -> pure (Just (KeySet ks KeysAll))
-            Nothing -> pure Nothing
-          where
-          parseKeyList d =
-            S.fromList . V.toList . fmap PublicKeyText <$> traverse (preview (_PLiteral . _LString)) d
-        _ -> pure Nothing
-    _ -> pure Nothing
+
 
 
 coreReadKeyset :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
@@ -1603,45 +1533,6 @@ coreCompose info b cont handler env = \case
     applyLam clo1 [v] cont' handler
   args -> argsError info b args
 
-createPrincipalForGuard :: i -> Guard QualifiedName PactValue -> EvalM e b i Pr.Principal
-createPrincipalForGuard info = \case
-  GKeyset (KeySet ks pf) -> case (toList ks, pf) of
-    ([k], KeysAll)
-      | ed25519HexFormat k -> Pr.K k <$ chargeGas 1_000
-    (l, _) -> do
-      h <- mkHash $ map (T.encodeUtf8 . _pubKey) l
-      case pf of
-        CustomPredicate (TQN (QualifiedName n (ModuleName mn mns))) -> do
-          let totalLength = T.length n + T.length mn + maybe 0 (T.length . _namespaceName) mns
-          chargeGasArgs info $ GConcat $ TextConcat $ GasTextLength totalLength
-        _ -> pure ()
-      pure $ Pr.W (hashToText h) (predicateToText pf)
-  GKeySetRef ksn ->
-    Pr.R ksn <$ chargeGas 1_000
-  GModuleGuard (ModuleGuard mn n) ->
-    Pr.M mn n <$ chargeGas 1_000
-  GUserGuard (UserGuard f args) -> do
-    h <- mkHash $ map encodeStable args
-    pure $ Pr.U (renderQualName f) (hashToText h)
-    -- TODO orig pact gets here ^^^^ a Name
-    -- which can be any of QualifiedName/BareName/DynamicName/FQN,
-    -- and uses the rendered string here. Need to double-check equivalence.
-  GCapabilityGuard (CapabilityGuard f args pid) -> do
-    let args' = map encodeStable args
-        f' = T.encodeUtf8 $ renderQualName f
-        pid' = T.encodeUtf8 . renderDefPactId <$> pid
-    h <- mkHash $ f' : args' ++ maybeToList pid'
-    pure $ Pr.C $ hashToText h
-  GDefPactGuard (DefPactGuard dpid name) -> Pr.P dpid name <$ chargeGas 1_000
-  where
-    chargeGas mg = chargeGasArgs info (GAConstant (MilliGas mg))
-    mkHash bss = do
-      let bs = mconcat bss
-          gasChargeAmt = 1_000 + fromIntegral (BS.length bs `quot` 64) * 1_000
-      chargeGas gasChargeAmt
-      pure $ pactHash bs
-
-
 coreCreatePrincipal :: (CEKEval e step b i, IsBuiltin b) => NativeFunction e step b i
 coreCreatePrincipal info b cont handler _env = \case
   [VGuard g] -> do
@@ -1979,7 +1870,7 @@ coreHyperlaneDecodeTokenMessage info b cont handler _env = \case
   [VString s] -> do
     chargeGasArgs info $ GHyperlaneEncodeDecodeTokenMessage (T.length s)
     case decodeBase64UrlUnpadded (T.encodeUtf8 s) of
-      Left _e -> throwExecutionError info $ HyperlaneDecodeError HyperlaneDecodeErrorBase64 
+      Left _e -> throwExecutionError info $ HyperlaneDecodeError HyperlaneDecodeErrorBase64
       Right bytes -> case Bin.runGetOrFail (unpackTokenMessageERC20 <* eof) (BS.fromStrict bytes) of
         Left (_, _, e) | "TokenMessage" `L.isPrefixOf` e -> do
                            throwExecutionError info $ HyperlaneDecodeError $ HyperlaneDecodeErrorInternal e

--- a/pact/Pact/Core/IR/Eval/Direct/ReplBuiltin.hs
+++ b/pact/Pact/Core/IR/Eval/Direct/ReplBuiltin.hs
@@ -50,7 +50,6 @@ import qualified Data.Attoparsec.Text as A
 
 import Pact.Core.Repl.Utils
 import qualified Pact.Time as PactTime
-import Pact.Core.Gas.TableGasModel
 import Data.IORef
 
 
@@ -427,27 +426,25 @@ envGasLimit info b _env = \case
     return $ VString $ "Set gas limit to " <> T.pack (show g)
   args -> argsError info b args
 
-envGasLog :: NativeFunction ReplRuntime ReplCoreBuiltin SpanInfo
+envGasLog :: NativeFunction 'ReplRuntime ReplCoreBuiltin SpanInfo
 envGasLog info b _env = \case
   [] -> do
-    gasLogRef <- viewEvalEnv (eeGasEnv . geGasLogRef)
-    gasLog <- liftIO $ readIORef gasLogRef
-    liftIO $ writeIORef gasLogRef (Just [])
-    case gasLog of
-      Nothing ->
-        return (VString "Enabled gas log")
-      Just logs -> let
+    (gasLogRef, logsJustEnabled) <- viewEvalEnv (eeGasEnv . geGasLog) >>= \case
+      Just ref -> pure (ref, False)
+      Nothing -> do
+        ref' <- liftIO $ newIORef []
+        replEvalEnv . eeGasEnv . geGasLog .== Just ref'
+        pure (ref', True)
+    logs <- liftIO $ readIORef gasLogRef
+    liftIO $ writeIORef gasLogRef []
+    if logsJustEnabled then return (VList (V.fromList [PString "Enabled gas log"]))
+    else let
         total = MilliGas $ sum [g | MilliGas g <- _gleThisUsed <$> logs]
         totalLine = PString . ("TOTAL: " <> ) $ renderCompactText total
-        logLines = renderLine <$> reverse logs
+        logLines = gasLogEntrytoPactValue <$> reverse logs
         in
           return (VList $ V.fromList (totalLine:logLines))
   args -> argsError info b args
-  where
-  renderLine :: GasLogEntry (ReplBuiltin CoreBuiltin) SpanInfo -> PactValue
-  renderLine entry = PString $ renderCompactText' $ n <> ": " <> pretty (_gleThisUsed entry)
-    where
-      n = pretty (_gleArgs entry) <+> pretty (_gleInfo entry)
 
 envEnableReplNatives :: NativeFunction ReplRuntime ReplCoreBuiltin SpanInfo
 envEnableReplNatives info b _env = \case
@@ -466,14 +463,8 @@ envGasModel info b _env = \case
   args@[VString model] -> do
     gm <- viewEvalEnv (eeGasEnv . geGasModel)
     newmodel' <- case model of
-      "table" -> pure $ replTableGasModel (fromMaybe (MilliGasLimit mempty) $ _gmGasLimit gm)
-      "fixed" -> pure (constantGasModel mempty (fromMaybe (MilliGasLimit mempty) $ _gmGasLimit gm))
+      "table" -> pure $ replTableGasModel (_gmGasLimit gm)
       _ -> argsError info b args
-    replEvalEnv . eeGasEnv . geGasModel .== newmodel'
-    return $ VString $ "Set gas model to " <> _gmDesc newmodel'
-  [VString "fixed", VInteger arg] -> do
-    gm <- viewEvalEnv (eeGasEnv . geGasModel)
-    let newmodel' = constantGasModel (gasToMilliGas (Gas (fromIntegral arg))) (fromMaybe (MilliGasLimit mempty) $ _gmGasLimit gm)
     replEvalEnv . eeGasEnv . geGasModel .== newmodel'
     return $ VString $ "Set gas model to " <> _gmDesc newmodel'
   args -> argsError info b args

--- a/pact/Pact/Core/Persistence/Types.hs
+++ b/pact/Pact/Core/Persistence/Types.hs
@@ -18,7 +18,6 @@
 module Pact.Core.Persistence.Types
  ( ModuleData(..)
  , GasM(..)
- , chargeGasM
  , PactDb(..)
  , Loaded(..)
  , HasLoaded(..)
@@ -49,7 +48,7 @@ import GHC.Generics
 import Data.Text(Text)
 import Data.Word(Word64)
 
-import Pact.Core.Gas
+import Pact.Core.Gas.Types
 import Pact.Core.Type
 import Pact.Core.Names
 import Pact.Core.IR.Term
@@ -185,10 +184,7 @@ newtype GasM b i a
   , MonadIO
   )
 
-chargeGasM :: GasArgs b -> GasM b i ()
-chargeGasM gasArgs = do
-  (gasEnv, info, stack) <- ask
-  either throwError return =<< liftIO (chargeGasArgsM gasEnv info stack gasArgs)
+
 
 -- | Fun-record type for Pact back-ends.
 -- b: The type of builtin functions.

--- a/pact/Pact/Core/Repl/Utils.hs
+++ b/pact/Pact/Core/Repl/Utils.hs
@@ -37,6 +37,7 @@ module Pact.Core.Repl.Utils
  , usesReplState
  , (.==)
  , (%==)
+ , gasLogEntrytoPactValue
  ) where
 
 import Control.Lens
@@ -62,6 +63,8 @@ import Pact.Core.Pretty
 import Pact.Core.Errors
 import Pact.Core.Environment
 import Pact.Core.Type
+import Pact.Core.Builtin
+import Pact.Core.PactValue
 import qualified Pact.Core.IR.Term as Term
 
 import System.Console.Haskeline.Completion
@@ -242,3 +245,8 @@ replError (SourceCode srcFile src) pe =
   padLeft t pad = T.replicate (pad - (T.length t)) " " <> t <> " "
   -- Zip the line number with the source text, and apply the number padding correctly
   withLine st pad lns = zipWith (\i e -> padLeft (T.pack (show i)) pad <> "| " <> e) [st+1..] lns
+
+gasLogEntrytoPactValue :: GasLogEntry (ReplBuiltin CoreBuiltin) SpanInfo -> PactValue
+gasLogEntrytoPactValue entry = PString $ renderCompactText' $ n <> ": " <> pretty (_gleThisUsed entry)
+  where
+    n = pretty (_gleArgs entry) <+> pretty (_gleInfo entry)

--- a/pact/Pact/Core/SizeOf.hs
+++ b/pact/Pact/Core/SizeOf.hs
@@ -23,7 +23,7 @@ module Pact.Core.SizeOf
   ( SizeOf(..)
   , SizeOf1(..)
   , constructorCost
-  , Bytes
+, Bytes
   , wordSize
   , SizeOfVersion(..)
 
@@ -70,8 +70,7 @@ import Pact.Core.Imports
 import Pact.Core.Info
 import Pact.Core.ModRefs
 import Pact.Core.Namespace (Namespace)
-import Pact.Core.IR.Eval.Runtime.Utils (chargeGasArgs)
-import Pact.Core.Gas (GasArgs(GCountBytes))
+import Pact.Core.Gas
 
 
 -- |  Estimate of number of bytes needed to represent data type

--- a/pact/Pact/Core/SizeOf.hs
+++ b/pact/Pact/Core/SizeOf.hs
@@ -23,7 +23,7 @@ module Pact.Core.SizeOf
   ( SizeOf(..)
   , SizeOf1(..)
   , constructorCost
-, Bytes
+  , Bytes
   , wordSize
   , SizeOfVersion(..)
 

--- a/profile-tx/ProfileTx.hs
+++ b/profile-tx/ProfileTx.hs
@@ -116,7 +116,7 @@ pubKeyFromSender = PublicKeyText . pubKeyFromSenderRaw
 coinTableName :: TableName
 coinTableName = TableName "coin-table" (ModuleName "coin" Nothing)
 
-prePopulateCoinEntries :: Default i => PactDb b i -> IO ()
+prePopulateCoinEntries :: Default i => PactDb CoreBuiltin i -> IO ()
 prePopulateCoinEntries pdb = do
   let style = defStyle {stylePrefix = msg "Pre-filling the coin table"}
   putStrLn "Setting up the coin table"
@@ -178,11 +178,10 @@ setupBenchEvalEnv
   -> PactValue -> IO (EvalEnv CoreBuiltin i)
 setupBenchEvalEnv pdb signers mBody = do
   gasRef <- newIORef mempty
-  gasLogRef <- newIORef Nothing
   let
     gasEnv = GasEnv
       { _geGasRef = gasRef
-      , _geGasLogRef = gasLogRef
+      , _geGasLog = Nothing
       , _geGasModel = tableGasModel (MilliGasLimit (MilliGas 200_000_000))
       }
   pure $ EvalEnv


### PR DESCRIPTION
This PR monomorphizes our Gas model charging to always use our gas table. There's about a 10% speed increase from this change.

Numbers pre-pr:
```
benchmarking Pact Core Benchmarks/Pure Code/Factorial 1000
time                 216.1 μs   (215.8 μs .. 216.7 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 216.0 μs   (215.8 μs .. 216.8 μs)
std dev              1.236 μs   (327.0 ns .. 2.522 μs)

benchmarking Pact Core Benchmarks/Coin Transfer/InterpretOnly(transfer) from SenderA to SenderB using: CEK
time                 76.84 μs   (76.76 μs .. 76.92 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 76.95 μs   (76.91 μs .. 77.00 μs)
std dev              106.9 ns   (83.52 ns .. 159.7 ns)

benchmarking Pact Core Benchmarks/Coin Transfer/InterpretOnly(transfer) from SenderA to SenderB using: Direct
time                 75.01 μs   (74.97 μs .. 75.05 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 75.01 μs   (74.95 μs .. 75.05 μs)
std dev              108.6 ns   (83.82 ns .. 140.9 ns)
```

Post pr:
```
benchmarking Pact Core Benchmarks/Pure Code/Factorial 1000
time                 184.4 μs   (181.5 μs .. 188.9 μs)
                     0.998 R²   (0.995 R² .. 0.999 R²)
mean                 186.2 μs   (184.4 μs .. 188.3 μs)
std dev              6.571 μs   (5.282 μs .. 8.562 μs)
variance introduced by outliers: 32% (moderately inflated)

benchmarking Pact Core Benchmarks/Coin Transfer/InterpretOnly(transfer) from SenderA to SenderB using: CEK
time                 71.82 μs   (71.66 μs .. 72.01 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 71.89 μs   (71.76 μs .. 72.04 μs)
std dev              307.4 ns   (228.9 ns .. 414.1 ns)

benchmarking Pact Core Benchmarks/Coin Transfer/InterpretOnly(transfer) from SenderA to SenderB using: Direct
time                 69.09 μs   (68.96 μs .. 69.21 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 69.06 μs   (68.91 μs .. 69.23 μs)
std dev              329.2 ns   (214.6 ns .. 462.8 ns)
```

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [x] Benchmark regressions
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
