### PR TITLE
Generic/type-bound data types disappeared from the text

### DIFF
--- a/docs/builtins/General/compose.md
+++ b/docs/builtins/General/compose.md
@@ -3,7 +3,7 @@
 Use `compose` to compose functions where `oper1` performs an operation using the specified `value` and `oper2` takes the results from `oper1` as input to produce the result for the composed function.
 
 You can use any data type for the `value` argument as long as the first `oper1` functions can take that same data type.
-By convention, the data type <a> is used to represent a type-bound parameter like the `value` argument in this function.
+By convention, the data type ```<a>``` is used to represent a type-bound parameter like the `value` argument in this function.
 
 ### Basic syntax
 
@@ -19,9 +19,9 @@ Use the following arguments to specify the functions `oper1` and `oper2` for com
 
 | Argument | Type | Description |
 | --- | --- | --- |
-| `oper1` | function: <a> -> <b> | Specifies the first function to operate on the specified `value` and return a result to provide input to the second function. |
-| `oper2` | function: <b> -> <c> | Specifies the second function to operate on the results of the `oper1` function. |
-| `value` | <a> | Specifies the value on which `oper1` operates. |
+| `oper1` | function: `<a>` -> `<b>` | Specifies the first function to operate on the specified `value` and return a result to provide input to the second function. |
+| `oper2` | function: `<b>` -> <c> | Specifies the second function to operate on the results of the `oper1` function. |
+| `value` | `<a>` | Specifies the value on which `oper1` operates. |
 
 ### Return values
 

--- a/docs/builtins/General/fold.md
+++ b/docs/builtins/General/fold.md
@@ -3,7 +3,7 @@
 Use `fold` to iteratively reduce a list by applying the `app` function to the last result for each element in the list, starting with the specified `init` initial value.
 
 You can use any data type for the `value` argument as long as the first `oper1` functions can take that same data type.
-By convention, data type notation like <a> and <b> are used to represent  type-bound parameters like the `init` and `list` arguments in this function.
+By convention, data type notation like `<a>` and `<b>` are used to represent  type-bound parameters like the `init` and `list` arguments in this function.
 
 ### Basic syntax
 
@@ -19,9 +19,9 @@ Use the following arguments to specify the function, initial value, and list for
 
 | Argument | Type       | Description                                       |
 |----------|------------|---------------------------------------------------|
-| `app` | function x:<a> y:<b> -> <a>` | Specifies the function to apply to each element and the last result. |
-| `init` | <a> | Specifies the initial value for the reduction. |
-| `list` | [<b>] | Specifies the list to iterate over.               |
+| `app` | function x:`<a>` y:`<b>` -> `<a>`` | Specifies the function to apply to each element and the last result. |
+| `init` | `<a>` | Specifies the initial value for the reduction. |
+| `list` | [`<b>`] | Specifies the list to iterate over.               |
 
 ### Return values
 

--- a/docs/builtins/General/hash.md
+++ b/docs/builtins/General/hash.md
@@ -4,7 +4,7 @@ Use `hash` to compute the BLAKE2b 256-bit hash of a specified `value`. The resul
 Strings values are converted directly.
 Other data type values are converted using their JSON representation. Non-value-level arguments are not allowed.
 
-By convention, the data type <a> is used to represent a type-bound parameter like the `value` argument in this function.
+By convention, the data type `<a>` is used to represent a type-bound parameter like the `value` argument in this function.
 
 ### Basic syntax
 
@@ -20,7 +20,7 @@ Use the following argument to specify the value for the `hash` Pact function:
 
 | Argument  | Type   | Description |
 |-----------|--------|-------------|
-| `value` | <a> | Specifies the value to be hashed. |
+| `value` | `<a>` | Specifies the value to be hashed. |
 
 ### Return values
 

--- a/docs/builtins/General/if.md
+++ b/docs/builtins/General/if.md
@@ -2,7 +2,7 @@
 
 Use `if` to test a condition. If the condition `cond` is true, evaluate the `then` expression; otherwise, evaluate the `else` expression.
 
