### PR TITLE
lsp renaming bug

### DIFF
--- a/pact-lsp/Pact/Core/LanguageServer.hs
+++ b/pact-lsp/Pact/Core/LanguageServer.hs
@@ -340,6 +340,7 @@ documentRenameRequestHandler = requestHandler SMethod_TextDocumentRename $ \req 
         nName = req ^. params . newName
         tls = fromMaybe [] $ view (lsTopLevel . at nuri) st
         toTextEdit r = TextEdit r nName
+    debug $ "documentRenameRequestHandler: " <> sshow nName <> "  ::  " <> sshow tls
     case getRenameSpanInfo tls <$> getMatch pos tls of
       Nothing -> do
         debug "documentRenameRequestHandler: could not find term at position"

--- a/pact-lsp/Pact/Core/LanguageServer.hs
+++ b/pact-lsp/Pact/Core/LanguageServer.hs
@@ -196,7 +196,7 @@ sendDiagnostics nuri mv content = liftIO (setupAndProcessFile nuri content) >>= 
     -- We only publish a single diagnostic
     publishDiagnostics 1  nuri mv $ partitionBySource [pactErrorToDiagnostic err]
   Right (st, tl) -> do
-    modifyState ((lsReplState %~ M.insert nuri st) . (lsTopLevel %~ M.unionWith (<>) tl))
+    modifyState ((lsReplState %~ M.insert nuri st) . (lsTopLevel %~ M.unionWith (\_ a -> a) tl))
 
     -- We emit an empty set of diagnostics
     publishDiagnostics 0  nuri mv $ partitionBySource []
@@ -340,7 +340,7 @@ documentRenameRequestHandler = requestHandler SMethod_TextDocumentRename $ \req 
         debug "documentRenameRequestHandler: could not find term at position"
         resp (Right (InR Null))
       Just changePos -> do
-        debug $ "documentRenameRequestHandler: got " <> sshow (length changePos) <> " changes"
+        debug $ "documentRenameRequestHandler: got " <> sshow (length changePos) <> " changes: " <> sshow changePos
         let changes = InL . toTextEdit . spanInfoToRange <$> changePos
             te = TextDocumentEdit
                  (OptionalVersionedTextDocumentIdentifier uri' $ InR Null)

--- a/pact-lsp/Pact/Core/LanguageServer/Renaming.hs
+++ b/pact-lsp/Pact/Core/LanguageServer/Renaming.hs
@@ -60,6 +60,7 @@ getRenameSpanInfo
   -> PositionMatch ReplCoreBuiltin SpanInfo
   -> [SpanInfo]
 getRenameSpanInfo tls = \case
+   TermMatch (App var@(Var _ _) _ _) -> getRenameSpanInfo tls (TermMatch var)
    TermMatch (Var (Name n vt) _) -> case vt of
      NBound _db -> mempty
      NTopLevel mn _mh -> do

--- a/pact-lsp/Pact/Core/LanguageServer/Renaming.hs
+++ b/pact-lsp/Pact/Core/LanguageServer/Renaming.hs
@@ -60,7 +60,9 @@ getRenameSpanInfo
   -> PositionMatch ReplCoreBuiltin SpanInfo
   -> [SpanInfo]
 getRenameSpanInfo tls = \case
-   TermMatch (App var@(Var _ _) _ _) -> getRenameSpanInfo tls (TermMatch var)
+  -- TODO: I've encountered an `App (Var ...)` at some point.
+  -- Double check if this is required
+  -- TermMatch (App var@(Var _ _) _ _) -> getRenameSpanInfo tls (TermMatch var)
    TermMatch (Var (Name n vt) _) -> case vt of
      NBound _db -> mempty
      NTopLevel mn _mh -> do

--- a/pact-tests/Pact/Core/Test/LanguageServer.hs
+++ b/pact-tests/Pact/Core/Test/LanguageServer.hs
@@ -13,7 +13,7 @@ import Language.LSP.Test
 import Language.LSP.Protocol.Types
 import Language.LSP.Protocol.Lens hiding (length, title, rename)
 
-import Control.Lens
+import Control.Lens hiding (inside)
 
 import System.Environment
 import Test.Tasty
@@ -30,6 +30,8 @@ import Pact.Core.Repl.BuiltinDocs.Internal
 import Data.Either (isLeft)
 import Data.Text.Encoding
 import qualified Data.ByteString.Lazy as LBS
+import Pact.Core.Info
+import Pact.Core.LanguageServer.Utils
 
 tests :: TestTree
 tests = testGroup "Pact LSP"
@@ -42,8 +44,18 @@ tests = testGroup "Pact LSP"
   , testGroup "Definition" definitionRequestTests
   , renameTests
   , testGroup "Multi-file dependency" dependencyTests
+  , testGroup "Inside position tests" positionTests
   ]
 
