### PR TITLE
Integration: Enforce ordering on txlogs

### DIFF
--- a/pact/Pact/Core/Persistence/MockPersistence.hs
+++ b/pact/Pact/Core/Persistence/MockPersistence.hs
@@ -164,7 +164,7 @@ mockPactDb serial = do
         writeIORef ptRollbackState Nothing
         txId <- atomicModifyIORef' ptTxId (\(TxId i) -> (TxId (succ i), TxId i))
         txLogQueue <- readIORef ptTxLogQueue
-        pure (M.findWithDefault [] txId txLogQueue)
+        pure $ reverse $ M.findWithDefault [] txId txLogQueue
       Local -> do
         -- in local, we simply roll back all tables
         -- then and return the logs, then roll back the logs table
@@ -375,4 +375,4 @@ rightToMaybe = \case
 record :: PactTables b i -> TxLog ByteString -> IO ()
 record PactTables{..} entry = do
   txIdNow <- readIORef ptTxId
-  modifyIORef ptTxLogQueue $ \txMap -> M.insertWith (<>) txIdNow [entry] txMap
+  modifyIORef ptTxLogQueue (M.insertWith (<>) txIdNow [entry])

--- a/pact/Pact/Core/Persistence/SQLite.hs
+++ b/pact/Pact/Core/Persistence/SQLite.hs
@@ -209,7 +209,8 @@ commitTx :: IORef TxId -> SQL.Database -> IORef [TxLog ByteString] -> IO [TxLog 
 commitTx txid db txLog = do
   _ <- atomicModifyIORef' txid (\old@(TxId n) -> (TxId (succ n), old))
   SQL.exec db "COMMIT TRANSACTION"
-  readIORef txLog
+  txls <- atomicModifyIORef' txLog ([],)
+  pure $ reverse txls
 
 beginTx :: IORef TxId -> SQL.Database -> IORef [TxLog ByteString] -> ExecutionMode -> IO (Maybe TxId)
 beginTx txid db txLog em = do


### PR DESCRIPTION
Updating the txlog regression to enforce that txlogs are output in insertion order.

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [x] Benchmark regressions
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