-By convention, the data type <a> is used to represent type-bound parameters that serve as input for functions and expressions or for generic arguments.
+By convention, the data type `<a>` is used to represent type-bound parameters that serve as input for functions and expressions or for generic arguments.
 
 ### Basic syntax
 
@@ -19,8 +19,8 @@ Use the following arguments to define the condition and expressions to be evalua
 | Argument | Type | Description |
 | --- | --- | --- |
 | `cond` | boolean | Specifies the condition to be tested. |
-| `then` | <a> | Specifies the expression to be evaluated if the condition is true. |
-| `else` | <a> | Specifies the expression to be evaluated if the condition is false. |
+| `then` | `<a>` | Specifies the expression to be evaluated if the condition is true. |
+| `else` | `<a>` | Specifies the expression to be evaluated if the condition is false. |
 
 ### Return value
 

--- a/docs/builtins/General/map.md
+++ b/docs/builtins/General/map.md
@@ -3,7 +3,7 @@
 Use `map` to apply an application function (`app`) to each element in a list (`list`), returning a new list of results.
 
 You can use any data type for the `list` argument as long as the first `app` function can take that same data type.
-By convention, data type notation like <a> and <b> are used to represent type-bound parameters that serve as input for functions and expressions or for generic arguments.
+By convention, data type notation like `<a>` and `<b>` are used to represent type-bound parameters that serve as input for functions and expressions or for generic arguments.
 
 ### Basic syntax
 
@@ -19,8 +19,8 @@ Use the following arguments to specify the application function and the list of 
 
 | Argument | Type | Description |
 | --- | --- | --- |
-| `app` | function x:<b> -> <a> | Specifies the application function to be applied to each element in the list. |
-| `list` | [<b>] | Specifies the list of elements to be mapped. |
+| `app` | function x:`<b>` -> `<a>` | Specifies the application function to be applied to each element in the list. |
+| `list` | [`<b>`] | Specifies the list of elements to be mapped. |
 
 ### Return value
 

--- a/docs/builtins/Operators/and-q.md
+++ b/docs/builtins/Operators/and-q.md
@@ -4,9 +4,9 @@ Use `and?` to apply a logical AND operation to the results of applying a specifi
 
 You can use any data type for the `value` argument as long as the two functions take that same data type and return the resulting boolean value for the logical AND operation performed by the `and?` function.
 
-By convention, the data type <a> is used if an argument represents a type-bound parameter like the `value` argument in this function: 
+By convention, the data type `<a>` is used if an argument represents a type-bound parameter like the `value` argument in this function: 
 
-(defun logicalAnd and?:bool (func1:(<a> -> bool) func2:(<a> -> bool) value:<a>))
+(defun logicalAnd and?:bool (func1:(`<a>` -> bool) func2:(`<a>` -> bool) value:`<a>`))
 
 ### Basic syntax
 
@@ -22,9 +22,9 @@ Use the following arguments to specify the functions and `value` for the `and?` 
 
 | Argument | Type | Description |
 | --- | --- | --- |
-| `func1` | function x:<a> -> bool | Specifies the first function to apply the specified `value` to. The result of applying the specified value of type `<a>` returns a boolean value. |
-| `func2` | function x:<a> -> bool | Specifies the second function to apply the specified `value` to. The result of applying the specified value of type `<a>` returns a boolean value.|
-| `value` | <a> | Specifies the value to apply to both `func1` and `func2` functions. |
+| `func1` | function x:`<a>` -> bool | Specifies the first function to apply the specified `value` to. The result of applying the specified value of type ``<a>`` returns a boolean value. |
+| `func2` | function x:`<a>` -> bool | Specifies the second function to apply the specified `value` to. The result of applying the specified value of type ``<a>`` returns a boolean value.|
+| `value` | `<a>` | Specifies the value to apply to both `func1` and `func2` functions. |
 
 ### Return values
 

--- a/docs/builtins/Operators/not-q.md
+++ b/docs/builtins/Operators/not-q.md
@@ -4,7 +4,7 @@ Use `not?` to apply a logical NOT operation to the results of applying a specifi
 
 You can use any data type for the `value` argument as long as the `app` function takes that same data type and returns the resulting boolean value for the logical NOT operation performed by the `not?` function.
 
