### PR TITLE
Integration + LSP: Improve line loc info in lexer/parser, add test for roundtripping behavior

### DIFF
--- a/pact-tests/Pact/Core/Test/DocsTests.hs
+++ b/pact-tests/Pact/Core/Test/DocsTests.hs
@@ -33,4 +33,4 @@ docsExistsTest b = testCase "Builtins should have docs" $ do
       ,"env-gaslog", "env-gasmodel-fixed", "env-milligas", "env-module-admin"
       ,"env-set-milligas", "env-stackframe", "env-verifiers", "negate"
       ,"pact-state", "print", "reset-pact-state", "rollback-tx", "show"
-      ,"sig-keyset", "test-capability"]
+      ,"sig-keyset", "test-capability", "env-set-debug-flag"]

--- a/pact-tests/Pact/Core/Test/LexerParserTests.hs
+++ b/pact-tests/Pact/Core/Test/LexerParserTests.hs
@@ -177,8 +177,16 @@ parserRoundtrip = property $ do
   res <- evalEither $ Lisp.parseExpr =<< Lisp.lexer (parsedExprToSrc ptok)
   ptok === toUnitExpr res
 
+-- sliceRoundtrip :: Property
+-- sliceRoundtrip = property $ do
+--   ptok <- forAll exprGen
+--   let sourceLoc = parsedExprToSrc ptok
+--   res <- evalEither $ Lisp.parseExpr =<< Lisp.lexer exprGen
+--   ptok === toUnitExpr res
+
 tests :: TestTree
 tests = testGroup "Lexer and Parser Tests"
   [ testProperty "lexer roundtrip" lexerRoundtrip
   , testProperty "parser roundtrip" $ withTests (1000 :: TestLimit) parserRoundtrip
+  -- , testProperty "slices roundtrip" $ withTests (1000 :: TestLimit) parserRoundtrip
   ]

--- a/pact-tests/Pact/Core/Test/LexerParserTests.hs
+++ b/pact-tests/Pact/Core/Test/LexerParserTests.hs
@@ -3,21 +3,28 @@ module Pact.Core.Test.LexerParserTests where
 import Test.Tasty
 import Test.Tasty.Hedgehog
 import Hedgehog
+import Data.Text(Text)
+import Data.List(intersperse)
+import Control.Monad
+import Control.Lens
+import Data.List.NonEmpty(NonEmpty(..))
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 import qualified Data.Text as T
-import Data.Decimal(DecimalRaw(..))
 
-import Pact.Core.Gen(identGen)
-import Pact.Core.Names
+import Pact.Core.Gen
+  (moduleHashGen, parsedTyNameGen, parsedNameGen
+  , moduleNameGen, identGen
+  , decimalGen)
 import qualified Pact.Core.Syntax.Lexer as Lisp
 import qualified Pact.Core.Syntax.LexUtils as Lisp
-import qualified Pact.Core.Syntax.ParseTree as Lisp
+import Pact.Core.Syntax.ParseTree as Lisp
 import qualified Pact.Core.Syntax.Parser as Lisp
 import Pact.Core.Syntax.LexUtils (Token(..))
 import Pact.Core.Literal
 import Pact.Core.Pretty
-import Pact.Core.Syntax.ParseTree (LetForm(LFLetNormal))
+import Pact.Core.Hash
+import Pact.Core.Info
 
 showPretty :: Pretty a => a -> T.Text
 showPretty = T.pack . show . pretty
@@ -86,45 +93,14 @@ parsedExprToSrc = T.pack . show . pretty
 varGen :: ParserGen
 varGen = (`Lisp.Var` ()) <$> parsedNameGen
 
-parsedNameGen :: Gen ParsedName
-parsedNameGen = Gen.choice [qn, bn]
-  where
-    bn = BN . BareName <$> identGen
-    qn = do
-      name <- identGen
-      mn   <- moduleNameGen
-      let qname = QualifiedName name mn
-      pure (QN qname)
-parsedTyNameGen :: Gen ParsedTyName
-parsedTyNameGen = Gen.choice [qn, bn]
-  where
-    bn = TBN . BareName <$> identGen
-    qn = do
-      name <- identGen
-      mn   <- moduleNameGen
-      let qname = QualifiedName name mn
-      pure (TQN qname)
-
-moduleNameGen :: Gen ModuleName
-moduleNameGen = do
-  modName <- identGen
-  modNS   <- Gen.maybe (NamespaceName <$> identGen)
-  pure (ModuleName modName modNS)
-
 constantGen :: ParserGen
 constantGen = (`Lisp.Constant` ()) <$> Gen.choice
   [ LString <$> Gen.text (Range.constant 1 64) Gen.alphaNum
   , LInteger <$> Gen.integral_(Range.constant (-10000) 10000)
-  , decimalGen
+  , LDecimal <$> decimalGen
   , Gen.constant LUnit
   , LBool <$> Gen.bool
   ]
