### PR TITLE
Fix captoken codec, add SigCapability, move Signer to its own module

### DIFF
--- a/pact-tng.cabal
+++ b/pact-tng.cabal
@@ -114,6 +114,7 @@ common pact-common
   default-extensions:
     OverloadedStrings
     DeriveGeneric
+    DerivingStrategies
     ViewPatterns
     LambdaCase
     TupleSections
@@ -257,6 +258,7 @@ library
     Pact.Core.Verifiers
     Pact.Core.Interpreter
     Pact.Core.DeriveConTag
+    Pact.Core.Signer
 
      -- Syntax modules
     Pact.Core.Syntax.ParseTree

--- a/pact/Pact/Core/Capabilities.hs
+++ b/pact/Pact/Core/Capabilities.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE StrictData #-}
 
-
 module Pact.Core.Capabilities
  ( DefCapMeta(..)
  , DefManagedMeta(..)
@@ -21,7 +20,6 @@ module Pact.Core.Capabilities
  , ManagedCapType(..)
  , PactEvent(..)
  , dcMetaFqName
- , Signer(..)
  , getManagedParam
  ) where
 
@@ -36,7 +34,6 @@ import GHC.Generics
 import Pact.Core.Pretty
 import Pact.Core.Names
 import Pact.Core.Hash ( ModuleHash )
-import Pact.Core.Scheme
 
 data DefManagedMeta name
   = DefManagedMeta (Int, Text) name
@@ -132,24 +129,13 @@ makeLenses ''CapToken
 makeLenses ''CapSlot
 makeLenses ''ManagedCap
 
--- | Signer combines PPKScheme, PublicKey, and the Address (aka the
---   formatted PublicKey).
-data Signer name v = Signer
- { _siScheme :: !(Maybe PPKScheme)
- -- ^ PPKScheme, which is defaulted to 'defPPKScheme' if not present
- , _siPubKey :: !Text
- -- ^ pub key value
- , _siAddress :: !(Maybe Text)
- -- ^ optional "address", for different pub key formats like ETH
- , _siCapList :: [CapToken name v]
- -- ^ clist for designating signature to specific caps
- } deriving (Eq, Ord, Show, Generic)
+
 
 instance (Pretty name, Pretty v) => Pretty (CapToken name v) where
   pretty (CapToken qn args) =
     pretty $ PrettyLispApp qn args
 
-instance (NFData name, NFData v) => NFData (Signer name v)
+
 instance (NFData name, NFData v) => NFData (ManagedCap name v)
 instance NFData v => NFData (ManagedCapType v)
 instance NFData v => NFData (PactEvent v)

--- a/pact/Pact/Core/Evaluate.hs
+++ b/pact/Pact/Core/Evaluate.hs
@@ -60,6 +60,7 @@ import Pact.Core.IR.Desugar
 import Pact.Core.Verifiers
 import Pact.Core.Interpreter
 import Pact.Core.Info
+import Pact.Core.Signer
 import qualified Pact.Core.IR.Eval.CEK as Eval
 import qualified Pact.Core.IR.Eval.Direct.Evaluator as Direct
 import qualified Pact.Core.Syntax.Lexer as Lisp
@@ -102,7 +103,7 @@ evalDirectInterpreter =
 data MsgData = MsgData
   { mdData :: !PactValue
   , mdHash :: !Hash
-  , mdSigners :: [Signer QualifiedName PactValue]
+  , mdSigners :: [Signer]
   , mdVerifiers :: [Verifier ()]
   }
 
@@ -178,7 +179,7 @@ setupEvalEnv pdb mode msgData gasModel' np spv pd efs = do
   mkMsgSigs ss = M.fromList $ map toPair ss
     where
     toPair (Signer _scheme pubK addr capList) =
