### PR TITLE
fix tarball file permissions to allow  write access for tarball extractor

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -44,10 +44,25 @@ jobs:
 
         echo Build the bundle
         nix build .#pact-binary-bundle --log-lines 500 --show-trace --out-link pact-binary-bundle --accept-flake-config
-        tar -zcvf pact-binary-bundle.${{ matrix.os }}.tar.gz $(readlink pact-binary-bundle)
 
         #echo Build the recursive output
         #nix build .#recursive.allDerivations --log-lines 500 --show-trace --accept-flake-config
+    - name: Prepare artifacts with adjusted permissions
+      run: |
+        # Resolve the actual path of the output
+        BUNDLE_PATH=$(readlink pact-binary-bundle)
+        
+        # Create a temporary directory for copying
+        mkdir bundle_copy
+        
+        # Copy the contents to the temporary directory
+        cp -r "$BUNDLE_PATH"/* bundle_copy/
+        
+        # Change permissions to make all files writable by the user and group
+        chmod -R ug+w bundle_copy/
+        
+        echo "Creating tarball with adjusted permissions..."
+        tar -zcvf pact-binary-bundle.${{ matrix.os }}.tar.gz -C bundle_copy/ .
 
     - name: Publish the bundle
       uses: actions/upload-artifact@v4

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -71,10 +71,11 @@ jobs:
         path: pact-binary-bundle
         retention-days: 5
 
-    # - name: Release latest build
-    #   uses: ncipollo/release-action@v1.14.0
-    #   with:
-    #     artifacts: pact-binary-bundle.${{ matrix.os }}.tar.gz
-    #     tag: development-latest
-    #     replacesArtifacts: true
-    #     allowUpdates: true
+      #    - name: Release latest build
+      #      if: github.ref == 'refs/heads/master'
+      #      uses: ncipollo/release-action@v1.14.0
+      #      with:
+      #        artifacts: pact-binary-bundle.${{ matrix.os }}.tar.gz
+      #        tag: nightly 
+      #        replacesArtifacts: true
+      #        allowUpdates: true

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -122,8 +122,8 @@ jobs:
           UBUNTU_TAR=pact.${{ env.GHC_VERSION }}.ubuntu-22.04.${{ env.RELEASE_SHA }}.tar.gz
           MACOS_TAR=pact.${{ env.GHC_VERSION }}.macos-14.${{ env.RELEASE_SHA }}.tar.gz
           
-          UBUNTU_RELEASE_FILE=pact-${{ env.RELEASE_VERSION }}-linux-22.04.tar.gz
-          MACOS_RELEASE_FILE=pact-${{ env.RELEASE_VERSION }}-aarch64-osx.tar.gz
+          UBUNTU_RELEASE_FILE=pact-${{ env.RELEASE_VERSION }}-linux-x64.tar.gz
+          MACOS_RELEASE_FILE=pact-${{ env.RELEASE_VERSION }}-darwin-aarch64.tar.gz
           
           curl "s3.us-east-1.amazonaws.com/kadena-cabal-cache/pact/$UBUNTU_TAR" -o "./$UBUNTU_RELEASE_FILE"
           curl "s3.us-east-1.amazonaws.com/kadena-cabal-cache/pact/$MACOS_TAR" -o "./$MACOS_RELEASE_FILE"
@@ -181,7 +181,7 @@ jobs:
     needs: release_to_github
     with:
       pact_arm: "${{ needs.release_to_github.outputs.OSX_RELEASE_URL }}"
-      pact_head: https://github.com/kadena-io/pact-5/releases/download/nightly/pact-nightly-aarch64-osx.tar.gz
+      pact_head: https://github.com/kadena-io/pact-5/releases/download/nightly/pact-nightly-darwin-aarch64.tar.gz
     secrets: inherit
               
         


### PR DESCRIPTION
It resolves the writable permissions issue for the tarball and removes the Nix path from the bundled files, creating a flat directory structure like `/bin` instead of `/nix/store/<nix-stuff>/bin`. This approach follows the conventional method for distributing tarballs.