-  where
-    decimalGen = do
-      i <- Gen.integral (Range.constant 0 255)
-      m <- Gen.integral (Range.constant 0 255)
-      pure $ LDecimal (Decimal i m)
-
 
 exprGen :: ParserGen
 exprGen = Gen.recursive Gen.choice
@@ -152,41 +128,279 @@ exprGen = Gen.recursive Gen.choice
       inner <- Gen.nonEmpty (Range.linear 1 8) exprGen
       pure $ Lisp.Let LFLetNormal binders inner ()
 
-    typeGen :: Gen Lisp.Type
-    typeGen = Gen.recursive Gen.choice
-      (Gen.constant . Lisp.TyPrim <$> [minBound ..])
-      [Lisp.TyList <$> typeGen
-      ,pure Lisp.TyPolyList
-      ,Lisp.TyModRef <$> Gen.list (Range.constant 1 5) moduleNameGen
-      ,pure Lisp.TyGuard
-      ,pure Lisp.TyKeyset
-      ,Lisp.TyObject <$> parsedTyNameGen
-      ,pure Lisp.TyTime
-      ,pure Lisp.TyPolyObject]
-
     binderGen = do
       name <- identGen
       ty <- Gen.maybe typeGen
       expr <- Gen.subterm exprGen id
       pure $ Lisp.Binder name ty expr
 
