### PR TITLE
Integration: Fix Hash ordering from StableEncoding

### DIFF
--- a/pact-tests/pact-tests/hash.repl
+++ b/pact-tests/pact-tests/hash.repl
@@ -34,6 +34,8 @@
 (insert-hash "c" (hash [my-mod, {'a:my-mod}, (create-user-guard (f my-mod))]))
 (insert-hash "d" (hash [my-mod, {'a:my-mod}, (create-user-guard (f my-mod))]))
 
+(expect "Hash of objects with multiple values:" "JRdgzVN17Xy4-8dWegAKj_BPNv6ffNpbtT6YOCiUcY8" (hash (chain-data)))
+
 (let*
   ( (h1 (get-hash "a"))
     (h2 (get-hash "b"))

--- a/pact/Pact/Core/StableEncoding.hs
+++ b/pact/Pact/Core/StableEncoding.hs
@@ -30,6 +30,7 @@ import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import qualified Pact.JSON.Decode as JD
 import qualified Pact.JSON.Encode as J
+import qualified Pact.JSON.Legacy.Utils as J
 import Unsafe.Coerce (unsafeCoerce)
 
 import Pact.Core.Capabilities
@@ -389,9 +390,9 @@ instance J.Encode (StableEncoding KeySet) where
 
 -- | Stable encoding of `Map Field PactValue`
 instance J.Encode (StableEncoding v) => J.Encode (StableEncoding (Map Field v)) where
-  build (StableEncoding o) = J.build $ J.Object $ c (M.toList o)
+  build (StableEncoding o) = J.build $ J.legacyMap _field (c o)
     where
-    c :: [(Field, v)] -> [(T.Text, StableEncoding v)]
+    c :: Map k v -> Map k (StableEncoding v)
     c = coerce
   {-# INLINABLE build #-}
 


### PR DESCRIPTION
This PR fixes the ordering for `StableEncoding` outputs for `PactValue` objects, and adds a simple regression `(hash (chain-data))`, which passes in both prod and pact-5

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [x] Benchmark regressions
N/A
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