-      (PublicKeyText (fromMaybe pubK addr),S.fromList capList)
+      (PublicKeyText (fromMaybe pubK addr),S.fromList (_sigCapability <$> capList))
   mkMsgVerifiers vs = M.fromListWith S.union $ map toPair vs
     where
     toPair (Verifier vfn _ caps) = (vfn, S.fromList caps)

--- a/pact/Pact/Core/PactValue.hs
+++ b/pact/Pact/Core/PactValue.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE StrictData #-}
+{-# LANGUAGE DerivingStrategies #-}
 
 
 module Pact.Core.PactValue
@@ -150,7 +151,6 @@ checkPvType ty = \case
     _ -> False
   PCapToken _ -> False
   PTime _ -> ty == TyTime
-
 
 
 newtype ObjectData term

--- a/pact/Pact/Core/Signer.hs
+++ b/pact/Pact/Core/Signer.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Pact.Core.Signer
+ ( SigCapability(..)
+ , Signer(..) )
+ where
+
+import Data.Text(Text)
+import Control.DeepSeq
+import GHC.Generics
+import Data.Maybe(fromMaybe)
+
+import Pact.Core.Capabilities
+import Pact.Core.PactValue
+import Pact.Core.Names
+import Pact.Core.Scheme
+import Pact.Core.StableEncoding
+
+import qualified Pact.JSON.Encode as J
+import qualified Pact.JSON.Decode as JD
+
+
+-- | Type corresponding to user-facing capabilities
+--
+newtype SigCapability
+  = SigCapability { _sigCapability :: CapToken QualifiedName PactValue }
+  deriving newtype (Eq, Ord, Show, NFData)
+
+-- | Signer combines PPKScheme, PublicKey, and the Address (aka the
+--   formatted PublicKey).
+data Signer = Signer
+ { _siScheme :: !(Maybe PPKScheme)
+ -- ^ PPKScheme, which is defaulted to 'defPPKScheme' if not present
+ , _siPubKey :: !Text
+ -- ^ pub key value
+ , _siAddress :: !(Maybe Text)
+ -- ^ optional "address", for different pub key formats like ETH
+ , _siCapList :: [SigCapability]
+ -- ^ clist for designating signature to specific caps
+ } deriving (Eq, Ord, Show, Generic)
+
+instance NFData Signer
+
+instance J.Encode SigCapability where
+  build (SigCapability (CapToken name args)) = J.object
+    [ "name" J..= J.build (StableEncoding name)
+    , "args" J..= J.build (J.Array (StableEncoding <$> args))
+    ]
+
+instance JD.FromJSON SigCapability where
+  parseJSON = JD.withObject "SigCapability" $ \o -> do
+    name <- o JD..: "name"
+    args <- o JD..: "args"
+    pure $ SigCapability $ CapToken (_stableEncoding name) (_stableEncoding <$> args)
+
+
+instance J.Encode Signer where
+  build o = J.object
+    [ "addr" J..?= _siAddress o
+    , "scheme" J..?= _siScheme o
+    , "pubKey" J..= _siPubKey o
+    , "clist" J..??= J.Array (_siCapList o)
+    ]
+
+instance JD.FromJSON Signer where
+  parseJSON = JD.withObject "Signer" $ \o -> do
+    scheme <- o JD..:? "scheme"
+    pubKey <- o JD..: "pubKey"
+    addr <- o JD..:? "addr"
+    clist <- fromMaybe [] <$> o JD..:? "clist"
+    pure $ Signer scheme pubKey addr clist


### PR DESCRIPTION
This PR moves `Signer` into its own module, as it isn't really used outside of the chainweb and request API.

Moreover: I am adding a `SigCapability` newtype, that essentially has a fixed json codec for the sake of both chainweb, as well as testing.

The changes here are mostly a refactoring, so it's covered by previous tests for signers. That said: in fixing the codec of `ModuleGuard`, I realize we definitely need a golden test for stable encoding. This will be done by @rsoeldner 

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [x] Benchmark regressions
Doesn't impact perf
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
