### PR TITLE
Bundle of changes from integration work

### DIFF
--- a/gasmodel/Pact/Core/GasModel/Utils.hs
+++ b/gasmodel/Pact/Core/GasModel/Utils.hs
@@ -33,7 +33,7 @@ import Pact.Core.IR.Term
 import Pact.Core.Persistence
 import Pact.Core.Hash
 import Pact.Core.Guards
-import Pact.Core.Evaluate
+import Pact.Core.Evaluate hiding (Cont(..))
 import Pact.Core.Namespace
 import Pact.Core.IR.Eval.CEK.Types hiding (Eval)
 import qualified Pact.Core.IR.Eval.CEK as Eval

--- a/pact-request-api/Pact/Core/Command/Types.hs
+++ b/pact-request-api/Pact/Core/Command/Types.hs
@@ -42,6 +42,8 @@ module Pact.Core.Command.Types
   , Signer(..),siScheme, siPubKey, siAddress, siCapList
   , UserSig(..)
   , PactResult(..)
+  , _PactResultOk
+  , _PactResultErr
   , CommandResult(..),crReqKey,crTxId,crResult,crGas,crLogs,crEvents
   , crContinuation,crMetaData
   , RequestKey(..)
@@ -263,6 +265,8 @@ data PactResult err
   = PactResultOk PactValue
   | PactResultErr err
   deriving (Eq, Show, Generic, Functor, Traversable, Foldable)
+
+makePrisms ''PactResult
 
 instance NFData err => NFData (PactResult err)
 

--- a/pact/Pact/Core/Compile.hs
+++ b/pact/Pact/Core/Compile.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE DerivingStrategies #-}
 
 module Pact.Core.Compile
  ( interpretTopLevel
@@ -74,7 +75,7 @@ data CompileValue i
   | LoadedInterface ModuleName ModuleHash
   | LoadedImports Import
   | InterpretValue PactValue i
-  deriving Show
+  deriving stock (Eq, Show)
 
 instance Pretty (CompileValue i) where
   pretty = \case

--- a/pact/Pact/Core/Evaluate.hs
+++ b/pact/Pact/Core/Evaluate.hs
@@ -9,7 +9,6 @@ module Pact.Core.Evaluate
   , EvalResult(..)
   , ContMsg(..)
   , Info
-  , initMsgData
   , evalExec
   , evalContinuation
   , evalGasPayerCap
@@ -94,14 +93,10 @@ evalDirectInterpreter =
 -- | Transaction-payload related environment data.
 data MsgData = MsgData
   { mdData :: !PactValue
-  , mdStep :: !(Maybe DefPactStep)
   , mdHash :: !Hash
   , mdSigners :: [Signer QualifiedName PactValue]
   , mdVerifiers :: [Verifier ()]
   }
-
-initMsgData :: Hash -> MsgData
-initMsgData h = MsgData (PObject mempty) def h mempty mempty
 
 type EvalInput = Either (Maybe DefPactExec) [Lisp.TopLevel Info]
 
@@ -165,7 +160,7 @@ setupEvalEnv pdb mode msgData gasModel' np spv pd efs = do
     , _eeMsgBody = mdData msgData
     , _eeHash = mdHash msgData
     , _eePublicData = pd
-    , _eeDefPactStep = mdStep msgData
+    , _eeDefPactStep = Nothing
     , _eeMode = mode
     , _eeFlags = efs
     , _eeNatives = coreBuiltinMap


### PR DESCRIPTION
Based on #189.

`MsgData` doesn't need `mdStep` anymore, it isn't used. `initMsgData` is just a footgun for me. 

`_erInput` makes the interface of `Evaluate` more annoying to use and doesn't seem to be needed.

`Pact.Core.Evaluate.ContMsg` was renamed to `Cont`. Not to be confused with `Pact.Core.Command.RPC.ContMsg`, which is public API.

PR checklist:

* [ ] Test coverage for the proposed changes
* [ ] PR description contains example output from repl interaction or a snippet from unit test output
* [ ] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [ ] Benchmark regressions
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