+typeGen :: Gen Lisp.Type
+typeGen = Gen.recursive Gen.choice
+  (Gen.constant . Lisp.TyPrim <$> [minBound ..])
+  [Lisp.TyList <$> typeGen
+  ,pure Lisp.TyPolyList
+  ,Lisp.TyModRef <$> Gen.list (Range.constant 1 5) moduleNameGen
+  ,pure Lisp.TyGuard
+  ,pure Lisp.TyKeyset
+  ,Lisp.TyObject <$> parsedTyNameGen
+  ,pure Lisp.TyTime
+  ,pure Lisp.TyPolyObject]
+
+margGen :: Gen (Lisp.MArg ())
+margGen =
+  MArg
+   <$> identGen
+   <*> Gen.maybe typeGen
+   <*> pure ()
+
+argGen :: Gen (Lisp.Arg ())
+argGen =
+  Arg
+   <$> identGen
+   <*> typeGen
+   <*> pure ()
+
+-- Todo in a followup: generate models
+annGen :: Gen [PactAnn ()]
+annGen =
+  Gen.list (Range.constant 0 1) genDoc
+  where
+  genDoc =
+    PactDoc
+      -- Note: we don't want to generate PactDocStrings, because
+      -- we can very easily hit our known parser ambiguity case and we just
+      -- don't wanna deal with that.
+      <$> pure PactDocAnn
+      <*> docStringGen
+
+docStringGen :: Gen Text
+docStringGen = Gen.text (Range.constant 0 20) Gen.alphaNum
+
+
+defunGen :: Gen (Defun ())
+defunGen =
+  Defun
+    <$> margGen
+    <*> Gen.list (Range.constant 1 5) margGen
+    <*> defBodyGen
+    <*> annGen
+    <*> pure ()
+
+-- NOTE:
+-- We can't just use `exprGen` everywhere for things like
+-- defuns and defcaps, because, unfortunately, there is parser ambiguity carried over
+-- from legacy pact due to docstrings and string literals in expressions.
+-- See [Docstring ambiguity] in Parser.y
+defBodyGen :: Gen (NonEmpty (Expr ()))
+defBodyGen = do
+  h <- exprGenNoStringLit
+  li <- Gen.list (Range.constant 0 5) exprGen
+  pure (h :| li)
+
+isNotStringLit :: Expr i -> Bool
+isNotStringLit = \case
+  Constant (LString _) _ -> False
+  _ -> True
+
+-- NOTE:
+-- We can't just use `exprGen` everywhere for things like
+-- defuns and defcaps, because, unfortunately, there is parser ambiguity carried over
+-- from legacy pact due to docstrings and string literals in expressions.
+-- See [Docstring ambiguity] in Parser.y
+exprGenNoStringLit :: Gen (Expr ())
+exprGenNoStringLit = do
+  e <- exprGen
+  e <$ guard (isNotStringLit e)
+
+
+defcapGen :: Gen (DefCap ())
+defcapGen =
+  DefCap
+    <$> margGen
+    <*> Gen.list (Range.constant 1 5) margGen
+    <*> defBodyGen
+    <*> annGen
+    <*> Gen.maybe metaGen
+    <*> pure ()
+
+metaGen :: Gen DCapMeta
+metaGen = Gen.choice [pure DefEvent, managedGen]
+  where
+  managedGen =
+    -- Todo: managed annotations have
+    -- parser ambiguity this needs to be `Just` for this reason
+    DefManaged . Just <$> ((,) <$> identGen <*> parsedNameGen)
+
+defpactGen :: Gen (DefPact ())
+defpactGen =
+  DefPact
+    <$> margGen
+    <*> Gen.list (Range.constant 1 5) margGen
+    <*> Gen.nonEmpty (Range.constant 1 5) stepGen
+    <*> annGen
+    <*> pure ()
+  where
+  stepGen =
+    Gen.choice [regularStepGen, stepWithRbGen]
+  regularStepGen =
+    -- Todo: models
+    Step <$> exprGen <*> pure Nothing
+  stepWithRbGen =
+    -- todo: models
+    StepWithRollback <$> exprGen <*> exprGen <*> pure Nothing
+
+defschemaGen :: Gen (DefSchema ())
+defschemaGen =
+  DefSchema
+    <$> identGen
+    <*> Gen.list (Range.constant 1 5) argGen
+    <*> annGen
+    <*> pure ()
+
+deftableGen :: Gen (DefTable ())
+deftableGen =
+  DefTable
+    <$> identGen
+    <*> parsedNameGen
+    <*> Gen.maybe ((,PactDocAnn) <$> docStringGen)
+    <*> pure ()
+
+defconstGen :: Gen (DefConst ())
+defconstGen =
+  DefConst
+    <$> margGen
+    <*> exprGen
+    <*> Gen.maybe ((,PactDocAnn) <$> docStringGen)
+    <*> pure ()
+
+defGen :: Gen (Lisp.Def ())
+defGen =
+  Gen.choice
+    [ Dfun <$> defunGen
+    , DCap <$> defcapGen
+    , DPact <$> defpactGen
+    , DSchema <$> defschemaGen
+    , DTable <$> deftableGen
+    , DConst <$> defconstGen
+    ]
+
+importGen :: Gen (Import ())
+importGen = do
+  mn <- moduleNameGen
+  mh <- Gen.maybe hashTextGen
+  imp <- Gen.maybe (Gen.list (Range.linear 0 5) identGen)
+  pure (Import mn mh imp ())
+
+hashTextGen :: Gen Text
+hashTextGen =
+  moduleHashToText <$> moduleHashGen
+
+extDeclGen :: Gen (ExtDecl ())
+extDeclGen =
+  Gen.choice [
+    ExtBless <$> hashTextGen <*> pure (),
+    ExtImport <$> importGen,
+    ExtImplements <$> moduleNameGen <*> pure ()
+  ]
+
+moduleGen :: Gen (Module ())
+moduleGen =
+  Module
+    <$> identGen
+    <*> govGen
+    <*> Gen.list (Range.constant 1 5) extDeclGen
+    <*> Gen.nonEmpty (Range.constant 1 5) defGen
+    <*> annGen
+    <*> pure ()
+  where
+  govGen = Gen.choice
+    [ KeyGov <$> identGen
+    , CapGov <$> identGen
+    ]
+
+ifdefunGen :: Gen (IfDefun ())
+ifdefunGen =
+  IfDefun
+    <$> margGen
+    <*> Gen.list (Range.constant 1 5) margGen
+    <*> annGen
+    <*> pure ()
+
+ifdefcapGen :: Gen (IfDefCap ())
+ifdefcapGen =
+  IfDefCap
+    <$> margGen
+    <*> Gen.list (Range.constant 1 5) margGen
+    <*> annGen
+    <*> Gen.maybe metaGen
+    <*> pure ()
+
+ifdefpactGen :: Gen (IfDefPact ())
+ifdefpactGen =
+  IfDefPact
+    <$> margGen
+    <*> Gen.list (Range.constant 1 5) margGen
+    <*> annGen
+    <*> pure ()
+
+ifDefGen :: Gen (IfDef ())
+ifDefGen =
+  Gen.choice
+  [ IfDfun <$> ifdefunGen
+  , IfDCap <$> ifdefcapGen
+  , IfDSchema <$> defschemaGen
+  , IfDPact <$> ifdefpactGen
+  , IfDConst <$> defconstGen
+  ]
+
+interfaceGen :: Gen (Interface ())
+interfaceGen =
+  Interface
+    <$> identGen
+    <*> Gen.list (Range.constant 1 5) ifDefGen
+    <*> Gen.list (Range.constant 0 5) importGen
+    <*> annGen
+    <*> pure ()
+
+topLevelGen :: Gen (TopLevel ())
+topLevelGen =
+  Gen.choice
+  [ TLTerm <$> exprGen
+  , TLModule <$> moduleGen
+  , TLInterface <$> interfaceGen
+  ]
+
+exprParserRoundtrip :: Property
+exprParserRoundtrip = property $ do
+  ptok <- forAll exprGen
+  res <- evalEither $ Lisp.parseExpr =<< Lisp.lexer (renderCompactText ptok)
+  ptok === void res
 
 parserRoundtrip :: Property
 parserRoundtrip = property $ do
-  ptok <- forAll exprGen
-  res <- evalEither $ Lisp.parseExpr =<< Lisp.lexer (parsedExprToSrc ptok)
-  ptok === toUnitExpr res
+  ptok <- forAll topLevelGen
+  res <- evalEither $ Lisp.parseProgram =<< Lisp.lexer (renderCompactText ptok)
+  [ptok] === (void <$> res)
 
