### PR TITLE
remove   pull_request_target trigger

### DIFF
--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -9,9 +9,6 @@ on:
     - '!.github/**'
     - '.github/workflows/applications.yml'
 
-  pull_request_target:
-    types: [ opened ]
-
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This runs a build of master when a PR is opened in addition to the PR branch being built.  It's not needed and is confusing in the view of the PR builds.

PR checklist:

* [ ] Test coverage for the proposed changes
* [ ] PR description contains example output from repl interaction or a snippet from unit test output
* [ ] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [ ] Benchmark regressions
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
