### PR TITLE
Integration: Fix PactEvent Codec, add LegacyPactError and Compat types

### DIFF
--- a/pact-request-api/Pact/Core/Command/Types.hs
+++ b/pact-request-api/Pact/Core/Command/Types.hs
@@ -302,13 +302,13 @@ data CommandResult log err = CommandResult {
 
 instance (J.Encode l, J.Encode err) => J.Encode (CommandResult l err) where
   build o = J.object
-    [ "gas" J..= A.Number (fromIntegral (_gas (_crGas o)) )
+    [ "gas" J..= J.Aeson (_gas (_crGas o))
     , "result" J..= _crResult o
     , "reqKey" J..= _crReqKey o
     , "logs" J..= _crLogs o
     , "events" J..??= J.Array (StableEncoding <$> _crEvents o)
     , "metaData" J..= _crMetaData o
-    , "continuation" J..=  fmap StableEncoding (_crContinuation o)
+    , "continuation" J..= fmap StableEncoding (_crContinuation o)
     , "txId" J..= fmap (A.Number . fromIntegral . _txId) (_crTxId o)
     ]
   {-# INLINE build #-}

--- a/pact-tests/Pact/Core/Test/JSONRoundtripTests.hs
+++ b/pact-tests/Pact/Core/Test/JSONRoundtripTests.hs
@@ -62,6 +62,7 @@ tests = testGroup "JSON Roundtrips" $ stableEncodings ++ jsonRoundtrips
     , StableEncodingCase defPactExecGen
     , StableEncodingCase namespaceGen
     , StableEncodingCase pactEventGen
+    , StableEncodingCase spanInfoGen
     ]
   jsonRoundtrips = fmap testJSONRoundtrip $
     [ EncodingCase signerGen

--- a/pact-tests/Pact/Core/Test/JSONRoundtripTests.hs
+++ b/pact-tests/Pact/Core/Test/JSONRoundtripTests.hs
@@ -61,6 +61,7 @@ tests = testGroup "JSON Roundtrips" $ stableEncodings ++ jsonRoundtrips
     , StableEncodingCase rowDataGen
     , StableEncodingCase defPactExecGen
     , StableEncodingCase namespaceGen
+    , StableEncodingCase pactEventGen
     ]
   jsonRoundtrips = fmap testJSONRoundtrip $
     [ EncodingCase signerGen

--- a/pact/Pact/Core/Hash.hs
+++ b/pact/Pact/Core/Hash.hs
@@ -50,12 +50,13 @@ import GHC.Generics
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Base64.URL as B64URL
 import qualified Data.Text.Encoding as T
+import qualified Pact.JSON.Encode as J
+import qualified Pact.JSON.Decode as JD
 
 import qualified Data.ByteArray as ByteArray
 import qualified Crypto.Hash as Crypto
 
 import Pact.Core.Pretty ( renderCompactString, Pretty(pretty) )
-import qualified Pact.JSON.Encode as J
 
 -- | Untyped hash value, encoded with unpadded base64url.
 -- Within Pact these are blake2b_256 but unvalidated as such,
@@ -159,7 +160,7 @@ fromB64UrlUnpaddedText bs = case decodeBase64UrlUnpadded bs of
 
 newtype ModuleHash = ModuleHash { _mhHash :: Hash }
   deriving (Eq, Ord, Show, Generic)
-  deriving newtype (NFData)
+  deriving newtype (NFData, J.Encode, JD.FromJSON)
 
 instance Pretty ModuleHash where
   pretty (ModuleHash h) = pretty h

--- a/pact/Pact/Core/Info.hs
+++ b/pact/Pact/Core/Info.hs
@@ -39,6 +39,8 @@ instance Pretty SpanInfo where
     pretty _liStartLine <> ":" <> pretty _liStartColumn
     <> "-" <> pretty _liEndLine <> ":" <> pretty _liEndColumn
 
+    
+
 -- | Combine two Span infos
 --   and spit out how far down the expression spans.
 combineSpan :: SpanInfo -> SpanInfo -> SpanInfo

--- a/pact/Pact/Core/StableEncoding.hs
+++ b/pact/Pact/Core/StableEncoding.hs
@@ -513,10 +513,10 @@ instance J.Encode (StableEncoding (DefPactContinuation QualifiedName PactValue))
 
 instance J.Encode (StableEncoding (PactEvent PactValue)) where
   build (StableEncoding (PactEvent name args modName (ModuleHash modHash))) = J.object
-    [ "name" J..= name
-    , "args" J..= J.Array (StableEncoding <$> args)
+    [ "params" J..= J.Array (StableEncoding <$> args)
+    , "name" J..= name
     , "module" J..= StableEncoding modName
-    , "moduleHash" J..= hashToText modHash
+    , "moduleHash" J..= modHash
     ]
   {-# INLINABLE build #-}
 
@@ -532,7 +532,7 @@ instance JD.FromJSON (StableEncoding ModuleHash) where
 instance JD.FromJSON (StableEncoding (PactEvent PactValue)) where
   parseJSON = JD.withObject "PactEvent" $ \o -> do
     name <- o JD..: "name"
-    args <- o JD..: "args"
+    args <- o JD..: "params"
     modName <- o JD..: "module"
     modHash <- o JD..: "moduleHash"
     pure $ StableEncoding (PactEvent name (fmap _stableEncoding args) (_stableEncoding modName) (_stableEncoding modHash))

--- a/pact/Pact/Core/StableEncoding.hs
+++ b/pact/Pact/Core/StableEncoding.hs
@@ -537,6 +537,14 @@ instance JD.FromJSON (StableEncoding (PactEvent PactValue)) where
     modHash <- o JD..: "moduleHash"
     pure $ StableEncoding (PactEvent name (fmap _stableEncoding args) (_stableEncoding modName) (_stableEncoding modHash))
 
+instance J.Encode (StableEncoding SpanInfo) where
+  build (StableEncoding si) = J.object
+    [ "startLine" J..= J.Aeson (_liStartLine si)
+    , "endLine" J..= J.Aeson (_liEndLine si)
+    , "startColumn" J..= J.Aeson (_liStartColumn si)
+    , "endColumn" J..= J.Aeson (_liEndColumn si)
+    ]
+
 instance JD.FromJSON (StableEncoding SpanInfo) where
   parseJSON = JD.withObject "SpanInfo" $ \o -> do
     startLine <- o JD..: "startLine"

--- a/test-utils/Pact/Core/Gen.hs
+++ b/test-utils/Pact/Core/Gen.hs
@@ -26,7 +26,7 @@ import Pact.Core.Guards
 import Pact.Core.Type
 import Pact.Core.Imports (Import(..))
 import Pact.Core.IR.Term
-import Pact.Core.Info (SpanInfo)
+import Pact.Core.Info
 import Pact.Core.Builtin
 import Pact.Core.Literal
 import Pact.Core.Capabilities
@@ -75,6 +75,14 @@ signerGen =
     <*> Gen.list (Range.linear 0 10) sigCapabilityGen
   where
   addrGen = Gen.text (Range.singleton 64) Gen.alphaNum
+
+spanInfoGen :: Gen SpanInfo
+spanInfoGen =
+  SpanInfo
+    <$> Gen.integral Range.constantBounded
+    <*> Gen.integral Range.constantBounded
+    <*> Gen.integral Range.constantBounded
+    <*> Gen.integral Range.constantBounded
 
 capTokenGen :: Gen name -> Gen v -> Gen (CapToken name v)
 capTokenGen n v =

--- a/test-utils/Pact/Core/Gen.hs
+++ b/test-utils/Pact/Core/Gen.hs
@@ -396,7 +396,7 @@ evalInterfaceGen :: Gen b -> Gen i -> Gen (EvalInterface b i)
 evalInterfaceGen b i = do
   name <- moduleNameGen
   defs <- Gen.list (Range.linear 0 100) (ifDefGen b i)
-  imports <- Gen.list (Range.linear 0 100) (importGen )
+  imports <- Gen.list (Range.linear 0 100) importGen
   h <- moduleHashGen
   Interface name defs imports h (Hash mempty) <$> i
 
@@ -565,3 +565,11 @@ identGen = do
 
 rowDataGen :: Gen RowData
 rowDataGen = RowData <$> Gen.map (Range.linear 0 4) ((,) <$> fieldGen <*> pactValueGen)
+
+pactEventGen :: Gen (PactEvent PactValue)
+pactEventGen =
+  PactEvent
+    <$> identGen
+    <*> Gen.list (Range.constant 0 5) pactValueGen
+    <*> moduleNameGen
+    <*> moduleHashGen


### PR DESCRIPTION
PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
```
JSON roundtrips for StableEncoding: "PactEvent PactValue":                                                          OK (0.02s)
        ✓ <interactive> passed 100 tests.
```
* [x] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [x] Benchmark regressions
N/A
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
