### PR TITLE
Add warnings to Repl

### DIFF
--- a/gasmodel/Pact/Core/GasModel/ContractBench.hs
+++ b/gasmodel/Pact/Core/GasModel/ContractBench.hs
@@ -179,6 +179,7 @@ setupBenchEvalEnv pdb signers mBody = do
     , _eeNamespacePolicy = SimpleNamespacePolicy
     , _eeGasEnv = gasEnv
     , _eeSPVSupport = noSPVSupport
+    , _eeWarnings = Nothing
     }
 
 

--- a/pact-lsp/Pact/Core/LanguageServer.hs
+++ b/pact-lsp/Pact/Core/LanguageServer.hs
@@ -251,6 +251,7 @@ setupAndProcessFile nuri content = do
           -- since there may be no way for us to set it for the LSP from pact directly.
           -- Once this is possible, we can set it to `False` as is the default
           , _replNativesEnabled = True
+          , _replOutputLine = const (pure ())
           }
   stateRef <- newIORef rstate
   res <- runReplT stateRef (processFile Repl.interpretEvalBigStep nuri content)

--- a/pact-tests/Pact/Core/Test/GasGolden.hs
+++ b/pact-tests/Pact/Core/Test/GasGolden.hs
@@ -29,7 +29,7 @@ import qualified Data.Text.IO as T
 import Data.List (sort)
 import Control.Lens
 
-type InterpretPact = SourceCode -> (ReplCompileValue -> ReplM ReplCoreBuiltin ()) -> ReplM ReplCoreBuiltin [ReplCompileValue]
+type InterpretPact = SourceCode -> ReplM ReplCoreBuiltin [ReplCompileValue]
 
 tests :: IO TestTree
 tests = do
@@ -122,8 +122,9 @@ runGasTest file interpret = do
             , _replTLDefPos = mempty
             , _replTx = Nothing
             , _replNativesEnabled = False
+            , _replOutputLine = const (pure ())
             }
   stateRef <- newIORef rstate
-  runReplT stateRef (interpret source (const (pure ()))) >>= \case
+  runReplT stateRef (interpret source) >>= \case
     Left _ -> pure Nothing
     Right _ -> Just <$> readIORef gasRef

--- a/pact-tests/Pact/Core/Test/ReplTests.hs
+++ b/pact-tests/Pact/Core/Test/ReplTests.hs
@@ -34,7 +34,7 @@ import Pact.Core.Errors
 import Pact.Core.Serialise
 
 
-type Interpreter = SourceCode -> (ReplCompileValue -> ReplM ReplCoreBuiltin ()) -> ReplM ReplCoreBuiltin [ReplCompileValue]
+type Interpreter = SourceCode -> ReplM ReplCoreBuiltin [ReplCompileValue]
 
 tests :: IO TestTree
 tests = do
@@ -89,9 +89,10 @@ runReplTest (ReplSourceDir path) pdb file src interp = do
             , _replTLDefPos = mempty
             , _replTx = Nothing
             , _replNativesEnabled = False
+            , _replOutputLine = const (pure ())
             }
   stateRef <- newIORef rstate
-  runReplT stateRef (interp source (const (pure ()))) >>= \case
+  runReplT stateRef (interp source) >>= \case
     Left e -> let
       rendered = replError (SourceCode file src) e
       in assertFailure (T.unpack rendered)

--- a/pact-tests/Pact/Core/Test/StaticErrorTests.hs
+++ b/pact-tests/Pact/Core/Test/StaticErrorTests.hs
@@ -47,9 +47,10 @@ runStaticTest label src interp predicate = do
             , _replTLDefPos = mempty
             , _replTx = Nothing
             , _replNativesEnabled = True
+            , _replOutputLine = const (pure ())
             }
   stateRef <- newIORef rstate
-  v <- runReplT stateRef (interpretReplProgram interp source (const (pure ())))
+  v <- runReplT stateRef (interpretReplProgram interp source)
   case v of
     Left err ->
       assertBool ("Expected Error to match predicate, but got " <> show err <> " instead") (predicate err)

--- a/pact/Pact/Core/Evaluate.hs
+++ b/pact/Pact/Core/Evaluate.hs
@@ -174,6 +174,7 @@ setupEvalEnv pdb mode msgData gasModel' np spv pd efs = do
     , _eeNamespacePolicy = np
     , _eeGasEnv = gasEnv
     , _eeSPVSupport = spv
+    , _eeWarnings = Nothing
     }
   where
   mkMsgSigs ss = M.fromList $ map toPair ss

--- a/pact/Pact/Core/IR/Eval/CEK.hs
+++ b/pact/Pact/Core/IR/Eval/CEK.hs
@@ -1496,12 +1496,14 @@ enforceGuard info cont handler env g = case g of
     isKeysetNameInSigs info cont handler env ksn
   GUserGuard ug -> runUserGuard info cont handler env ug
   GCapabilityGuard cg -> enforceCapGuard info cont handler cg