--- sliceRoundtrip :: Property
--- sliceRoundtrip = property $ do
---   ptok <- forAll exprGen
---   let sourceLoc = parsedExprToSrc ptok
---   res <- evalEither $ Lisp.parseExpr =<< Lisp.lexer exprGen
---   ptok === toUnitExpr res
+-- | Here we will test that slicing from generated source
+--   will produce accurate source locations
+--
+--   If our parser + lexer generate correct source locations for toplevels, then
+--   it also means we should be able to parse, then slice the locations, then concatenate them again
+--   to yield the original source
+--
+sliceRoundtrip :: Property
+sliceRoundtrip = property $ do
+  toplevels <- forAll (Gen.list (Range.constant 1 3) topLevelGen)
+  let srcText = T.concat $ intersperse " " $ renderCompactText <$> toplevels
+  res <- evalEither $ Lisp.parseProgram =<< Lisp.lexer srcText
+  let slices = T.concat $ intersperse " " $ sliceFromSource srcText . view topLevelInfo <$> res
+  srcText === slices
 
 tests :: TestTree
 tests = testGroup "Lexer and Parser Tests"
   [ testProperty "lexer roundtrip" lexerRoundtrip
-  , testProperty "parser roundtrip" $ withTests (1000 :: TestLimit) parserRoundtrip
-  -- , testProperty "slices roundtrip" $ withTests (1000 :: TestLimit) parserRoundtrip
+  , testProperty "parser roundtrips for exprs" $ withTests (1000 :: TestLimit) exprParserRoundtrip
+  , testProperty "parser roundtrips for all toplevels" $ withTests (1000 :: TestLimit) parserRoundtrip
+  , testProperty "source slices correspond with their source code locations" $ withTests (1000 :: TestLimit) sliceRoundtrip
   ]

--- a/pact/Pact/Core/Builtin.hs
+++ b/pact/Pact/Core/Builtin.hs
@@ -769,6 +769,7 @@ data ReplOnlyBuiltin
   | REnvEnableReplNatives
   | REnvModuleAdmin
   | REnvVerifiers
+  | REnvSetDebugFlag
   deriving (Show, Enum, Bounded, Eq, Generic)
 
 
@@ -816,6 +817,7 @@ instance IsBuiltin ReplOnlyBuiltin where
     REnvEnableReplNatives -> 1
     REnvModuleAdmin -> 1
     REnvVerifiers -> 1
+    REnvSetDebugFlag -> 1
 
     -- RLoad -> 1
     -- RLoadWithEnv -> 2
@@ -898,6 +900,7 @@ replBuiltinsToText = \case
   REnvEnableReplNatives -> "env-enable-repl-natives"
   REnvModuleAdmin -> "env-module-admin"
   REnvVerifiers -> "env-verifiers"
+  REnvSetDebugFlag -> "env-set-debug-flag"
 
 replBuiltinToText :: (t -> Text) -> ReplBuiltin t -> Text
 replBuiltinToText f = \case

--- a/pact/Pact/Core/Compile.hs
+++ b/pact/Pact/Core/Compile.hs
@@ -127,7 +127,7 @@ evalModuleGovernance interpreter tl = do
   case tl of
     Lisp.TLModule m -> do
       let info = Lisp._mInfo m
-      let unmangled = Lisp._mName m
+      let unmangled = ModuleName (Lisp._mName m) Nothing
       mname <- mangleNamespace unmangled
       lookupModule (Lisp._mInfo m) mname >>= \case
         Just targetModule -> do
@@ -152,7 +152,7 @@ evalModuleGovernance interpreter tl = do
         Nothing -> enforceNamespaceInstall info interpreter
     Lisp.TLInterface iface -> do
       let info = Lisp._ifInfo iface
-      let unmangled = Lisp._ifName iface
+      let unmangled = ModuleName (Lisp._ifName iface) Nothing
       ifn <- mangleNamespace unmangled
       lookupModuleData info ifn >>= \case
         Nothing -> enforceNamespaceInstall info interpreter

--- a/pact/Pact/Core/Debug.hs
+++ b/pact/Pact/Core/Debug.hs
@@ -38,12 +38,10 @@ debugPrint dp term =
         DPLexer -> whenReplFlagSet ReplDebugLexer $ liftIO $ do
           putStrLn "----------- Lexer output -----------------"
           print (pretty term)
-        DPParser -> whenReplFlagSet ReplDebugParser $ case term of
-          Syntax.TLTerm t ->
+        DPParser -> whenReplFlagSet ReplDebugParser $
             liftIO $ do
               putStrLn "----------- Parser output ----------------"
-              print (pretty t)
-          _ -> pure ()
+              print (pretty term)
         DPDesugar -> whenReplFlagSet ReplDebugDesugar $ case term of
           Term.TLTerm t ->
             liftIO $ do

--- a/pact/Pact/Core/Environment/Types.hs
+++ b/pact/Pact/Core/Environment/Types.hs
@@ -129,12 +129,13 @@ data ReplDebugFlag
   = ReplDebugLexer
   | ReplDebugParser
   | ReplDebugDesugar
