### PR TITLE
Table references as pact values

### DIFF
--- a/gasmodel/Pact/Core/GasModel/Utils.hs
+++ b/gasmodel/Pact/Core/GasModel/Utils.hs
@@ -24,7 +24,6 @@ import Pact.Core.Literal
 import Pact.Core.Type
 import Pact.Core.Capabilities
 import Pact.Core.IR.Desugar
-import Pact.Core.IR.Eval.Runtime
 import Pact.Core.IR.Eval.CEK.CoreBuiltin
 import Pact.Core.PactValue
 import Pact.Core.IR.Term

--- a/pact-tests/Pact/Core/Test/JSONRoundtripTests.hs
+++ b/pact-tests/Pact/Core/Test/JSONRoundtripTests.hs
@@ -62,7 +62,10 @@ tests = testGroup "JSON Roundtrips" $ stableEncodings ++ jsonRoundtrips
     , StableEncodingCase defPactExecGen
     , StableEncodingCase namespaceGen
     , StableEncodingCase pactEventGen
+    , StableEncodingCase tableNameGen
+    , StableEncodingCase tableValueGen
     , StableEncodingCase spanInfoGen
+    , StableEncodingCase typeGen
     ]
   jsonRoundtrips = fmap testJSONRoundtrip $
     [ EncodingCase signerGen

--- a/pact-tests/legacy-serial-tests/coin-v5/coin-v5.repl
+++ b/pact-tests/legacy-serial-tests/coin-v5/coin-v5.repl
@@ -544,7 +544,7 @@
 ; using Pact40 error messages
 (expect-failure
   "create side of cross-chain transfer fails yield on wrong chain"
-  "yield provenance"
+  "Yield provenance does not match"
   (continue-pact 1 false (hash "burn-create")
     { "create-account": 'doug
     , "create-account-guard": (read-keyset 'doug)
@@ -562,7 +562,7 @@
 ; double spends are disallowed by construction
 (expect-failure
   "cross-chain transfer pact prevents double spends"
-  "pact completed"
+  "Requested defpact already completed"
   (continue-pact 1 false (hash "burn-create")))
 
 ; account guard rotation
@@ -768,7 +768,7 @@
 
 (expect-failure
  "account creation fails when no keyset corresponds with keyset ref"
- "no such keyset defined"
+ "Cannot find keyset in database: 'brandon"
  (create-allocation-account "brandon" (time "2020-10-31T00:00:00Z") "brandon" 200000.0))
 
 ; successful keyset refs require defined keyset

--- a/pact-tests/legacy-serial-tests/marmalade-v2/marmalade.repl
+++ b/pact-tests/legacy-serial-tests/marmalade-v2/marmalade.repl
@@ -274,7 +274,7 @@
     })
 
   (expect-failure "offer fails when called directly"
-    "pact-id: not in pact execution"
+    "Attempted to fetch defpact data, but currently not within defpact execution"
     (offer (read-string "token-id") (read-string "account") 1.0)
   )
 

--- a/pact-tests/pact-tests/base64.repl
+++ b/pact-tests/pact-tests/base64.repl
@@ -22,22 +22,22 @@
 
 (expect-failure
   "base64 decoding fails on non base64-encoded input"
-  "Could not decode string"
+  "Decoding error: invalid b64 encoding"
   (base64-decode "aGVsbG8gd29ybGQh%"))
 
 (expect-failure
   "base64 decoding fails on garbage input 1"
-  "Could not decode string"
+  "Decoding error: invalid b64 encoding"
   (base64-decode "aaa"))
 
 (expect-failure
   "base64 decoding fails on garbage input 2"
-  "Could not decode string"
+  "Decoding error: invalid b64 encoding"
   (base64-decode "asdflk"))
 
 (expect-failure
   "base64 decoding fails on garbage input 3"
-  "Could not decode string"
+  "Decoding error: invalid b64 encoding"
   (base64-decode "!@#$%&"))
 
 ; Todo: unicode escape codes?
@@ -53,5 +53,5 @@
 
 (expect-failure
   "base64 decoding fails on non-canonical encodings"
-  "Could not base64-decode string"
+  "Decoding error: invalid b64 encoding"
   (base64-decode "ZE=="))

--- a/pact-tests/pact-tests/caps.repl
+++ b/pact-tests/pact-tests/caps.repl
@@ -752,12 +752,12 @@
 
 (expect-failure
  "emit-event: must be in module"
- "Unable to resolve current calling module"
+ "Emitted event does not match module: events"
  (emit-event (EV)))
 
 (expect-failure
  "emit-event: non-event"
- "must be managed or event defcap"
+ "Invalid event capability events.NON.{Pl17Zu2iMddv942W_ChGFDyPWN4zFVjtVvI8HP4_0AY}"
  (emit-non-event))
 
 (expect
@@ -993,7 +993,7 @@
    )
 
    (defun emit-a(a:integer) (emit-event (A_EVENT a a))))
-   
+
 
 (use B)
 (call-a)

--- a/pact-tests/pact-tests/coin-v1.repl
+++ b/pact-tests/pact-tests/coin-v1.repl
@@ -526,7 +526,7 @@
 ;  (env-exec-config ['DisablePact40, 'DisableInlineMemCheck, 'DisablePact43, "DisablePact44", "DisablePact45"])
 (expect-failure
   "create side of cross-chain transfer fails yield on wrong chain"
-  "does not match (chain"
+  "Yield provenance does not match"
   (continue-pact 1 false (hash "burn-create")
     { "create-account": 'doug
     , "create-account-guard": (read-keyset 'doug)
@@ -548,7 +548,7 @@
 ; double spends are disallowed by construction
 (expect-failure
   "cross-chain transfer pact prevents double spends"
-  "pact completed"
+  "Requested defpact already completed"
   (continue-pact 1 false (hash "burn-create")))
 
 ; account guard rotation
@@ -723,7 +723,7 @@
 
 (expect-failure
  "account creation fails when no keyset corresponds with keyset ref"
- "no such keyset defined"
+ "Cannot find keyset in database: 'brandon"
  (create-allocation-account "brandon" (time "2020-10-31T00:00:00Z") "brandon" 200000.0))
 
 ; successful keyset refs require defined keyset

--- a/pact-tests/pact-tests/coin-v5.repl
+++ b/pact-tests/pact-tests/coin-v5.repl
@@ -555,7 +555,7 @@
 ; using Pact40 error messages
 (expect-failure
   "create side of cross-chain transfer fails yield on wrong chain"
-  "yield provenance"
+  "Yield provenance does not match"
   (continue-pact 1 false (hash "burn-create")
     { "create-account": 'doug
     , "create-account-guard": (read-keyset 'doug)
@@ -573,7 +573,7 @@
 ; double spends are disallowed by construction
 (expect-failure
   "cross-chain transfer pact prevents double spends"
-  "pact completed"
+  "Requested defpact already completed:  defpact id:UT9N17TRzn2FmWlZdT_S7y-AC1A_yOugNbfRSz4VFPE"
   (continue-pact 1 false (hash "burn-create")))
 
 ; account guard rotation
@@ -779,7 +779,7 @@
 
 (expect-failure
  "account creation fails when no keyset corresponds with keyset ref"
- "no such keyset defined"
+ "Cannot find keyset in database: 'brandon"
  (create-allocation-account "brandon" (time "2020-10-31T00:00:00Z") "brandon" 200000.0))
 
 ; successful keyset refs require defined keyset

--- a/pact-tests/pact-tests/db.repl
+++ b/pact-tests/pact-tests/db.repl
@@ -64,35 +64,46 @@
 (env-exec-config []) ;; clear disable history flag except pre-4.2.0
 (begin-tx)
 (use dbtest)
+(expect-failure "module admin protected by admin-key" "Keyset failure (keys-all): [admin...]" (acquire-module-admin dbtest))
 (expect-failure
- "write protected by admin key" "Keyset failure"
+ "write protected by admin key"
+ "Module admin necessary for operation but has not been acquired:dbtest"
  (write persons "foo" ROW_A))
 (expect-failure
- "update protected by admin key" "Keyset failure"
+ "update protected by admin key"
+ "Module admin necessary for operation but has not been acquired:dbtest"
  (update persons "foo" ROW_A))
 (expect-failure
- "insert protected by admin key" "Keyset failure"
+ "insert protected by admin key"
+ "Module admin necessary for operation but has not been acquired:dbtest"
  (insert persons "foo" ROW_A))
 (expect-failure
- "keys protected by admin key" "Keyset failure"
+ "keys protected by admin key"
+ "Module admin necessary for operation but has not been acquired:dbtest"
  (keys persons))
 (expect-failure
- "read protected by admin key" "Keyset failure"
+ "read protected by admin key"
+ "Module admin necessary for operation but has not been acquired:dbtest"
  (read persons ID_A))
 (expect-failure
- "with-read protected by admin key" "Keyset failure"
+ "with-read protected by admin key"
+ "Module admin necessary for operation but has not been acquired:dbtest"
  (with-read persons ID_A { 'name:= name } name))
 (expect-failure
- "with-default-read protected by admin key" "Keyset failure"
+ "with-default-read protected by admin key"
+ "Module admin necessary for operation but has not been acquired:dbtest"
  (with-default-read persons ID_A { 'name: "stu" } { 'name:= name } name))
 (expect-failure
- "select protected by admin key" "Keyset failure"
+ "select protected by admin key"
+ "Module admin necessary for operation but has not been acquired:dbtest"
  (select persons (constantly true)))
 (expect-failure
- "keys protected by admin key" "Keyset failure"
+ "keys protected by admin key"
+ "Module admin necessary for operation but has not been acquired:dbtest"
  (keys persons))
 (expect-failure
- "create-table protected by admin key" "Keyset failure"
+ "create-table protected by admin key"
+ "Module admin necessary for operation but has not been acquired:dbtest"
  (create-table persons2))
 
 ;; just making sure this doesn't blow up, output is still TBD on better Term output in general
@@ -103,13 +114,16 @@
 (env-exec-config ["AllowReadInLocal"])
 (use dbtest)
 (expect-failure
- "write protected by admin key in local" "Keyset failure"
+ "write protected by admin key in local"
+ "Module admin necessary for operation but has not been acquired:dbtest"
  (write persons "foo" ROW_A))
 (expect-failure
- "update protected by admin key in local" "Keyset failure"
+ "update protected by admin key in local"
+ "Module admin necessary for operation but has not been acquired:dbtest"
  (update persons "foo" ROW_A))
 (expect-failure
- "insert protected by admin key in local" "Keyset failure"
+ "insert protected by admin key in local"
+ "Module admin necessary for operation but has not been acquired:dbtest"
  (insert persons "foo" ROW_A))
 (expect
  "keys allowed in local" [ID_A]
@@ -130,7 +144,8 @@
  "keys allowed in local" [ID_A]
  (keys persons))
 (expect-failure
- "create-table protected by admin key in local" "Keyset failure"
+ "create-table protected by admin key in local"
+ "Module admin necessary for operation but has not been acquired:dbtest"
  (create-table persons2))
 
 ;; test nested commits
@@ -286,4 +301,41 @@
 (expect "reading with a no fields returns the full object" {"a": 2,"b": 1} (read tbl "jose" []))
 (expect "selecting with fields on empty fields" [{"a": 2} {"a": 3}] (select tbl ["a"] (constantly true)))
 (expect "selecting with fields with no fields results in empty objects" [{} {}] (select tbl [] (constantly true)))
+(commit-tx)
+
+; DB regression
+(begin-tx)
+(module table-abstraction g (defcap g () true)
+  (defschema sc a:integer b:integer)
+  (defschema sc2 a:integer b:integer c:string)
+  (defschema sc3 a:integer b:integer)
+  (deftable tbl:{sc})
+  (deftable tbl2:{sc2})
+  (deftable tbl3:{sc3})
+  (deftable tbl4:{sc})
+
+  (defun write-to-table:unit (tv:table{sc} k:string v:object{sc})
+    (write tv k v)
+    ()
+  )
+
+  (defun read-from-tables:[object{sc}] (tvs:[table{sc}] k:string)
+    (map (lambda (tv) (read tv k)) tvs)
+  )
+
+)
+
+(create-table tbl)
+(create-table tbl2)
+(create-table tbl3)
+(create-table tbl4)
+
+(expect "can write to table tbl" () (write-to-table tbl "jose" {"a": 1, "b": 2}))
+(expect-failure "Cannot write to tbl2: different schema" "Runtime typecheck failure" (write-to-table tbl2 "jose" {"a": 2, "b": 2}))
+(expect "can write to table tbl4: same schema" () (write-to-table tbl4 "jose" {"a": 3, "b": 2}))
+(expect "can write to table tbl3: different schema, same structure" () (write-to-table tbl3 "jose" {"a": 4, "b": 2}))
+
+(expect "can read from tables with the same schema" [{"a": 1,"b": 2} {"a": 3,"b": 2} {"a": 4,"b": 2}]  (read-from-tables [tbl, tbl4, tbl3] "jose"))
+(expect-failure "Cannot read from tables with different schema" "Runtime typecheck failure" (read-from-tables [tbl, tbl2] "jose"))  
+
 (commit-tx)

--- a/pact-tests/pact-tests/defpact.repl
+++ b/pact-tests/pact-tests/defpact.repl
@@ -19,7 +19,7 @@
 (use defcap-module)
 
 (expect "should return 'step-0'" "step-0" (defpact-single-step))
-(expect-failure "should not executing step again" "not-step-0" (defpact-single-step))
+(expect-failure "should not executing step again" "defpact execution context already in the environment" (defpact-single-step))
 (commit-tx)
 
 

--- a/pact-tests/pact-tests/gov.repl
+++ b/pact-tests/pact-tests/gov.repl
@@ -79,5 +79,5 @@
 (expect-failure
  "gov not granted after install"
  "autonomous-ns-gov"
- (write user.ns-gov.t "a" { 's: "x" }))
+ (acquire-module-admin user.ns-gov))
 

--- a/pact-tests/pact-tests/keysets.repl
+++ b/pact-tests/pact-tests/keysets.repl
@@ -78,18 +78,18 @@
 
 (expect-failure
   "Defining un-namespaced keys fails - env keys, name failure"
-  "Cannot define a keyset outside of a namespace"
+  "Cannot define keyset outside of a namespace"
   (define-keyset 'alice-keys))
 
 ;; Show failure on lookup for keys
 (expect-failure
   "Defining un-namespaced keys fails - actual keys, name failure"
-  "Cannot define a keyset outside of a namespace"
+  "Cannot define keyset outside of a namespace"
   (define-keyset 'alice (read-keyset 'alice-keys)))
 
 (expect-failure
   "Defining namespaced key fails - env keys, outside namespace"
-  "Cannot define a keyset outside of a namespace"
+  "Cannot define keyset outside of a namespace"
   (define-keyset "alice.alice-keys"))
 
 (namespace 'alice)
@@ -130,7 +130,7 @@
 
 (expect-failure
   "keyset definition parsing is not permissive post-pact-4.4 - define-keyset"
-  "Cannot define a keyset outside"
+  "Cannot define keyset outside"
   (define-keyset "TEST <2>."))
 
 (expect-failure
@@ -140,17 +140,17 @@
 (namespace 'alice)
 (expect-failure
   "keyset name format is not permissive post-pact-4.4 - empty-keyset - define-keyset"
-  "incorrect keyset name format"
+  "Invalid keyset name format"
   (define-keyset ""))
 
 (expect-failure
   "keyset name format is not permissive post-pact-4.4 - empty-keyset - enforce-keyset"
-  "incorrect keyset name format"
+  "Invalid keyset name format"
   (enforce-keyset ""))
 
 (expect-failure
   "keyset name format is not permissive post-pact-4.4 - empty keyset - enforce-guard - keyset ref"
-  "incorrect keyset name format"
+  "Invalid keyset name format"
   (enforce-guard (keyset-ref-guard "")))
 
 ;; admin/user guard differentiation in keyset

--- a/pact-tests/pact-tests/marmalade/pact/marmalade.repl
+++ b/pact-tests/pact-tests/marmalade/pact/marmalade.repl
@@ -262,7 +262,7 @@
     })
 
   (expect-failure "offer fails when called directly"
-    "pact-id: not in pact execution"
+    "Attempted to fetch defpact data, but currently not within defpact execution"
     (offer (read-string "token-id") (read-string "account") 1.0)
   )
 

--- a/pact-tests/pact-tests/nested-defpacts.repl
+++ b/pact-tests/pact-tests/nested-defpacts.repl
@@ -369,29 +369,29 @@
 ; Case 2 test
 (begin-tx)
 (expect "Case 2: step 0" ["hello1-nested" "hello1-nested" "hello1"] (parent.bad-parent))
-(expect-failure "Case 2: step 1" "Nested defpacts were not all advanced in prior step for pact" (continue-pact 1))
+(expect-failure "Case 2: step 1" "Nested defpact not advanced DldRwCblQ7Loqy6wYJnaodHl30d3j3eH-qtFzfEv46g" (continue-pact 1))
 (commit-tx)
 
 ; Case 3 test
 (begin-tx)
 (expect "Case 3: step 0" ["hello1-nested" "hello1-nested" "hello1"] (parent.bad1))
-(expect-failure "Case 3: step 1" "Nested defpacts were not all advanced in prior step for pact" (continue-pact 1))
+(expect-failure "Case 3: step 1" "Nested defpact not advanced 183L52xV0ivDcgsehtAOwvlOXTeLYmG00yIySUiXBAY" (continue-pact 1))
 (commit-tx)
 
 ; Case 4 test
 (begin-tx)
-(expect-failure "Case 4: step 0" "applyNestedPact: invalid nested defpact length, must be equal to length of parent" (parent.bad2))
+(expect-failure "Case 4: step 0" "Nested defpact execution failed, parameter mismatch: PactId: DldRwCblQ7Loqy6wYJnaodHl30d3j3eH-qtFzfEv46g step count: 2 Parent step count: 3" (parent.bad2))
 (commit-tx)
 
 ; Case 5 test
 (begin-tx)
-(expect-failure "Case 5: step 0" "applyNestedPact: invalid nested defpact length, must be equal to length of parent" (parent.bad3))
+(expect-failure "Case 5: step 0" "Nested defpact execution failed, parameter mismatch: PactId: 5I6koMWVHo7UQhUSpFjWBqxHKW5erkEzT9CuAmjbZ6U step count: 2 Parent step count: 3" (parent.bad3))
 (commit-tx)
 
 ; Case 6 test
 (begin-tx)
 (expect "Case 6: step 0" ["hello1-nested" "hello1-nested" "hello1"] (parent.bad4))
-(expect-failure "Case 6: step 1" "Attempting to continue a pact that was not nested" (continue-pact 1))
+(expect-failure "Case 6: step 1" "Requested nested defpact double execution: defpact id: z7mCQuEV5PzQ0A0jfOD9UV0W7InCocHSoJqno8xZNWw" (continue-pact 1))
 (commit-tx)
 
 ; Nested yields

--- a/pact-tests/pact-tests/strings.repl
+++ b/pact-tests/pact-tests/strings.repl
@@ -4,12 +4,12 @@
 (expect "str-to-list on str returns a list of single char strings"
   ["a" "b" "c"] (str-to-list "abc"))
 (expect "str-to-list on empty string" [] (str-to-list ""))
-(expect-failure "str-to-list fails on list" "Invalid arguments" (str-to-list []))
+(expect-failure "str-to-list fails on list" "Type error" (str-to-list []))
 
 "===== concat"
 (expect "concat works on empty list" "" (concat []))
 (expect "concat works on list of str" "abc" (concat ["a" "b" "c"]))
 (expect "concat works on list of multi char strings" "aabbcc" (concat ["aa" "bb" "cc"]))
 (expect "concat works singleton list" "abc" (concat ["abc"]))
-(expect-failure "concat fails when not all elems are strings" "concat: expecting list of strings" (concat ["a" "b" 2]))
-(expect-failure "concat fails on non list" "Invalid arguments" (concat "hello"))
+(expect-failure "concat fails when not all elems are strings" "Type error" (concat ["a" "b" 2]))
+(expect-failure "concat fails on non list" "Type error" (concat "hello"))

--- a/pact/Pact/Core/Errors.hs
+++ b/pact/Pact/Core/Errors.hs
@@ -440,6 +440,7 @@ pactValueToArgTypeError = \case
   PGuard _ -> ATEPrim PrimGuard
   PModRef _ -> ATEModRef
   PCapToken _ -> ATEClosure
+  PTable _ -> ATETable
 
 typeToArgTypeError :: Type -> ArgTypeError
 typeToArgTypeError = \case
@@ -781,7 +782,7 @@ instance Pretty EvalError where
     NestedDefPactParentStepCountMismatch pid stepCount parentStepCount ->
       Pretty.hsep
       [ "Nested defpact execution failed, parameter mismatch:"
-      , "PacId: " <> pretty pid
+      , "PactId: " <> pretty pid
       , "step count: " <> pretty stepCount
       , "Parent step count: " <> pretty parentStepCount
       ]
@@ -825,7 +826,7 @@ instance Pretty EvalError where
     InvalidManagedCap fqn ->
       "Install capability error: capability is not managed and cannot be installed:" <+> pretty (fqnToQualName fqn)
     CapNotInstalled cap ->
-      "Capability not installed:" <+> pretty cap
+      "Managed capability not installed:" <+> pretty cap
     CapAlreadyInstalled cap ->
       "Capability already installed:" <+> pretty cap
     ModuleMemberDoesNotExist fqn ->
@@ -856,7 +857,7 @@ instance Pretty EvalError where
     NativeIsTopLevelOnly b ->
       "Top-level call used in module" <+> pretty b
     EventDoesNotMatchModule mn ->
-      "Emitted event does not match module" <+> pretty mn
+      "Emitted event does not match module:" <+> pretty mn
     InvalidEventCap fqn ->
       "Invalid event capability" <+> pretty fqn
     NestedDefpactsNotAdvanced dpid ->
@@ -1434,7 +1435,7 @@ evalErrorToBoundedText = mkBoundedText . \case
     thsep ["Install capability failed. Capability is not declared as a managed capability and cannot be installed.", tFqn fqn]
   CapNotInstalled cap ->
     thsep
-      ["Capability"
+      ["Managed capability"
       , renderQualName (_ctName cap)
       , "was not installed."
       , "Check the sigs field or the arguments to verify that the capability is specified correctly."]

--- a/pact/Pact/Core/IR/Eval/CEK/CoreBuiltin.hs
+++ b/pact/Pact/Core/IR/Eval/CEK/CoreBuiltin.hs
@@ -805,7 +805,7 @@ coreEnforceGuard info b cont handler env = \case
     chargeGasArgs info $ GStrOp $ StrOpParse $ T.length s
     case parseAnyKeysetName s of
       Left {} ->
-        throwNativeExecutionError info b "incorrect keyset name format"
+        throwExecutionError info (InvalidKeysetNameFormat s)
       Right ksn -> isKeysetNameInSigs info cont handler env ksn
   args -> argsError info b args
 
@@ -814,7 +814,7 @@ keysetRefGuard info b cont handler env = \case
   [VString g] -> do
     chargeGasArgs info $ GStrOp $ StrOpParse $ T.length g
     case parseAnyKeysetName g of
-      Left {} -> throwNativeExecutionError info b "incorrect keyset name format"
+      Left {} -> throwExecutionError info (InvalidKeysetNameFormat g)
       Right ksn -> do
         let pdb = view cePactDb env
         liftGasM info (_pdbRead pdb DKeySets ksn) >>= \case
@@ -829,7 +829,6 @@ coreTypeOf info b cont handler _env = \case
     VPactValue pv ->
       returnCEKValue cont handler $ VString $ renderType $ synthesizePvType pv
     VClosure _ -> returnCEKValue cont handler $ VString "<<closure>>"
-    VTable tv -> returnCEKValue cont handler $ VString (renderType (TyTable (_tvSchema tv)))
   args -> argsError info b args
 
 coreDec :: (IsBuiltin b) => NativeFunction e b i
@@ -1603,7 +1602,7 @@ dbDescribeKeySet info b cont handler env = \case
           Nothing ->
             throwExecutionError info (NoSuchKeySet ksn)
       Left{} ->
-        throwNativeExecutionError info b  "incorrect keyset name format"
+        throwExecutionError info (InvalidKeysetNameFormat s)
   args -> argsError info b args
 
 coreCompose :: (IsBuiltin b) => NativeFunction e b i

--- a/pact/Pact/Core/IR/Eval/CEK/Types.hs
+++ b/pact/Pact/Core/IR/Eval/CEK/Types.hs
@@ -59,6 +59,7 @@ module Pact.Core.IR.Eval.CEK.Types
  , pattern VPartialNative
  , pattern VCapToken
  , pattern VTime
+ , pattern VTable
  , CapCont(..)
  , CapState(..)
  , csSlots, csManaged
@@ -242,8 +243,6 @@ instance (NFData b, NFData i) => NFData (CanApply e b i)
 data CEKValue (e :: RuntimeMode) (b :: K.Type) (i :: K.Type)
   = VPactValue !PactValue
   -- ^ PactValue(s), which contain no terms
-  | VTable !TableValue
-  -- ^ Table references, which despite being a syntactic
   -- value with
   | VClosure  !(CanApply e b i)
   -- ^ Closures, which may contain terms
@@ -254,11 +253,13 @@ instance (NFData b, NFData i) => NFData (CEKValue e b i)
 instance Show (CEKValue e b i) where
   show = \case
     VPactValue pv -> show pv
-    VTable vt -> "table" <> show (_tvName vt)
     VClosure _ -> "closure<>"
 
 pattern VLiteral :: Literal -> CEKValue e b i
 pattern VLiteral lit = VPactValue (PLiteral lit)
+
+pattern VTable :: TableValue -> CEKValue e b i
+pattern VTable tv = VPactValue (PTable tv)
 
 pattern VString :: Text -> CEKValue e b i
 pattern VString txt = VLiteral (LString txt)
@@ -575,7 +576,6 @@ instance (Pretty b, Show i, Show b) => Pretty (NativeFn e b i) where
 instance (Show i, Show b, Pretty b) => Pretty (CEKValue e b i) where
   pretty = \case
     VPactValue pv -> pretty pv
-    VTable tv -> "table" <> P.braces (pretty (_tvName tv))
     VClosure{} ->
       P.angles "closure#"
 

--- a/pact/Pact/Core/IR/Eval/CEK/Utils.hs
+++ b/pact/Pact/Core/IR/Eval/CEK/Utils.hs
@@ -50,7 +50,7 @@ toArgTypeError = \case
     PGuard _ -> ATEPrim PrimGuard
     PModRef _ -> ATEModRef
     PCapToken _ -> ATEClosure
-  VTable{} -> ATETable
+    PTable _ -> ATETable
   VClosure{} -> ATEClosure
 
 --------------------------

--- a/pact/Pact/Core/IR/Eval/Direct/ReplBuiltin.hs
+++ b/pact/Pact/Core/IR/Eval/Direct/ReplBuiltin.hs
@@ -116,16 +116,13 @@ coreExpectFailure info b _env = \case
   [VString desc, VString toMatch, VClosure vclo] -> do
     es <- get
     tryError (applyLamUnsafe vclo []) >>= \case
-      Left (PEUserRecoverableError userErr _ _) -> do
+      Left userErr -> do
         put es
         let err = renderCompactText userErr
         if toMatch `T.isInfixOf` err
           then return $ VLiteral $ LString $ "Expect failure: Success: " <> desc
           else return $ VLiteral $ LString $
                "FAILURE: " <> desc <> ": expected error message '" <> toMatch <> "', got '" <> err <> "'"
-      Left _err -> do
-        put es
-        return $ VLiteral $ LString $ "Expect failure: Success: " <> desc
       Right v ->
         return $ VLiteral $ LString $ "FAILURE: " <> toMatch <> ": expected failure, got result: " <> prettyShowValue v
   args -> argsError info b args

--- a/pact/Pact/Core/IR/Eval/Runtime/Types.hs
+++ b/pact/Pact/Core/IR/Eval/Runtime/Types.hs
@@ -13,8 +13,7 @@
 {-# LANGUAGE InstanceSigs #-}
 
 module Pact.Core.IR.Eval.Runtime.Types
-  ( TableValue(..)
-  , ErrorState(..)
+  (ErrorState(..)
   , EvalCapType(..)) where
 
 
@@ -26,20 +25,9 @@ import Control.DeepSeq
 import Pact.Core.Names
 
 import Pact.Core.PactValue
-import Pact.Core.Hash
-import Pact.Core.Type
 import Pact.Core.Capabilities
 import Pact.Core.Environment
 
-
-data TableValue
-  = TableValue
-  { _tvName :: !TableName
-  , _tvHash :: !ModuleHash
-  , _tvSchema :: !Schema
-  } deriving (Show, Generic)
-
-instance NFData TableValue
 
 -- | State to preserve in the error handler
 data ErrorState i

--- a/pact/Pact/Core/IR/ModuleHashing.hs
+++ b/pact/Pact/Core/IR/ModuleHashing.hs
@@ -113,6 +113,9 @@ updatePactValueHash mname mhash = \case
   PCapToken (CapToken ct pvs) ->
     PCapToken $ CapToken (updateFqNameHash mname mhash ct) (updatePactValueHash mname mhash <$> pvs)
   PTime t -> PTime t
+  PTable tv@(TableValue tn _ sc)
+    | _tableModuleName tn == mname -> PTable (TableValue tn mhash sc)
+    | otherwise -> PTable tv
 
 encodeModule :: (Serialise (SerialiseV1 b)) => Module Name Type b () -> B.ByteString
 encodeModule (Module mname mgov defs mblessed imports mimps _mh _txh _mcode _i) =

--- a/pact/Pact/Core/PactValue.hs
+++ b/pact/Pact/Core/PactValue.hs
@@ -30,6 +30,7 @@ module Pact.Core.PactValue
  , _PUnit
  , synthesizePvType
  , pactValueToText
+ , TableValue(..)
  ) where
 
 import Control.Lens
@@ -54,7 +55,20 @@ import Pact.Core.Literal
 import Pact.Core.Pretty
 import Pact.Core.ModRefs
 import Pact.Core.Capabilities
+import Pact.Core.Hash
 
+
+data TableValue
+  = TableValue
+  { _tvName :: !TableName
+  , _tvHash :: !ModuleHash
+  , _tvSchema :: !Schema
+  } deriving (Show, Eq, Ord, Generic)
+
+instance Pretty TableValue where
+  pretty (TableValue n _ _) = pretty (renderTableName n)
+
+instance NFData TableValue
 
 data PactValue
   = PLiteral !Literal
@@ -63,6 +77,7 @@ data PactValue
   | PObject !(Map Field PactValue)
   | PModRef !ModRef
   | PCapToken !(CapToken FullyQualifiedName PactValue)
+  | PTable !TableValue
   | PTime !PactTime.UTCTime
   -- Note:
   -- This ord instance is dangerous. Be careful of comparisons with it
@@ -117,6 +132,7 @@ instance Pretty PactValue where
     PCapToken (CapToken fqn args) ->
       "CapToken" <> pretty (CapToken (fqnToQualName fqn) args)
     PTime t -> dquotes $ pretty (formatLTime t)
+    PTable t -> pretty t
 
 
 pactValueToText :: PactValue -> Text
@@ -161,6 +177,8 @@ pactValueToText = \case
     qualName = fqnToQualName qn
     in T.concat ["CapToken(", renderQualName qualName, args',")"] -- Todo: check
   PTime t -> tdquotes $ formatLTime t
+  PTable (TableValue tn _ _) ->
+    renderTableName tn
   where
     tdquotes x = T.concat ["\"",x,"\""]
     tshow :: Show a => a -> Text
@@ -185,6 +203,7 @@ instance Pretty (AbbrevPretty PactValue) where
     PTime t -> pretty (PactTime.formatTime "%Y-%m-%d %H:%M:%S%Q %Z" t)
     PList l ->
       brackets (prettyAbbrevText' 15 (hsep (pretty . AbbrevPretty <$> V.toList (V.take 10 l))))
+    PTable t -> prettyAbbrevText' 20 (pretty t)
 
 synthesizePvType :: PactValue -> Type
 synthesizePvType = \case
@@ -195,6 +214,7 @@ synthesizePvType = \case
   PObject _ -> TyAnyObject
   PCapToken {} -> TyCapToken
   PTime _ -> TyTime
+  PTable sc -> TyTable (_tvSchema sc)
 
 
 

--- a/pact/Pact/Core/Persistence/SQLite.hs
+++ b/pact/Pact/Core/Persistence/SQLite.hs
@@ -128,12 +128,15 @@ createSysTables db = do
   where
     mkTbl tbl = do
       SQL.exec db (cStmt tbl)
+      SQL.exec db (indexStmt tbl)
       mkTblStatement db tbl
     cStmt tbl = "CREATE TABLE IF NOT EXISTS \"" <> tbl <> "\" \
-                \ (txid UNSIGNED BIG INT, \
-                \  rowkey TEXT, \
-                \  rowdata BLOB, \
-                \  UNIQUE (txid, rowkey))"
+                \ (rowkey TEXT,  \
+                \  txid UNSIGNED BIGINT NOT NULL, \
+                \  rowdata BLOB NOT NULL, \
+                \  UNIQUE (txid, rowkey));"
+    indexStmt tbl =
+      "CREATE INDEX IF NOT EXISTS \"" <> tbl <> "_ix\"" <> " ON \"" <> tbl <> "\" (txid DESC);"
 
 data TblStatements
   = TblStatements

--- a/pact/Pact/Core/Repl.hs
+++ b/pact/Pact/Core/Repl.hs
@@ -63,7 +63,6 @@ runRepl = do
       putStrLn $ T.unpack $ replError (SourceCode "(interactive)" "") err
     _ -> pure ()
   where
-
   replSettings = Settings (replCompletion replCoreBuiltinNames) (Just ".pc-history") True
   displayOutput :: (Pretty a, MonadIO m) => a -> InputT m ()
   displayOutput = outputStrLn . show . pretty

--- a/pact/Pact/Core/Repl/Runtime/ReplBuiltin.hs
+++ b/pact/Pact/Core/Repl/Runtime/ReplBuiltin.hs
@@ -125,9 +125,13 @@ coreExpectFailure info b cont handler _env = \case
           then returnCEKValue cont handler $ VLiteral $ LString $ "Expect failure: Success: " <> desc
           else returnCEKValue cont handler $ VLiteral $ LString $
                "FAILURE: " <> desc <> ": expected error message '" <> toMatch <> "', got '" <> err <> "'"
-      Left _err -> do
+      Left errMsg -> do
         put es
-        returnCEKValue cont handler $ VLiteral $ LString $ "Expect failure: Success: " <> desc
+        let err = renderCompactText errMsg
+        if toMatch `T.isInfixOf` err
+          then returnCEKValue cont handler $ VLiteral $ LString $ "Expect failure: Success: " <> desc
+          else returnCEKValue cont handler $ VLiteral $ LString $
+               "FAILURE: " <> desc <> ": expected error message '" <> toMatch <> "', got '" <> err <> "'"
       Right (EvalValue v) ->
         returnCEKValue cont handler $ VLiteral $ LString $ "FAILURE: " <> toMatch <> ": expected failure, got result: " <> prettyShowValue v
   args -> argsError info b args

--- a/pact/Pact/Core/Serialise/CBOR_V1.hs
+++ b/pact/Pact/Core/Serialise/CBOR_V1.hs
@@ -980,6 +980,24 @@ instance Serialise (SerialiseV1 name) => Serialise (SerialiseV1 (CapToken name P
     SerialiseV1 <$> (CapToken <$> decodeS <*> decodeS)
   {-# INLINE decode #-}
 
+instance Serialise (SerialiseV1 TableName) where
+  encode (SerialiseV1 (TableName tn mn)) =
+    encodeListLen 2 <> encode tn <> encodeS mn
+  {-# INLINE encode #-}
+  decode = do
+    safeDecodeListLen 2 "TableName"
+    SerialiseV1 <$> (TableName <$> decode <*> decodeS)
+  {-# INLINE decode #-}
+
+instance Serialise (SerialiseV1 TableValue) where
+  encode (SerialiseV1 (TableValue tn k v)) =
+    encodeListLen 3 <> encodeS tn <> encodeS k <> encodeS v
+  {-# INLINE encode #-}
+  decode = do
+    safeDecodeListLen 3 "TableValue"
+    SerialiseV1 <$> (TableValue <$> decodeS <*> decodeS <*> decodeS)
+  {-# INLINE decode #-}
+
 instance Serialise (SerialiseV1 PactValue) where
   encode (SerialiseV1 pv) =
     encodeListLen 2 <>
@@ -991,6 +1009,7 @@ instance Serialise (SerialiseV1 PactValue) where
       PModRef mr -> encodeWord 4 <> encodeS mr
       PCapToken ct -> encodeWord 5 <> encodeS ct
       PTime (UTCTime (NominalDiffTime pt)) -> encodeWord 6 <> encode pt
+      PTable t -> encodeWord 7 <> encodeS t
   {-# INLINE encode #-}
   decode = do
     safeDecodeListLen 2 "PactValue"
@@ -1002,6 +1021,7 @@ instance Serialise (SerialiseV1 PactValue) where
       4 -> PModRef <$> decodeS
       5 -> PCapToken <$> decodeS
       6 -> PTime . UTCTime . NominalDiffTime <$> decode
+      7 -> PTable <$> decodeS
       _ -> fail "unexpected decoding"
   {-# INLINE decode #-}
 

--- a/pact/Pact/Core/SizeOf.hs
+++ b/pact/Pact/Core/SizeOf.hs
@@ -366,6 +366,8 @@ makeSizeOf ''DefManagedMeta
 makeSizeOf ''DefCapMeta
 makeSizeOf ''Governance
 makeSizeOf ''ModRef
+makeSizeOf ''TableName
+makeSizeOf ''TableValue
 makeSizeOf ''PactValue
 makeSizeOf ''DefPactContinuation
 makeSizeOf ''Provenance

--- a/pact/Pact/Core/Type.hs
+++ b/pact/Pact/Core/Type.hs
@@ -120,7 +120,9 @@ data Type
 instance NFData Type
 
 data Schema
-  = Schema QualifiedName (Map Field Type)
+  = Schema
+  { _scName :: QualifiedName
+  , _scFields :: Map Field Type }
   deriving (Eq, Show, Ord, Generic)
 
 instance NFData Schema
@@ -255,7 +257,7 @@ instance Pretty Type where
       "object" <> Pretty.braces (pretty n)
     TyTable (Schema n _sc) ->
       "table" <> Pretty.braces (pretty n)
-    TyCapToken -> "CAPTOKEN"
+    TyCapToken -> "cap-token"
     TyAnyList -> "list"
     TyAnyObject -> "object"
     TyAny -> "*"


### PR DESCRIPTION
We are unnecessarily nerfing table references in pact-5 to not be able to be passed to functions. This undoes the nerf, and makes them typecheck-able

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [x] Benchmark regressions
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