-  GModuleGuard (ModuleGuard mn _) -> calledByModule mn >>= \case
-    True -> returnCEKValue cont handler (VBool True)
-    False -> do
-      md <- getModule info mn
-      let cont' = IgnoreValueC (PBool True) cont
-      acquireModuleAdmin info cont' handler env md
+  GModuleGuard (ModuleGuard mn _) -> do
+    emitPactWarning info ModuleGuardEnforceDetected
+    calledByModule mn >>= \case
+      True -> returnCEKValue cont handler (VBool True)
+      False -> do
+        md <- getModule info mn
+        let cont' = IgnoreValueC (PBool True) cont
+        acquireModuleAdmin info cont' handler env md
   GDefPactGuard (DefPactGuard dpid _) -> do
     curDpid <- getDefPactId info
     if curDpid == dpid

--- a/pact/Pact/Core/IR/Eval/CoreBuiltin.hs
+++ b/pact/Pact/Core/IR/Eval/CoreBuiltin.hs
@@ -1207,7 +1207,9 @@ createCapabilityPactGuard info b cont handler _env = \case
 
 createModuleGuard :: (IsBuiltin b) => NativeFunction e b i
 createModuleGuard info b cont handler _env = \case
-  [VString n] ->
+  [VString n] -> do
+    emitPactWarning info $ DeprecatedNative (builtinName b)
+      "Module guards have been deprecate and will be removed in a future release, please switch to capability guards"
     findCallingModule >>= \case
       Just mn ->  do
         let cg = GModuleGuard (ModuleGuard mn n)
@@ -1219,6 +1221,8 @@ createModuleGuard info b cont handler _env = \case
 createDefPactGuard :: (IsBuiltin b) => NativeFunction e b i
 createDefPactGuard info b cont handler _env = \case
   [VString name] -> do
+    emitPactWarning info $ DeprecatedNative (builtinName b)
+      "Pact guards have been deprecated and will be removed in a future release, please switch to capability guards"
     dpid <- getDefPactId info
     returnCEKValue cont handler $ VGuard $ GDefPactGuard $ DefPactGuard dpid name
   args -> argsError info b args

--- a/pact/Pact/Core/IR/Eval/Runtime/Types.hs
+++ b/pact/Pact/Core/IR/Eval/Runtime/Types.hs
@@ -18,7 +18,6 @@ module Pact.Core.IR.Eval.Runtime.Types
   , EvalCapType(..)) where
 
 
-
 import Data.List.NonEmpty(NonEmpty)
 import GHC.Generics
 import Control.DeepSeq

--- a/pact/Pact/Core/IR/Eval/Runtime/Utils.hs
+++ b/pact/Pact/Core/IR/Eval/Runtime/Utils.hs
@@ -540,4 +540,4 @@ emitPactWarning i pw =
   viewEvalEnv eeWarnings >>= \case
     Nothing -> pure ()
     Just warnRef ->
-      liftIO $ modifyIORef' warnRef (S.insert (Located i pw))
+      liftIO $ modifyIORef' warnRef (pushWarning (Located i pw))

--- a/pact/Pact/Core/IR/Eval/Runtime/Utils.hs
+++ b/pact/Pact/Core/IR/Eval/Runtime/Utils.hs
@@ -54,6 +54,7 @@ module Pact.Core.IR.Eval.Runtime.Utils
  , createEnumerateList
  , guardForModuleCall
  , guardTable
+ , emitPactWarning
  ) where
 
 import Control.Lens hiding (from, to)
@@ -84,6 +85,7 @@ import Pact.Core.Persistence
 import Pact.Core.Environment
 import Pact.Core.DefPacts.Types
 import Pact.Core.Gas
+import Pact.Core.Info
 
 import Pact.Core.Guards
 import Pact.Core.Capabilities
@@ -532,3 +534,10 @@ createEnumerateList info from to inc
     listSize <- sizeOf info SizeOfV0 (max (abs from) (abs to))
     chargeGasArgs info (GMakeList len listSize)
     pure $ V.enumFromStepN from inc (fromIntegral len)
+
+emitPactWarning :: i -> PactWarning -> EvalM e b i ()
+emitPactWarning i pw =
+  viewEvalEnv eeWarnings >>= \case
+    Nothing -> pure ()
+    Just warnRef ->
+      liftIO $ modifyIORef' warnRef (S.insert (Located i pw))

--- a/pact/Pact/Core/Info.hs
+++ b/pact/Pact/Core/Info.hs
@@ -49,10 +49,4 @@ data Located i a
   = Located
   { _locLocation :: i
   , _locElem :: a }
