### PR TITLE
Integration: Add legacy pact id support

### DIFF
--- a/pact/Pact/Core/Names.hs
+++ b/pact/Pact/Core/Names.hs
@@ -65,6 +65,8 @@ module Pact.Core.Names
  , parseQualifiedName
  , parseFullyQualifiedName
  , VerifierName(..)
+ , LegacyDefPactId(..)
+ , renderLegacyDefpactId
  ) where
 
 import Control.Lens
@@ -419,6 +421,10 @@ instance Pretty DefPactId where
 
 type Parser = MP.Parsec () Text
 
+newtype LegacyDefPactId
+  = LegacyDefPactId { _unLegacyDefpactId :: DefPactId }
+  deriving (Eq, Ord, Show, NFData)
+
 identParser :: Parser Text
 identParser = do
   c1 <- MP.letterChar <|> MP.oneOf specials
@@ -515,6 +521,15 @@ renderDefPactId (DefPactId t) = t
 renderParsedTyName :: ParsedTyName -> Text
 renderParsedTyName (TBN (BareName n)) = n
 renderParsedTyName (TQN qn) = renderQualName qn
+
+-- | Legacy hack.
+--   Turns out many years ago, we used the `show` instance,
+--   for pact Ids. Turns out, this actually resulted in all pact ID's having
+--   db entries such as `PactId "<hash>"`. This makes it explicit.
+--   It was clobbered.
+renderLegacyDefpactId :: LegacyDefPactId -> Text
+renderLegacyDefpactId (LegacyDefPactId t) =
+  "PactId \"" <> renderDefPactId t <> "\""
 
 newtype VerifierName = VerifierName Text
   deriving newtype (J.Encode, NFData, Eq, Show, Ord, FromJSON)


### PR DESCRIPTION
This is to support previously clobbered pact ids, where the `show` instance was used for the key. This bleeds over to chainweb.

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [x] Benchmark regressions
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
