### PR TITLE
Fix internal evaluate API to catch unknown exceptions

### DIFF
--- a/pact/Pact/Core/Environment/Types.hs
+++ b/pact/Pact/Core/Environment/Types.hs
@@ -75,10 +75,10 @@ module Pact.Core.Environment.Types
 
 
 import Control.Lens
-import Control.Monad.Catch
 import Control.Monad.Reader
 import Control.Monad.State.Strict
 import Control.Monad.Except
+import Control.Exception.Safe
 import Data.Set(Set)
 import Data.Text(Text)
 import Data.Map.Strict(Map)

--- a/pact/Pact/Core/Persistence/SQLite.hs
+++ b/pact/Pact/Core/Persistence/SQLite.hs
@@ -13,7 +13,7 @@ module Pact.Core.Persistence.SQLite (
 ) where
 
 import Control.Monad
-import Control.Monad.Catch
+import Control.Exception.Safe
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Data.IORef
 import Data.Text (Text)
@@ -27,7 +27,6 @@ import qualified Pact.Core.Errors as E
 import Pact.Core.Persistence
 import Pact.Core.Guards (renderKeySetName, parseAnyKeysetName)
 import Pact.Core.Names
-import Control.Exception (throwIO)
 import Pact.Core.Serialise
 import Pact.Core.StableEncoding (encodeStable)
 

--- a/pact/Pact/Core/Repl.hs
+++ b/pact/Pact/Core/Repl.hs
@@ -17,7 +17,7 @@
 module Pact.Core.Repl(runRepl, execScript) where
 
 import Control.Monad.IO.Class
-import Control.Monad.Catch
+import Control.Exception.Safe
 import Control.Monad.Except
 import Control.Monad.Trans(lift)
 import System.Console.Haskeline
@@ -63,7 +63,7 @@ runRepl = do
 
   replSettings = Settings (replCompletion replCoreBuiltinNames) (Just ".pc-history") True
   displayOutput = outputStrLn . show . pretty
-  catch' ma = catchAll ma (\e -> outputStrLn (show e) *> loop)
+  catch' ma = catchAny ma (\e -> outputStrLn (show e) *> loop)
   defaultSrc = SourceCode "(interactive)" mempty
   loop = do
     minput <- fmap T.pack <$> getInputLine "pact>"

--- a/tools/LegacyPactDbCheck.hs
+++ b/tools/LegacyPactDbCheck.hs
@@ -4,7 +4,7 @@
 
 module Main where
 
-import Control.Monad.Catch
+import Control.Exception.Safe
 import qualified Database.SQLite3 as SQL
 import Data.Text (Text)
 import qualified Data.Text as T


### PR DESCRIPTION
Fix our external facing `Evaluate` api to properly rollback on calls to the `evalExec` family of functions.

The testing of this PR is done within chainweb.

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [x] Benchmark regressions
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
