### PR TITLE
add `--explain-error-code ERROR_CODE flag` to the repl

### DIFF
--- a/repl/Main.hs
+++ b/repl/Main.hs
@@ -48,7 +48,7 @@ data ReplOpts
   | OUnsignedReq { _oReqYaml :: FilePath }
   -- Crypto
   | OGenKey
-  | OExplain String
+  | OExplainErrorCode String
   deriving (Eq, Show)
 
 replOpts :: O.Parser (Maybe ReplOpts)
@@ -59,7 +59,7 @@ replOpts = O.optional $
   <|> apiReqFlag
   <|> unsignedReqFlag
   <|> loadFlag
-  <|> explainFlag
+  <|> explainErrorCodeFlag
 
 -- Todo: trace output and coverage?
 loadFlag :: O.Parser ReplOpts
@@ -86,10 +86,10 @@ apiReqFlag =
                   O.help "Format API request JSON using REQ_YAML file")
   <*> localFlag
 
-explainFlag :: O.Parser ReplOpts
-explainFlag =
-  OExplain <$> O.strOption (O.long "explain" <> O.metavar "ERROR_CODE" <>
-                           O.help "Describe the error code")
+explainErrorCodeFlag :: O.Parser ReplOpts
+explainErrorCodeFlag =
+  OExplainErrorCode <$> O.strOption (O.long "explain-error-code" <> O.metavar "ERROR_CODE" <>
+                                     O.help "Describe the error code")
 
 unsignedReqFlag :: O.Parser ReplOpts
 unsignedReqFlag = OUnsignedReq
@@ -122,7 +122,7 @@ main = O.execParser argParser >>= \case
           Just s -> runScript s dbg
           Nothing -> runScript fp dbg
       | otherwise -> runScript fp dbg
-    OExplain errCodeStr -> case errorCodeFromText $ T.pack errCodeStr of
+    OExplainErrorCode errCodeStr -> case errorCodeFromText $ T.pack errCodeStr of
       Nothing -> putStrLn $ "Invalid error code format" -- todo enhance error
       Just errCode -> let (PrettyErrorCode phase cause _) = prettyErrorCode $ PactErrorCode errCode NoInfo
         in T.putStrLn ("Encountered failure in: " <> phase <> ", caused by: " <> cause)


### PR DESCRIPTION
output:
```
The Pact Smart Contract Language Interpreter

Usage: pact [(-v|--version) | (-b|--builtins) | --lsp | (-a|--apireq REQ_YAML) 
              [-l|--local] |
              (-u|--unsigned REQ_YAML) | [-r|--findscript] [-t|--trace] FILE | 
              --explain-error-code ERROR_CODE]

Available options:
  -h,--help                Show this help text
  -v,--version             Display version
  -b,--builtins            List builtins
  --lsp                    Start Language Server
  -a,--apireq REQ_YAML     Format API request JSON using REQ_YAML file
  -l,--local               Format for /local endpoint
  -u,--unsigned REQ_YAML   Format unsigned API request JSON using REQ_YAML file
  -r,--findscript          For .pact files, attempts to locate a .repl file to
                           execute.
  -t,--trace               Show trace output
  FILE                     File path to compile (if .pact extension) or execute.
  --explain-error-code ERROR_CODE
                           Describe the error code



cabal run pact -- --explain-error-code 0x0003080000000000
Encountered failure in: PEExecutionError, caused by: EvalError
```

PR checklist:

* [ ] Test coverage for the proposed changes
* [ ] PR description contains example output from repl interaction or a snippet from unit test output
* [ ] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [ ] Benchmark regressions
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
