### PR TITLE
Bugfix: Fix sqlite pact db keys implementation, add regression

### DIFF
--- a/pact-tests/pact-tests/db.repl
+++ b/pact-tests/pact-tests/db.repl
@@ -234,3 +234,45 @@
   [["a" 1] ["b" 2]]
   (fold-db fdb-tbl (lambda (k o)  (< k "c")) (lambda (k o) [k (at 'a o)]))
   )
+
+; Ensure keys is distinct
+; Due to the increasing nature of TXIDs and table entries, what we need to actually check is that
+; if we update keys in different transactions, keys returns only distinct keys in
+; TXIDs
+(begin-tx)
+(module m g (defcap g () true)
+(defschema sc a:integer b:integer)
+(deftable tbl:{sc})
+
+(defun add-elem(a:integer k:string)
+  (write tbl k {"a":a, "b":a})
+)
+
+(defun update-elem(a:integer k:string)
+  (update tbl k {"a":a})
+)
+
+(defun all-elems()
+  (fold-db tbl (lambda (x y) true) (lambda (k o) {"key":k, "value":o}))
+)
+)
+(create-table tbl)
+(commit-tx)
+
+; Add two entries
+(begin-tx)
+(m.add-elem 1 "jose")
+(m.add-elem 1 "robert")
+(commit-tx)
+
+(begin-tx)
+(m.update-elem 2 "jose")
+(m.update-elem 3 "robert")
+(commit-tx)
+
+(begin-tx)
+(expect "All-elems return distinct objects"
+  [ {"key": "jose","value": {"a": 2,"b": 1}}
+  , {"key": "robert","value": {"a": 3,"b": 1}} ]
+  (m.all-elems))
+(commit-tx)

--- a/pact/Pact/Core/Persistence/SQLite.hs
+++ b/pact/Pact/Core/Persistence/SQLite.hs
@@ -141,7 +141,7 @@ mkTblStatement db tbl = do
     insertStmt <- SQL.prepare db ("INSERT INTO \"" <> tbl <> "\" (txid, rowkey, rowdata) VALUES (?,?,?)")
     insertOrUpdateStmt <- SQL.prepare db ("INSERT OR REPLACE INTO \"" <> tbl <> "\" (txid, rowkey, rowdata) VALUES (?,?,?)")
     readValueStmt <- SQL.prepare db ("SELECT rowdata FROM \""<> tbl <> "\" WHERE rowkey = ? ORDER BY txid DESC LIMIT 1")
-    readKeysStmt <-  SQL.prepare db ("SELECT rowkey FROM \""<> tbl <> "\" ORDER BY txid DESC")
+    readKeysStmt <-  SQL.prepare db ("SELECT DISTINCT rowkey FROM \""<> tbl <> "\" ORDER BY rowkey DESC")
     pure $ TblStatements insertStmt insertOrUpdateStmt readValueStmt readKeysStmt
 
 addUserTable :: SQL.Database -> IORef StmtCache -> TableName -> IO TblStatements


### PR DESCRIPTION
The following test, prior to this PR, fails on the sqlite pact db (but works fine for in-memory):
```
(begin-tx)
(module m g (defcap g () true)
(defschema sc a:integer b:integer)
(deftable tbl:{sc})

(defun add-elem(a:integer k:string)
  (write tbl k {"a":a, "b":a})
)

(defun update-elem(a:integer k:string)
  (update tbl k {"a":a})
)

(defun all-elems()
  (fold-db tbl (lambda (x y) true) (lambda (k o) {"key":k, "value":o}))
)
)
(create-table tbl)
(commit-tx)

; Add two entries
(begin-tx)
(m.add-elem 1 "jose")
(m.add-elem 1 "robert")
(commit-tx)

(begin-tx)
(m.update-elem 2 "jose")
(m.update-elem 3 "robert")
(commit-tx)

(begin-tx)
(expect "All-elems return distinct objects"
  [ {"key": "jose","value": {"a": 2,"b": 1}}
  , {"key": "robert","value": {"a": 3,"b": 1}} ]
  (m.all-elems))
(commit-tx)
```

This PR fixes this behavior. The `keys` method in the sqlite pact db was not calling `DISTINCT` on the entries. 

Thanks @salamaashoush for the report!! This was found via the pact -s

PR checklist:

* [x] Test coverage for the proposed changes
- Changes added to `db.repl`
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [ ] Benchmark regressions
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