+positionTests :: [TestTree]
+positionTests =
+  [ testCase "a should be inside" $
+      liftIO $ assertBool "should be inside" (Position 0 0 `inside` SpanInfo 0 0 0 1)
+  , testCase "a should be inside" $
+      liftIO $ assertBool "should be inside" (not $ Position 0 1 `inside` SpanInfo 0 0 0 1)
+  , testCase "(a) on position inside a" $
+    liftIO $ assertBool "should be inside" (Position 0 1 `inside` SpanInfo 0 0 0 3)
+  ]
 diagnosticTests :: [TestTree]
 diagnosticTests
   = [ testCase "Failure Diagnostic" $ runPactLSP $ do

--- a/pact-tests/Pact/Core/Test/LexerTests.hs
+++ b/pact-tests/Pact/Core/Test/LexerTests.hs
@@ -10,7 +10,16 @@ import Pact.Core.Info (SpanInfo(..))
 
 tests :: TestTree
 tests = testGroup "Lexer spans"
-  [ testCase "single line expression" $ let
+  [ testCase "single token ident" $ let
+      expected = [PosToken (TokenIdent "a") (SpanInfo 0 0 0 1)]
+    in either (const (assertFailure "")) (@?= expected) (lexer "a")
+  , testCase "app with single token ident" $ let
+      expected = [PosToken TokenOpenParens (SpanInfo 0 0 0 1)
+                 ,PosToken (TokenIdent "a") (SpanInfo 0 1 0 2)
+                 ,PosToken TokenCloseParens (SpanInfo 0 2 0 3)
+                 ]
+    in either (const (assertFailure "")) (@?= expected) (lexer "(a)")
+  , testCase "single line expression" $ let
       expected =
         [PosToken TokenOpenParens (SpanInfo 0 0 0 1)
         ,PosToken (TokenIdent "test") (SpanInfo 0 1 0 5)

--- a/pact-tests/PactCoreTests.hs
+++ b/pact-tests/PactCoreTests.hs
@@ -12,7 +12,7 @@ import qualified Pact.Core.Test.LegacySerialiseTests as LegacySerialiseTests
 import qualified Pact.Core.Test.StaticErrorTests as StaticErrorTests
 import qualified Pact.Core.Test.ZkTests as ZkTests
 import qualified Pact.Core.Test.PoseidonTests as PoseidonTests
--- import qualified Pact.Core.Test.LanguageServer as LanguageServer
+import qualified Pact.Core.Test.LanguageServer as LanguageServer
 import qualified Pact.Core.Test.GasGolden as GasGolden
 import qualified Pact.Core.Test.SizeOfTests as SizeOfTests
 import qualified Pact.Core.Test.ConTagGolden as ConTagGoldenTests
@@ -37,7 +37,7 @@ main = do
     , ZkTests.tests
     , PoseidonTests.tests
     , PersistenceTests.tests
-    -- , LanguageServer.tests
+    , LanguageServer.tests
     , gasGolden
     , SizeOfTests.tests
     , commandTests


### PR DESCRIPTION
Within the VSCode plugin, multiple renaming's will result in a strange output.

This PR adds more logging and re-activates the test suite.

PR checklist:

* [ ] Test coverage for the proposed changes
* [ ] PR description contains example output from repl interaction or a snippet from unit test output
* [ ] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [ ] Benchmark regressions
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
