### PR TITLE
Make evalGasPayerCap have the same Expr type as evalExecTerm

### DIFF
--- a/pact/Pact/Core/Evaluate.hs
+++ b/pact/Pact/Core/Evaluate.hs
@@ -261,11 +261,11 @@ evalGasPayerCap
   -> Set ExecutionFlag -> NamespacePolicy
   -> PublicData -> MsgData
   -> CapState QualifiedName PactValue
-  -> Lisp.Expr Info -> IO (Either (PactError Info) EvalResult)
+  -> Lisp.Expr SpanInfo -> IO (Either (PactError Info) EvalResult)
 evalGasPayerCap capToken db spv gasModel flags nsp publicData msgData capState body = do
   evalEnv <- setupEvalEnv db Transactional msgData Nothing gasModel nsp spv publicData flags
   let evalState = def & esCaps .~ capState
-  interpretGasPayerTerm evalEnv evalState capToken body
+  interpretGasPayerTerm evalEnv evalState capToken (def <$ body)
 
 
 interpret

--- a/pact/Pact/Core/Serialise/LegacyPact.hs
+++ b/pact/Pact/Core/Serialise/LegacyPact.hs
@@ -705,9 +705,9 @@ fromLegacyTerm mh = \case
       BuiltinForm CAnd{} _ -> traverse (fromLegacyTerm mh) args >>= \case
         [b1, b2] -> pure (BuiltinForm (CAnd b1 b2) ())
         [b1] -> mkOneArgLam $ \x -> BuiltinForm (CAnd b1 x) ()
-        [] -> mkTwoArgLam $ \x y -> BuiltinForm (CAnd x y) ()
-        args' ->
-          pure $ App fn' args' ()
+        args' -> do
+          lam <- mkTwoArgLam $ \x y -> BuiltinForm (CAnd x y) ()
+          pure $ App lam args' ()
 
       BuiltinForm COr{} _ -> traverse (fromLegacyTerm mh) args >>= \case
         [b1, b2] -> pure (BuiltinForm (COr b1 b2) ())


### PR DESCRIPTION
Small PR. Changing `Expr Info` to `Expr SpanInfo` is a pretty trivial change which makes all APIs into pact from pactservice consistent.

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [x] Benchmark regressions
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