-By convention, the data type <a> is used if an argument represents a type-bound parameter like the `value` argument in this function: 
+By convention, the data type `<a>` is used if an argument represents a type-bound parameter like the `value` argument in this function: 
 
 ### Basic syntax
 
@@ -20,8 +20,8 @@ Use the following arguments to specify the application function and the value to
 
 | Argument | Type | Description |
 | --- | --- | --- |
-| `app` | function x:<a> -> bool | Specifies the application function to apply the specified `value` to. The result of applying the specified value returns a boolean value. |
-| `value` | <a> | Specifies the value to be applied to the application function. |
+| `app` | function x:`<a>` -> bool | Specifies the application function to apply the specified `value` to. The result of applying the specified value returns a boolean value. |
+| `value` | `<a>` | Specifies the value to be applied to the application function. |
 
 ### Return value
 

--- a/docs/builtins/Operators/or-q.md
+++ b/docs/builtins/Operators/or-q.md
@@ -4,7 +4,7 @@ Use `or?` to apply a logical OR operation to the results of applying a specified
 
 You can use any data type for the `value` argument as long as the two functions take that same data type and return the resulting boolean value for the logical OR operation performed by the `or?` function.
 
-By convention, the data type <a> is used if an argument represents a type-bound parameter like the `value` argument in this function. 
+By convention, the data type `<a>` is used if an argument represents a type-bound parameter like the `value` argument in this function. 
 
 ### Basic syntax
 
@@ -20,9 +20,9 @@ Use the following arguments to specify the functions and the `value` to be appli
 
 | Argument | Type | Description |
 | --- | --- | --- |
-| `func1` | function x:<a> -> bool | Specifies the first function to apply the specified `value` to. The result of applying the specified value returns a boolean value. |
-| `func2` | function x:<a> -> bool | Specifies the second function to apply the specified `value` to. The result of applying the specified value returns a boolean value.|
-| `value` | <a> | Specifies the value to apply to both `func1` and `func2` functions. |
+| `func1` | function x:`<a>` -> bool | Specifies the first function to apply the specified `value` to. The result of applying the specified value returns a boolean value. |
+| `func2` | function x:`<a>` -> bool | Specifies the second function to apply the specified `value` to. The result of applying the specified value returns a boolean value.|
+| `value` | `<a>` | Specifies the value to apply to both `func1` and `func2` functions. |
 
 ### Return value
 

--- a/docs/builtins/Repl/expect-that.md
+++ b/docs/builtins/Repl/expect-that.md
@@ -3,7 +3,7 @@
 Use `expect-that` to evaluate an expression and succeed if the resulting value passes a predicate function.
 
 You can use any data type for the `exp` argument as long as the `pred` function can take that same data type and return the resulting boolean value .
-By convention, the data type <a> is used to represent type-bound parameters that serve as input for functions and expressions or for generic arguments.
+By convention, the data type `<a>` is used to represent type-bound parameters that serve as input for functions and expressions or for generic arguments.
 
 ### Basic syntax
 
@@ -20,8 +20,8 @@ Use the following arguments when using the `expect-that` Pact function.
 | Argument | Type | Description |
 |----------|------|-------------|
 | `doc` | string | Specifies the documentation string describing the expectation. |
-| `pred` | value:<a> -> bool | Specifies the predicate function that takes the result of `exp` and returns a boolean. |
-| `exp` | <a> | Specifies the expression to evaluate. The expression can be of any Pact type.          |
+| `pred` | value:`<a>` -> bool | Specifies the predicate function that takes the result of `exp` and returns a boolean. |
+| `exp` | `<a>` | Specifies the expression to evaluate. The expression can be of any Pact type.          |
 
 ### Return value
 


### PR DESCRIPTION
PR checklist:

* [ ] Test coverage for the proposed changes
* [ ] PR description contains example output from repl interaction or a snippet from unit test output
* [ ] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [ ] Benchmark regressions
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