-  | ReplDebugTypechecker
-  | ReplDebugTypecheckerType
-  | ReplDebugSpecializer
-  | ReplDebugUntyped
   deriving (Show, Eq, Ord, Enum, Bounded)
 
+instance Pretty ReplDebugFlag where
+  pretty = \case
+    ReplDebugLexer -> "lexer"
+    ReplDebugParser -> "parser"
+    ReplDebugDesugar -> "desugar"
 
 
 -- | Execution flags specify behavior of the runtime environment,
@@ -353,7 +354,7 @@ data ReplState b
   , _replTx :: Maybe (TxId, Maybe Text)
   , _replNativesEnabled :: Bool
   -- ^
-  , _replOutputLine :: !(forall a. Pretty a => a -> EvalM 'ReplRuntime b SpanInfo ())
+  , _replOutputLine :: !(Text -> EvalM 'ReplRuntime b SpanInfo ())
   }
 
 data RuntimeMode

--- a/pact/Pact/Core/Guards.hs
+++ b/pact/Pact/Core/Guards.hs
@@ -111,6 +111,11 @@ data Governance name
   | CapGov (FQNameRef name)
   deriving (Eq, Show, Generic)
 
+instance Pretty (Governance name) where
+  pretty = \case
+    KeyGov kn -> dquotes (pretty (renderKeySetName kn))
+    CapGov fqnref -> pretty fqnref
+
 instance NFData name => NFData (Governance name)
 
 data KSPredicate

--- a/pact/Pact/Core/Info.hs
+++ b/pact/Pact/Core/Info.hs
@@ -14,6 +14,7 @@ module Pact.Core.Info
 import Control.Lens
 import Data.Default
 import Data.Text(Text)
+import Data.List(intersperse)
 import qualified Data.Text as T
 import GHC.Generics
 import Control.DeepSeq (NFData)
@@ -60,7 +61,8 @@ sliceFromSourceLines codeLines (SpanInfo startLine startCol endLine endCol) =
     --
     -- Note: we take `end - start + 1` since end is inclusive.
     let lineSpan = take (max 1 (endLine - startLine + 1)) $ drop startLine codeLines
-    in T.concat (over _head (T.drop startCol) . over _last (T.take (endCol + 1)) $ lineSpan)
+    -- Note: we can't use `unlines` here. it adds an extra terminating newline
+    in T.concat $ intersperse "\n" (over _head (T.drop startCol) . over _last (T.take endCol) $ lineSpan)
 
 sliceFromSource :: Text -> SpanInfo -> Text
 sliceFromSource t si = sliceFromSourceLines (T.lines t) si

--- a/pact/Pact/Core/Names.hs
+++ b/pact/Pact/Core/Names.hs
@@ -402,6 +402,11 @@ instance Eq (FQNameRef name) where
   (FQParsed pn) == (FQParsed pn') = pn == pn'
   (FQName fqn) == (FQName fqn') = fqn == fqn'
 
+instance Pretty (FQNameRef name) where
+  pretty = \case
+    FQParsed pn -> pretty pn
+    FQName fqn -> pretty (_fqName fqn)
+
 
 
 makeLenses ''FullyQualifiedName

--- a/pact/Pact/Core/Repl/UserDocs.hs
+++ b/pact/Pact/Core/Repl/UserDocs.hs
@@ -15,7 +15,7 @@ functionDocs
   -> ReplM ReplCoreBuiltin ()
 functionDocs = \case
   Lisp.TLModule md -> do
-    mn <- mangleNamespace (Lisp._mName md)
+    mn <- mangleNamespace (ModuleName (Lisp._mName md) Nothing)
     traverse_ (addModuleDoc mn) (Lisp._mDefs md)
   _ -> pure ()
   where

--- a/pact/Pact/Core/Syntax/LexUtils.hs
+++ b/pact/Pact/Core/Syntax/LexUtils.hs
@@ -166,7 +166,7 @@ newtype LexerM a =
 
 
 initState :: Text -> AlexInput
-initState = AlexInput 0 0 '\n'
+initState = AlexInput 0 0 '\0'
 
 getSpanInfo :: LexerM SpanInfo
 getSpanInfo = do

--- a/pact/Pact/Core/Syntax/Lexer.x
+++ b/pact/Pact/Core/Syntax/Lexer.x
@@ -111,7 +111,8 @@ stringLiteral :: Text -> SpanInfo -> LexerM PosToken
 stringLiteral _ info = do
   inp <- get
   body <- loop [] inp
-  pure (PosToken (TokenString (T.pack body)) info)
+  info' <- getSpanInfo
+  pure (PosToken (TokenString (T.pack body)) (combineSpan info info'))
   where
   loop acc inp =
     case lexerGetChar inp of

--- a/pact/Pact/Core/Syntax/ParseTree.hs
+++ b/pact/Pact/Core/Syntax/ParseTree.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE InstanceSigs #-}
 
 module Pact.Core.Syntax.ParseTree where
 
@@ -20,8 +21,6 @@ import Pact.Core.Literal
 import Pact.Core.Names
 import Pact.Core.Pretty
 import Pact.Core.Type(PrimType(..))
-import Pact.Core.Guards
-
 
 data Operator
   = AndOp
@@ -101,7 +100,7 @@ data Arg i
   { _argName :: Text
   , _argType :: Type
   , _argInfo :: i
-  } deriving (Show, Functor, Generic, NFData)
+  } deriving (Eq, Show, Functor, Generic, NFData)
 
 data MArg i
   = MArg
@@ -175,7 +174,7 @@ data Defun i
   , _dfunTerm :: NonEmpty (Expr i)
   , _dfunAnns :: [PactAnn i]
   , _dfunInfo :: i
-  } deriving (Show, Functor, Generic, NFData)
+  } deriving (Eq, Show, Functor, Generic, NFData)
 
 instance Pretty (Defun i) where
   pretty (Defun da args term anns _) =
@@ -197,7 +196,7 @@ data DefConst i
   , _dcTerm :: Expr i
   , _dcDocs :: Maybe (Text, PactDocType)
   , _dcInfo :: i
-  } deriving (Show, Functor, Generic, NFData)
+  } deriving (Eq, Show, Functor, Generic, NFData)
 
 instance Pretty (DefConst i) where
   pretty (DefConst marg term doc _) =
