### PR TITLE
Fix verifier codec

### DIFF
--- a/pact/Pact/Core/Evaluate.hs
+++ b/pact/Pact/Core/Evaluate.hs
@@ -183,7 +183,7 @@ setupEvalEnv pdb mode msgData gasModel' np spv pd efs = do
       (PublicKeyText (fromMaybe pubK addr),S.fromList (_sigCapability <$> capList))
   mkMsgVerifiers vs = M.fromListWith S.union $ map toPair vs
     where
-    toPair (Verifier vfn _ caps) = (vfn, S.fromList caps)
+    toPair (Verifier vfn _ caps) = (vfn, S.fromList (_sigCapability <$> caps))
 
 evalExec
   :: ExecutionMode -> PactDb CoreBuiltin Info -> SPVSupport -> GasModel CoreBuiltin -> Set ExecutionFlag -> NamespacePolicy


### PR DESCRIPTION
#210 unintentionally broke a codec chainweb depends on. This PR fixes the signer codec + adds roundtrip tests

PR checklist:

* [ ] Test coverage for the proposed changes
* [ ] PR description contains example output from repl interaction or a snippet from unit test output
* [ ] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [ ] Benchmark regressions
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
