### PR TITLE
Improve repl stack frame pretty printing

### DIFF
--- a/pact/Pact/Core/Literal.hs
+++ b/pact/Pact/Core/Literal.hs
@@ -23,6 +23,7 @@ import GHC.Generics
 
 import Pact.Core.Pretty
 import qualified Text.Megaparsec as MP
+import qualified Data.Text as T
 import qualified Text.Megaparsec.Char as MP
 import Data.Char (digitToInt)
 
@@ -50,6 +51,19 @@ instance Pretty Literal where
       if roundTo 0 d == d then
         pretty (show (roundTo 0 d)) <> ".0"
       else pretty (show d)
+    LUnit -> "()"
+    LBool b -> if b then "true" else "false"
+
+instance Pretty (AbbrevPretty Literal) where
+  pretty (AbbrevPretty lit) = case lit of
+    LString t
+      | T.length t < 15 -> dquotes (pretty t)
+      | otherwise -> dquotes (pretty (T.take 12 t <> "..."))
+    LInteger i -> prettyAbbrevText 15 i
+    LDecimal d ->
+      if roundTo 0 d == d then
+        pretty (show (roundTo 0 d)) <> ".0"
+      else prettyAbbrevText 15 (show d)
     LUnit -> "()"
     LBool b -> if b then "true" else "false"
 

--- a/pact/Pact/Core/Pretty.hs
+++ b/pact/Pact/Core/Pretty.hs
@@ -16,11 +16,15 @@ module Pact.Core.Pretty
 , parensSep
 , bracesSep
 , PrettyLispApp(..)
+, AbbrevPretty(..)
+, prettyAbbrevText
+, prettyAbbrevText'
 ) where
 
 import Data.Text(Text)
 import Prettyprinter
 import qualified Prettyprinter as Pretty
+import qualified Data.Text as T
 import Prettyprinter.Render.String
 import Prettyprinter.Render.Text
 import Data.List.NonEmpty(NonEmpty)
@@ -57,6 +61,30 @@ commaBrackets = encloseSep "[" "]" ","
 bracketsSep   = brackets . sep
 parensSep     = parens   . sep
 bracesSep     = braces   . sep
+
+-- A useful type for "abbreviated"
+-- values
+newtype AbbrevPretty a
+  = AbbrevPretty a
+  deriving (Show)
+
+-- | Very inefficient, but useful for making pretty printed, abbreviated strings, to display
+-- things like long lists as [1, 2, ...]
+-- Invariant: `lim` should be at least > 3, otherwise you'll get an ugly string
+prettyAbbrevText :: Pretty a => Int -> a -> Doc ann
+prettyAbbrevText lim v =
+  let k = renderCompactText v
+  in if T.length k <= (lim - 3) then pretty k
+  else pretty (T.take (lim - 3) k <> "...")
+
+-- | Very inefficient, but useful for making pretty printed, abbreviated strings, to display
+-- things like long lists as [1, 2, ...]
+-- Invariant: `lim` should be at least > 3, otherwise you'll get an ugly string
+prettyAbbrevText' :: Int -> Doc ann -> Doc ann
+prettyAbbrevText' lim v =
+  let k = renderCompactText' v
+  in if T.length k <= (lim - 3) then pretty k
+  else pretty (T.take (lim - 3) k <> "...")
 
 data PrettyLispApp n arg
   = PrettyLispApp

--- a/pact/Pact/Core/StackFrame.hs
+++ b/pact/Pact/Core/StackFrame.hs
@@ -46,4 +46,4 @@ instance NFData i => NFData (StackFrame i)
 
 instance Pretty (StackFrame i) where
   pretty (StackFrame sfn args _ _) =
-    pretty $ PrettyLispApp sfn args
+    pretty $ PrettyLispApp sfn (AbbrevPretty <$> args)


### PR DESCRIPTION
While working on separate PRs, I noticed that it is incredibly annoying to sometimes fail with large callstacks, so I've fixed this.

Take this repl file function that simply fails with a callstack:
```pact
(defun fails-with-args (a b c k)
  (enforce false "boom")
)

(fails-with-args "a1u23123uh123uh123uh123uh123uh123123" (^ 2 10) 20 (enumerate 1 100))
```

Before this PR, this fails with:
```
Loaded repl defun fails-with-args
scratch/kek.repl:23:2: boom
 23 |   (enforce false "boom")
    |   ^^^^^^^^^^^^^^^^^^^^^^
  at (#repl.fails-with-args "a1u23123uh123uh123uh123uh123uh123123" 1024 20 [ 1
, 2
, 3
, 4
, 5
, 6
, 7
, 8
, 9
...
```

(I cut the output, it goes from 1 to 100)

After this PR:

```
Loaded repl defun fails-with-args
scratch/kek.repl:23:2: boom
 23 |   (enforce false "boom")
    |   ^^^^^^^^^^^^^^^^^^^^^^
  at (#repl.fails-with-args "a1u23123uh12..." 1024 20 [1 2 3 4 5 6 ...])
  ```


PR checklist:

* [x] Test coverage for the proposed changes
- We don't test for repl error messages, they are not meant to be stable
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [ ] Benchmark regressions
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