@@ -206,14 +205,14 @@ instance Pretty (DefConst i) where
       pretty marg <+>
       (nest 2 $
         line <>
-        maybe mempty (\(d, ann) -> pretty (PactDoc ann d) <> line) doc
-        <> pretty term
+        pretty term  <>
+        maybe mempty (\(d, ann) -> line <> pretty (PactDoc ann d)) doc
         )
 
 data DCapMeta
   = DefEvent
   | DefManaged (Maybe (Text, ParsedName))
-  deriving (Show, Generic, NFData)
+  deriving (Eq, Show, Generic, NFData)
 
 instance Pretty DCapMeta where
   pretty = \case
@@ -231,7 +230,7 @@ data DefCap i
   , _dcapAnns :: [PactAnn i]
   , _dcapMeta :: Maybe DCapMeta
   , _dcapInfo :: i
-  } deriving (Show, Functor, Generic, NFData)
+  } deriving (Eq, Show, Functor, Generic, NFData)
 
 instance Pretty (DefCap i) where
   pretty (DefCap n args term anns meta _) =
@@ -252,7 +251,7 @@ data DefSchema i
   , _dscArgs :: [Arg i]
   , _dscAnns :: [PactAnn i]
   , _dscInfo :: i
-  } deriving (Show, Functor, Generic, NFData)
+  } deriving (Eq, Show, Functor, Generic, NFData)
 
 instance Pretty (DefSchema i) where
   pretty (DefSchema n args anns _) =
@@ -274,7 +273,7 @@ data DefTable i
   , _dtSchema :: ParsedName
   , _dtDocs :: Maybe (Text, PactDocType)
   , _dtInfo :: i
-  } deriving (Show, Functor, Generic, NFData)
+  } deriving (Eq, Show, Functor, Generic, NFData)
 
 instance Pretty (DefTable i) where
   pretty (DefTable n schema docs _) =
@@ -282,13 +281,13 @@ instance Pretty (DefTable i) where
       "deftable"
       <+> pretty n
       <> ":"
-      <> brackets (pretty schema)
+      <> braces (pretty schema)
       <> maybe mempty (\d -> line <> pretty (uncurry (flip PactDoc) d)) docs
 
 data PactStep i
   = Step (Expr i) (Maybe [PropertyExpr i])
   | StepWithRollback (Expr i) (Expr i) (Maybe [PropertyExpr i])
-  deriving (Show, Functor, Generic, NFData)
+  deriving (Eq, Show, Functor, Generic, NFData)
 
 instance Pretty (PactStep i) where
   pretty = \case
@@ -309,7 +308,7 @@ data DefPact i
   , _dpSteps :: NonEmpty (PactStep i)
   , _dpAnns :: [PactAnn i]
   , _dpInfo :: i
-  } deriving (Show, Functor, Generic, NFData)
+  } deriving (Eq, Show, Functor, Generic, NFData)
 
 instance Pretty (DefPact i) where
   pretty (DefPact n args steps anns _) =
@@ -327,7 +326,7 @@ instance Pretty (DefPact i) where
 data Managed
   = AutoManaged
   | Managed Text ParsedName
-  deriving (Show)
+  deriving (Eq, Show)
 
 data Def i
   = Dfun (Defun i)
@@ -336,7 +335,7 @@ data Def i
   | DSchema (DefSchema i)
   | DTable (DefTable i)
   | DPact (DefPact i)
-  deriving (Show, Functor, Generic, NFData)
+  deriving (Eq, Show, Functor, Generic, NFData)
 
 instance Pretty (Def i) where
   pretty = \case
@@ -347,49 +346,72 @@ instance Pretty (Def i) where
     DTable dc -> pretty dc
     DPact dc -> pretty dc
 
