### PR TITLE
Fixing heading for sub-sections

### DIFF
--- a/docs/builtins/Database/describe-keyset.md
+++ b/docs/builtins/Database/describe-keyset.md
@@ -12,7 +12,7 @@ To get metadata for the specified `keyset` name, use the following syntax:
 (describe-keyset keyset)
 ```
 
-## Arguments
+### Arguments
 
 Use the following argument to specify the keyset for which to retrieve metadata using the `describe-keyset` Pact function.
 
@@ -20,7 +20,7 @@ Use the following argument to specify the keyset for which to retrieve metadata 
 | --- | --- | --- |
 | `keyset` | string | Specifies the name of the keyset that you want to retrieve metadata for. |
 
-## Return values
+### Return values
 
 The `describe-keyset` function returns a guard.
 
@@ -29,7 +29,7 @@ The returned object includes the following properties:
 - `pred`: The predicate function associated with the keyset.
 - `keys`: An array of public keys associated with the keyset.
 
-## Examples
+### Examples
 
 The following example retrieves metadata for a keyset named `'admin-keyset'` in the Pact REPL:
 


### PR DESCRIPTION
Fixes wrong heading for the `Arguments`, `Return values`, and `Examples` subsections in the `describe-keyset.md` documentation.

The wrong markup heading (currently `##`, it should be`###`) is being used causing them to appear in the right side content menu at `Reference/Functions/Database` ([docs page](https://docs.kadena.io/reference/functions/database)).

PR checklist:

* [ ] Test coverage for the proposed changes
* [ ] PR description contains example output from repl interaction or a snippet from unit test output
* [ ] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [ ] Benchmark regressions
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