-  deriving (Show, Functor, Foldable, Traversable)
-
-instance (Eq a) => Eq (Located i a) where
-  (Located _ a) == (Located _ a') = a == a'
-
-instance (Ord a) => Ord (Located i a) where
-  compare (Located _ a) (Located _ a') = compare a a'
+  deriving (Show, Eq, Ord, Functor, Foldable, Traversable)

--- a/pact/Pact/Core/Info.hs
+++ b/pact/Pact/Core/Info.hs
@@ -1,10 +1,12 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE DeriveTraversable #-}
 
 module Pact.Core.Info
  ( SpanInfo(..)
  , combineSpan
  , NoInfo(..)
+ , Located(..)
  ) where
 
 import Data.Default
@@ -42,3 +44,15 @@ instance Pretty SpanInfo where
 combineSpan :: SpanInfo -> SpanInfo -> SpanInfo
 combineSpan (SpanInfo l1 c1 _ _) (SpanInfo _ _ l2 c2) =
   SpanInfo l1 c1 l2 c2
+
+data Located i a
+  = Located
+  { _locLocation :: i
+  , _locElem :: a }
+  deriving (Show, Functor, Foldable, Traversable)
+
+instance (Eq a) => Eq (Located i a) where
+  (Located _ a) == (Located _ a') = a == a'
+
+instance (Ord a) => Ord (Located i a) where
+  compare (Located _ a) (Located _ a') = compare a a'

--- a/pact/Pact/Core/Names.hs
+++ b/pact/Pact/Core/Names.hs
@@ -90,9 +90,8 @@ import Data.String (IsString)
 
 -- | Newtype wrapper over bare namespaces
 newtype NamespaceName = NamespaceName { _namespaceName :: Text }
-  deriving (Eq, Ord, Show, Generic)
-
-instance NFData NamespaceName
+  deriving (Generic)
+  deriving newtype (Eq, Ord, Show, NFData)
 
 instance Pretty NamespaceName where
   pretty (NamespaceName n) = pretty n
@@ -113,7 +112,7 @@ instance Pretty ModuleName where
 newtype BareName
   = BareName
   { _bnName :: Text }
-  deriving (Show, Eq, Ord, NFData)
+  deriving newtype (Show, Eq, Ord, NFData)
 
 instance Pretty BareName where
   pretty (BareName b) = pretty b
@@ -318,7 +317,7 @@ data TypeName
 newtype NativeName
   = NativeName
   { _natName :: Text }
-  deriving (Show, Eq, NFData)
+  deriving newtype (Show, Eq, Ord, NFData)
 
 makeLenses ''TypeVar
 makeLenses ''TypeName
@@ -376,7 +375,7 @@ renderFullyQualName (FullyQualifiedName mn n mh) =
 -- | Newtype over text user keys
 newtype RowKey
   = RowKey { _rowKey :: Text }
-  deriving (Eq, Ord, Show, NFData)
+  deriving newtype (Eq, Ord, Show, NFData)
 
 makeLenses ''RowKey
 
@@ -413,7 +412,7 @@ makeLenses ''QualifiedName
 --   parent + the nested continuation
 newtype DefPactId
   = DefPactId { _defPactId :: Text }
-  deriving (Eq,Ord,Show, NFData)
+  deriving newtype (Eq,Ord,Show, NFData)
 
 instance Pretty DefPactId where
   pretty (DefPactId p) = pretty p

--- a/pact/Pact/Core/Syntax/Parser.y
+++ b/pact/Pact/Core/Syntax/Parser.y
@@ -388,9 +388,6 @@ Bool :: { ParsedExpr }
   : true { Constant (LBool True) (_ptInfo $1) }
   | false { Constant (LBool False) (_ptInfo $1) }
 
-BOOLEAN :: { Bool }
-  : true { True }
-  | false { False }
 
 Var :: { ParsedExpr }
   : IDENT '.' ModQual  { Var (QN (mkQualName (getIdent $1) $3)) (combineSpan (_ptInfo $1) (view _3 $3))  }

--- a/profile-tx/ProfileTx.hs
+++ b/profile-tx/ProfileTx.hs
@@ -176,6 +176,7 @@ setupBenchEvalEnv pdb signers mBody = do
     , _eeNamespacePolicy = SimpleNamespacePolicy
     , _eeGasEnv = gasEnv
     , _eeSPVSupport = noSPVSupport
+    , _eeWarnings = Nothing
     }
 
 


### PR DESCRIPTION
This PR reintroduces runtime warnings, being optionally togged on or off, as well as a new warning whenever a module reference is used.

```
pact>(module m g (defcap g () true) (defun some-guard () (create-module-guard "boop")))
Loaded module m, hash OE27e8Ms6lBjXMdlolQQ9NyKJNc_EKEbsa_RjZGkOtY
pact>(some-guard)
Warning: Using deprecated native create-module-guard: Module guards have been deprecated and will be removed in a future release, please switch to capability guards
ModuleGuard {module: m,name: boop}
pact>(enforce-guard (some-guard))
Warning: Using deprecated native create-module-guard: Module guards have been deprecated and will be removed in a future release, please switch to capability guards
Warning: Module guard enforce detected. Module guards are known to be unsafe, and will be removed in a future version of pact
true
pact>
```

In the repl in particular: Warnings are printed after each expression execution and then cleared.

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [x] Benchmark regressions
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