-data Import
+data Import i
   = Import
   { _impModuleName  :: ModuleName
   , _impModuleHash :: Maybe Text
-  , _impImported :: Maybe [Text] }
-  deriving (Show, Generic, NFData)
+  , _impImported :: Maybe [Text]
+  , _impInfo :: i }
+  deriving (Eq, Show, Generic, NFData, Functor)
 
-instance Pretty Import where
-  pretty (Import mn mh imp) =
+importInfo :: Lens' (Import i) i
+importInfo =
+  lens _impInfo (\(Import m h imp _) i -> Import m h imp i)
+
+instance Pretty (Import i) where
+  pretty (Import mn mh imp _) =
     parens $
       "use" <+> pretty mn <> prettyMh mh <> prettyImp imp
     where
     prettyMh = maybe mempty (\h -> space <> dquotes (pretty h))
-    prettyImp = maybe mempty (\imps -> space <> commaBrackets (dquotes . pretty <$> imps))
+    prettyImp = maybe mempty (\imps -> space <> brackets (hsep (pretty <$> imps)))
 
-data ExtDecl
-  = ExtBless Text
-  | ExtImport Import
-  | ExtImplements ModuleName
-  deriving (Show, Generic, NFData)
+data ExtDecl i
+  = ExtBless Text i
+  | ExtImport (Import i)
+  | ExtImplements ModuleName i
+  deriving (Eq, Show, Generic, NFData, Functor)
 
-instance Pretty ExtDecl where
+extDeclInfo :: Lens' (ExtDecl i) i
+extDeclInfo f = \case
+  ExtBless b i -> ExtBless b <$> f i
+  ExtImport imp -> ExtImport <$> importInfo f imp
+  ExtImplements m i -> ExtImplements m <$> f i
+
+instance Pretty (ExtDecl i) where
   pretty = \case
-    ExtBless t ->
+    ExtBless t _ ->
       parens $ "bless" <+> dquotes (pretty t)
     ExtImport imp -> pretty imp
-    ExtImplements m ->
+    ExtImplements m _ ->
       parens $ "implements" <+> pretty m
+
+data Governance
+  = KeyGov Text
+  | CapGov Text
+  deriving (Eq, Show, Generic)
+
+instance NFData Governance
+
+instance Pretty Governance where
+  pretty = \case
+    KeyGov t -> dquotes (pretty t)
+    CapGov t -> pretty t
 
 data Module i
   = Module
-  { _mName :: ModuleName
-  , _mGovernance :: Governance ParsedName
-  , _mExternal :: [ExtDecl]
+  { _mName :: Text
+  , _mGovernance :: Governance
+  , _mExternal :: [ExtDecl i]
   , _mDefs :: NonEmpty (Def i)
   , _mAnns :: [PactAnn i]
   , _mInfo :: i
-  } deriving (Show, Functor, Generic, NFData)
+  } deriving (Eq, Show, Functor, Generic, NFData)
 
 instance Pretty (Module i) where
   pretty (Module mname mgov mexts defs anns _) =
     parens $
-      "module" <+> pretty (_mnName mname) <+> pretty mgov <>
+      "module" <+> pretty mname <+> pretty mgov <>
         nest 2
         ( line <>
           prettyAnnListWithNewline anns <>
@@ -401,24 +423,24 @@ data TopLevel i
   = TLModule (Module i)
   | TLInterface (Interface i)
   | TLTerm (Expr i)
-  | TLUse Import i
-  deriving (Show, Functor, Generic, NFData)
+  | TLUse (Import i)
+  deriving (Eq, Show, Functor, Generic, NFData)
 
 instance Pretty (TopLevel i) where
   pretty = \case
     TLModule m -> pretty m
     TLInterface m -> pretty m
     TLTerm term -> pretty term
-    TLUse i _ -> pretty i
+    TLUse i -> pretty i
 
 data Interface i
   = Interface
-  { _ifName :: ModuleName
+  { _ifName :: Text
   , _ifDefns :: [IfDef i]
-  , _ifImports :: [Import]
+  , _ifImports :: [Import i]
   , _ifAnns :: [PactAnn i]
   , _ifInfo :: i
-  } deriving (Show, Functor, Generic, NFData)
+  } deriving (Eq, Show, Functor, Generic, NFData)
 
 instance Pretty (Interface i) where
   pretty (Interface ifn defs imports anns _) =
@@ -439,7 +461,7 @@ data IfDefun i
   , _ifdArgs :: [MArg i]
   , _ifdAnns :: [PactAnn i]
   , _ifdInfo :: i
-  } deriving (Show, Functor, Generic, NFData)
+  } deriving (Eq, Show, Functor, Generic, NFData)
 
 instance Pretty (IfDefun i) where
   pretty (IfDefun n args anns _) =
@@ -456,7 +478,7 @@ data IfDefCap i
   , _ifdcAnns :: [PactAnn i]
   , _ifdcMeta :: Maybe DCapMeta
   , _ifdcInfo :: i
-  } deriving (Show, Functor, Generic, NFData)
+  } deriving (Eq, Show, Functor, Generic, NFData)
 
 instance Pretty (IfDefCap i) where
   pretty (IfDefCap n args anns meta _) =
@@ -477,7 +499,7 @@ data IfDefPact i
   , _ifdpArgs :: [MArg i]
   , _ifdpAnns :: [PactAnn i]
   , _ifdpInfo :: i
-  } deriving (Show, Functor, Generic, NFData)
+  } deriving (Eq, Show, Functor, Generic, NFData)
 
 instance Pretty (IfDefPact i) where
   pretty (IfDefPact n args anns _) =
@@ -551,7 +573,7 @@ data IfDef i
   | IfDCap (IfDefCap i)
   | IfDSchema (DefSchema i)
   | IfDPact (IfDefPact i)
-  deriving (Show, Functor, Generic, NFData)
+  deriving (Eq, Show, Functor, Generic, NFData)
 
 instance Pretty (IfDef i) where
   pretty = \case
@@ -625,10 +647,6 @@ pattern RTLInterface m = RTLTopLevel (TLInterface m)
 pattern RTLTerm :: Expr i -> ReplTopLevel i
 pattern RTLTerm te = RTLTopLevel (TLTerm te)
 
-pattern RTLUse :: Import -> i -> ReplTopLevel i
-pattern RTLUse imp i = RTLTopLevel (TLUse imp i)
-
-
 termInfo :: Lens' (Expr i) i
 termInfo f = \case
   Var n i -> Var n <$> f i
@@ -651,8 +669,8 @@ topLevelInfo f = \case
   TLModule m -> (\i -> TLModule m{_mInfo=i}) <$> f (_mInfo m)
   TLInterface m -> (\i -> TLInterface m{_ifInfo=i}) <$> f (_ifInfo m)
   TLTerm t -> TLTerm <$> termInfo f t
-  TLUse imp i ->
-    TLUse imp <$> f i
+  TLUse imp ->
+    TLUse <$> importInfo f imp
 
 instance Pretty (Expr i) where
   pretty = \case

--- a/test-utils/Pact/Core/Gen.hs
+++ b/test-utils/Pact/Core/Gen.hs
@@ -41,6 +41,7 @@ import Pact.Core.Gas
 import Pact.Core.ModRefs
 import Pact.Core.Hash
 import Data.Ratio ((%), denominator)
+import Pact.Core.Guards (KeySetName(KeySetName))
 
 namespaceNameGen :: Gen NamespaceName
 namespaceNameGen = NamespaceName <$> identGen
@@ -172,16 +173,15 @@ governanceGen = Gen.choice
   , CapGov <$> resolvedGovGen
   ]
 
-tyPrimGen :: Gen PrimType
-tyPrimGen = Gen.choice
-  [ pure PrimInt
-  , pure PrimDecimal
-  , pure PrimBool
-  , pure PrimString
-  , pure PrimGuard
-  , pure PrimTime
-  , pure PrimUnit
+parsedNameGovernanceGen :: Gen (Governance ParsedName)
+parsedNameGovernanceGen =
+  Gen.choice
+  [ KeyGov <$> (KeySetName <$> identGen <*> pure Nothing)
+  , CapGov . FQParsed <$> parsedNameGen
   ]
+
+tyPrimGen :: Gen PrimType
+tyPrimGen = Gen.enumBounded
 
 fieldGen :: Gen Field
 fieldGen = Field <$> identGen


### PR DESCRIPTION
Contained in this PR are:
- Fixes to span infos for several parser productions (They were not being combined properly, thanks Hedgehog!)
- Fixes to pretty printing in the parse tree (Pretty printing the parse tree will now always produce a parseable representation of the tree. Note: It does not keep documentation intact. We would need a parse tree that does not clobber doc nodes for that. That may come with a pact formatter)
- A slicing function for source locations for toplevel productions for chainweb's use
- Tests for all of the above
- `:debug x` flags are now removed in the repl. Instead replaced by the function `(env-set-debug-flag <flag>)`. Documentation will be in a followup PR (cc @lsgunnlsgunn )


```
pact>(env-set-debug-flag "all")
set debug flags to [lexer, parser, desugar]
()
pact>(module m g (defcap g () @doc "this is the governance cap!" true) (defun f () (do "hello world!")))
----------- Lexer output -----------------
[ (
, module
, ident<m>
, ident<g>
, (
, defcap
, ident<g>
, (
, )
, @doc
, "this is the governance cap!"
, true
, )
, (
, defun
, ident<f>
, (
, )
, (
, ident<do>
, "hello world!"
, )
, )
, ) ]
----------- Parser output ----------------
(module m g
  (defcap g ()
    @doc "this is the governance cap!"
    true)
  (defun f ()
    (do "hello world!")))
Loaded module m, hash CM5qhTRveIChn9FVR4l1EehqgtjIrVFPLgOxBprf0Zk
```

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [x] Benchmark regressions
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
