### PR TITLE
Fix location for span infos, report better error locations in repl

### DIFF
--- a/docs/builtins/Repl/load.md
+++ b/docs/builtins/Repl/load.md
@@ -1,0 +1,42 @@
+## load
+
+Load and evaluate a file, resetting repl state beforehand if optional RESET is
+true.
+
+
+### Basic syntax
+
+To load a separate pact or repl file, call
+
+```pact
+(load "my-file.pact")
+```
+
+If the load requires resetting repl state, use
+
+```pact
+(load "my-file.pact" true)
+```
+
+
+## Arguments
+
+Use the following argument when using the `load` Pact function.
+
+| Argument | Type     | Description                                                  |
+|----------|----------|--------------------------------------------------------------|
+| File     | string   | The file to load                                             |
+| Reset    | bool     | (Optional) Reset the repl state before loading               |
+
+### Return value
+
+`load` returns the unit value `()`
+
+### Example
+
+The following example demonstrates how to use the `load` function to set "my-key" and "admin-key" as the current transaction signing keys in a Pact REPL:
+
+```pact
+pact> (load "hello-world.repl")
+"Hello pact!"
+```

--- a/pact-lsp/Pact/Core/LanguageServer.hs
+++ b/pact-lsp/Pact/Core/LanguageServer.hs
@@ -40,6 +40,8 @@ import qualified Data.Text.IO as T
 import qualified Data.Text as T
 import System.Exit
 
+import Control.Monad
+import Control.Monad.State.Strict(put)
 import Control.Monad.Reader (ReaderT, runReaderT, ask)
 import Control.Monad.Trans (lift)
 import Control.Concurrent.MVar
@@ -49,6 +51,7 @@ import qualified Pact.Core.Syntax.ParseTree as Lisp
 import qualified Pact.Core.Syntax.Lexer as Lisp
 import qualified Pact.Core.Syntax.Parser as Lisp
 import Pact.Core.IR.Term
+import Pact.Core.Persistence
 import Pact.Core.LanguageServer.Utils
 import Pact.Core.LanguageServer.Renaming
 import Pact.Core.Repl.BuiltinDocs
@@ -59,12 +62,13 @@ import qualified Pact.Core.IR.ModuleHashing as MHash
 import qualified Pact.Core.IR.ConstEval as ConstEval
 import qualified Pact.Core.Repl.Compile as Repl
 import Pact.Core.Interpreter
+import Data.Default
 
 data LSState =
   LSState
   { _lsReplState :: M.Map NormalizedUri (ReplState ReplCoreBuiltin)
   -- ^ Post-Compilation State for each opened file
-  , _lsTopLevel :: M.Map NormalizedUri [EvalTopLevel ReplCoreBuiltin SpanInfo]
+  , _lsTopLevel :: M.Map NormalizedUri [EvalTopLevel ReplCoreBuiltin FileLocSpanInfo]
   -- ^ Top-level terms for each opened file. Used to find the match of a
   --   particular (cursor) position inside the file.
   }
@@ -201,9 +205,9 @@ sendDiagnostics nuri mv content = liftIO (setupAndProcessFile nuri content) >>= 
     -- We emit an empty set of diagnostics
     publishDiagnostics 0  nuri mv $ partitionBySource []
   where
-    pactErrorToDiagnostic :: PactError SpanInfo -> Diagnostic
+    pactErrorToDiagnostic :: PactError FileLocSpanInfo -> Diagnostic
     pactErrorToDiagnostic err = Diagnostic
-      { _range = err ^. peInfo .to spanInfoToRange
+      { _range = err ^. peInfo . spanInfo . to spanInfoToRange
       , _severity = Just DiagnosticSeverity_Error
       , _code = Nothing -- We do not have any error code right now
       , _codeDescription = Nothing
@@ -226,11 +230,11 @@ sendDiagnostics nuri mv content = liftIO (setupAndProcessFile nuri content) >>= 
 setupAndProcessFile
   :: NormalizedUri
   -> Text
-  -> IO (Either (PactError SpanInfo)
+  -> IO (Either (PactError FileLocSpanInfo)
           (ReplState ReplCoreBuiltin
-          ,M.Map NormalizedUri  [EvalTopLevel ReplCoreBuiltin SpanInfo]))
+          ,M.Map NormalizedUri  [EvalTopLevel ReplCoreBuiltin FileLocSpanInfo]))
 setupAndProcessFile nuri content = do
-  pdb <- mockPactDb serialisePact_repl_spaninfo
+  pdb <- mockPactDb serialisePact_repl_fileLocSpanInfo
   let
     builtinMap = if isReplScript fp
                  then replBuiltinMap
@@ -250,11 +254,14 @@ setupAndProcessFile nuri content = do
           -- since there may be no way for us to set it for the LSP from pact directly.
           -- Once this is possible, we can set it to `False` as is the default
           , _replNativesEnabled = True
+          , _replLoad = doLoad
+          , _replLogType = ReplStdOut
+          , _replLoadedFiles = mempty
           , _replOutputLine = const (pure ())
           , _replTestResults = []
           }
   stateRef <- newIORef rstate
-  res <- evalReplM stateRef (processFile Repl.interpretEvalBigStep nuri content)
+  res <- evalReplM stateRef (processFile Repl.interpretEvalBigStep nuri src)
   st <- readIORef stateRef
   pure $ (st,) <$> res
   where
@@ -269,9 +276,10 @@ spanInfoToRange (SpanInfo sl sc el ec) = mkRange
 
 
 getMatch
-  :: Position
-  -> [EvalTopLevel ReplCoreBuiltin SpanInfo]
-  -> Maybe (PositionMatch ReplCoreBuiltin SpanInfo)
+  :: HasSpanInfo i
+  => Position
+  -> [EvalTopLevel ReplCoreBuiltin i]
+  -> Maybe (PositionMatch ReplCoreBuiltin i)
 getMatch pos tl = getAlt (foldMap (Alt . topLevelTermAt pos) tl)
 
 documentDefinitionRequestHandler :: Handlers LSM
@@ -291,7 +299,7 @@ documentDefinitionRequestHandler = requestHandler SMethod_TextDocumentDefinition
           pure Nothing
       _ -> pure Nothing
     debug $ "documentDefinition request: " <> renderText nuri
-    let loc = Location uri' . spanInfoToRange
+    let loc = Location uri' . spanInfoToRange . view spanInfo
     case loc <$> tlDefSpan of
       Just x -> resp (Right $ InL $ Definition (InL x))
       Nothing -> resp (Right $ InR $ InR Null)
@@ -310,7 +318,7 @@ documentHoverRequestHandler = requestHandler SMethod_TextDocumentHover $ \req re
                   (M.lookup (replCoreBuiltinToUserText builtin) builtinDocs)
 
                 mc = MarkupContent MarkupKind_Markdown (_markdownDoc docs)
-                range = spanInfoToRange i
+                range = spanInfoToRange (view spanInfo i)
                 hover = Hover (InL mc) (Just range)
                 in resp (Right (InL hover))
 
@@ -349,40 +357,61 @@ documentRenameRequestHandler = requestHandler SMethod_TextDocumentRename $ \req 
             we = WorkspaceEdit Nothing (Just [InL te]) Nothing
         resp (Right (InL we))
 
+doLoad :: FilePath -> Bool -> EvalM ReplRuntime ReplCoreBuiltin FileLocSpanInfo ()
+doLoad fp reset = do
+  oldSrc <- useReplState replCurrSource
+  fp' <- mangleFilePath fp
+  res <- liftIO $ E.try (T.readFile fp')
+  pactdb <- liftIO (mockPactDb serialisePact_repl_fileLocSpanInfo)
+  oldEE <- useReplState replEvalEnv
+  when reset $ do
+    ee <- liftIO (defaultEvalEnv pactdb replBuiltinMap)
+    put def
+    replEvalEnv .== ee
+  when (Repl.isPactFile fp) $ esLoaded . loToplevel .= mempty
+  _ <- case res of
+    Left (_e:: E.IOException) ->
+      throwExecutionError def $ EvalError $ "File not found: " <> T.pack fp
+    Right txt -> do
+      let source = SourceCode fp txt
+      replCurrSource .== source
+      let nfp = normalizedFilePathToUri (toNormalizedFilePath fp')
+      processFile Repl.interpretEvalBigStep nfp source
+  replCurrSource .== oldSrc
+  unless reset $ do
+    replEvalEnv .== oldEE
+  pure ()
+
+
+mangleFilePath :: FilePath -> EvalM ReplRuntime b FileLocSpanInfo FilePath
+mangleFilePath fp = do
+  (SourceCode currFile _) <- useReplState replCurrSource
+  case currFile of
+    "<local>" -> pure fp
+    _ | isAbsolute fp -> pure fp
+      | takeFileName currFile == currFile -> pure fp
+      | otherwise -> pure $ combine (takeDirectory currFile) fp
+
 processFile
-  :: Interpreter ReplRuntime ReplCoreBuiltin SpanInfo
+  :: Interpreter ReplRuntime ReplCoreBuiltin FileLocSpanInfo
   -> NormalizedUri
-  -> Text
-  -> ReplM ReplCoreBuiltin (M.Map NormalizedUri [EvalTopLevel ReplCoreBuiltin SpanInfo])
-processFile replEnv nuri source = do
-  lexx <- liftEither (Lisp.lexer source)
-  parsed <- liftEither $ Lisp.parseReplProgram lexx
+  -> SourceCode
+  -> ReplM ReplCoreBuiltin (M.Map NormalizedUri [EvalTopLevel ReplCoreBuiltin FileLocSpanInfo])
+processFile replEnv nuri (SourceCode f source) = do
+  lexx <- liftEither $ over _Left (fmap toFileLoc) (Lisp.lexer source)
+  parsed <- liftEither $ bimap (fmap toFileLoc) ((fmap.fmap) toFileLoc) $ Lisp.parseReplProgram lexx
   M.unionsWith (<>) <$> traverse pipe parsed
   where
-    currFile = maybe "<local>" fromNormalizedFilePath (uriToNormalizedFilePath nuri)
-    mangleFilePath fp = case currFile of
-        "<local>" -> pure fp
-        _ | isAbsolute fp -> pure fp
-          | takeFileName currFile == currFile -> pure fp
-          | otherwise -> pure $ combine (takeDirectory currFile) fp
-    pipe rtl = case Repl.topLevelIsReplLoad rtl of
-      Right (Repl.ReplLoadFile fp _ i) -> do
-          fp' <- mangleFilePath (T.unpack fp)
-          res <- liftIO $ E.try (T.readFile fp')
-          case res of
-             Left (_e:: E.IOException) ->
-               throwExecutionError i $ EvalError $ "File not found: " <> fp
-             Right txt -> do
-               let nfp = normalizedFilePathToUri (toNormalizedFilePath fp')
-               processFile replEnv nfp txt
-      Left (Lisp.RTLTopLevel tl) -> do
-        functionDocs tl
-        (ds, deps) <- compileDesugarOnly replEnv tl
-        constEvaled <- ConstEval.evalTLConsts replEnv ds
-        tlFinal <- MHash.hashTopLevel constEvaled
-        let act = M.singleton nuri [ds] <$ evalTopLevel replEnv (RawCode mempty) tlFinal deps
-        catchError act (const (pure mempty))
-      _ ->  pure mempty
+    toFileLoc = FileLocSpanInfo f
+    pipe (Lisp.RTLTopLevel tl) = do
+      functionDocs tl
+      (ds, deps) <- compileDesugarOnly replEnv tl
+      constEvaled <- ConstEval.evalTLConsts replEnv ds
+      tlFinal <- MHash.hashTopLevel constEvaled
+      let act = M.singleton nuri [ds] <$ evalTopLevel replEnv (RawCode mempty) tlFinal deps
+      catchError act (const (pure mempty))
+    pipe _ = pure mempty
+
 
 sshow :: Show a => a -> Text
 sshow = T.pack . show

--- a/pact-repl/Pact/Core/Repl/UserDocs.hs
+++ b/pact-repl/Pact/Core/Repl/UserDocs.hs
@@ -10,7 +10,7 @@ import qualified Pact.Core.Syntax.ParseTree as Lisp
 import Data.Foldable (traverse_)
 
 functionDocs
-  :: Lisp.TopLevel SpanInfo
+  :: Lisp.TopLevel FileLocSpanInfo
   -- The original module syntax
   -> ReplM ReplCoreBuiltin ()
 functionDocs = \case

--- a/pact-tests/Pact/Core/Test/DocsTests.hs
+++ b/pact-tests/Pact/Core/Test/DocsTests.hs
@@ -33,4 +33,4 @@ docsExistsTest b = testCase "Builtins should have docs" $ do
       ,"env-gaslog", "env-gasmodel-fixed", "env-milligas", "env-module-admin"
       ,"env-set-milligas", "env-stackframe", "env-verifiers", "negate"
       ,"pact-state", "print", "reset-pact-state", "rollback-tx", "show"
-      ,"sig-keyset", "test-capability", "env-set-debug-flag"]
+      ,"sig-keyset", "test-capability", "env-set-debug-flag","load-with-env"]

--- a/pact-tests/Pact/Core/Test/LegacySerialiseTests.hs
+++ b/pact-tests/Pact/Core/Test/LegacySerialiseTests.hs
@@ -58,11 +58,11 @@ legacyTests = do
       Nothing -> error "Reading existing modules failed"
       Just ms -> do
         modTests <- fmap concat $ forM repl $ \r -> do
-          sequence [runTest r interpretReplProgramBigStep "CEK", runTest r interpretReplProgramDirect "Direct"]
+          sequence [runTest r interpretEvalBigStep "CEK", runTest r interpretEvalDirect "Direct"]
         pure (testGroup p modTests)
         where
         runTest r interpreter interpName = do
-          pdb <- mockPactDb serialisePact_repl_spaninfo
+          pdb <- mockPactDb serialisePact_repl_fileLocSpanInfo
 
           -- add default spaninfo
           let ms' = (fmap.fmap) (const def) ms

--- a/pact-tests/Pact/Core/Test/ReplTests.hs
+++ b/pact-tests/Pact/Core/Test/ReplTests.hs
@@ -26,27 +26,25 @@ import Pact.Core.Persistence.MockPersistence
 import Pact.Core.Repl.Utils
 import Pact.Core.Persistence.SQLite (withSqlitePactDb)
 
-import Pact.Core.Info (SpanInfo)
-import Pact.Core.Repl.Compile
+import Pact.Core.Info
 import Pact.Core.Environment
 import Pact.Core.Builtin
 import Pact.Core.Errors
 import Pact.Core.Serialise
 import Pact.Core.Persistence
 import Pact.Core.IR.Term
+import Pact.Core.Repl.Compile
 import qualified Pact.Core.IR.ModuleHashing as MH
 
-
-type Interpreter = SourceCode -> ReplM ReplCoreBuiltin [ReplCompileValue]
 
 tests :: IO TestTree
 tests = do
   files <- replTestFiles
   pure $ testGroup "ReplTests"
-    [ testGroup "in-memory db:bigstep" (runFileReplTest interpretReplProgramBigStep <$> files)
-    , testGroup "sqlite db:bigstep" (runFileReplTestSqlite interpretReplProgramBigStep <$> files)
-    , testGroup "in-memory db:direct" (runFileReplTest interpretReplProgramDirect <$> files)
-    , testGroup "sqlite db:direct" (runFileReplTestSqlite interpretReplProgramDirect <$> files)
+    [ testGroup "in-memory db:bigstep" (runFileReplTest interpretEvalBigStep <$> files)
+    , testGroup "sqlite db:bigstep" (runFileReplTestSqlite interpretEvalBigStep <$> files)
+    , testGroup "in-memory db:direct" (runFileReplTest interpretEvalDirect <$> files)
+    , testGroup "sqlite db:direct" (runFileReplTestSqlite interpretEvalDirect <$> files)
     ]
 
 newtype ReplSourceDir
@@ -59,32 +57,32 @@ defaultReplTestDir = "pact-tests" </> "pact-tests"
 replTestFiles :: IO [FilePath]
 replTestFiles = filter (\f -> isExtensionOf "repl" f || isExtensionOf "pact" f) <$> getDirectoryContents defaultReplTestDir
 
-runFileReplTest :: Interpreter -> TestName -> TestTree
+runFileReplTest :: ReplInterpreter -> TestName -> TestTree
 runFileReplTest interp file = testCase file $ do
-  pdb <- mockPactDb serialisePact_repl_spaninfo
+  pdb <- mockPactDb serialisePact_repl_fileLocSpanInfo
   src <- T.readFile (defaultReplTestDir </> file)
   runReplTest (ReplSourceDir defaultReplTestDir) pdb file src interp
 
 
-runFileReplTestSqlite :: Interpreter -> TestName -> TestTree
+runFileReplTestSqlite :: ReplInterpreter -> TestName -> TestTree
 runFileReplTestSqlite interp file = testCase file $ do
   ctnt <- T.readFile (defaultReplTestDir </> file)
-  withSqlitePactDb serialisePact_repl_spaninfo ":memory:" $ \pdb -> do
+  withSqlitePactDb serialisePact_repl_fileLocSpanInfo ":memory:" $ \pdb -> do
     runReplTest (ReplSourceDir defaultReplTestDir) pdb file ctnt interp
 
 runReplTest
   :: ReplSourceDir
-  -> PactDb ReplCoreBuiltin SpanInfo
+  -> PactDb ReplCoreBuiltin FileLocSpanInfo
   -> FilePath
   -> T.Text
-  -> Interpreter
+  -> ReplInterpreter
   -> Assertion
 runReplTest (ReplSourceDir path) pdb file src interp = do
   ee <- defaultEvalEnv pdb replBuiltinMap
   let source = SourceCode (path </> file) src
-  let rstate = mkReplState ee (const (pure ())) & replCurrSource .~ source
+  let rstate = mkReplState ee (const (pure ())) (\f reset -> void (loadFile interp f reset)) & replCurrSource .~ source
   stateRef <- newIORef rstate
-  evalReplM stateRef (interp source) >>= \case
+  evalReplM stateRef (interpretReplProgram interp source) >>= \case
     Left e -> let
       rendered = replError (SourceCode file src) e
       in assertFailure (T.unpack rendered)
@@ -103,8 +101,9 @@ runReplTest (ReplSourceDir path) pdb file src interp = do
   ensureModuleHashesMatch = do
     keys <- ignoreGas def $ _pdbKeys pdb DModules
     traverse_ moduleHashMatches keys
-  ensurePassing (ReplTestResult _testName loc _ res) = case res of
+  ensurePassing (ReplTestResult _testName loc res) = case res of
     ReplTestPassed -> pure()
     ReplTestFailed msg -> do
+      -- Todo: refine this with file locs
       let render = replError (SourceCode file src) (PEExecutionError (EvalError msg) [] loc)
       assertFailure (T.unpack render)

--- a/pact-tests/gas-goldens/builtinGas.golden
+++ b/pact-tests/gas-goldens/builtinGas.golden
@@ -11,7 +11,7 @@
 >=: 264
 ^: 868
 abs: 100
-acquire-module-admin: 295594
+acquire-module-admin: 295598
 add-time: 750
 and?: 628
 at: 706

--- a/pact/Pact/Core/Builtin.hs
+++ b/pact/Pact/Core/Builtin.hs
@@ -781,6 +781,8 @@ data ReplOnlyBuiltin
   | REnvModuleAdmin
   | REnvVerifiers
   | REnvSetDebugFlag
+  | RLoad
+  | RLoadWithEnv
   deriving (Show, Enum, Bounded, Eq, Generic)
 
 
@@ -830,9 +832,8 @@ instance IsBuiltin ReplOnlyBuiltin where
     REnvModuleAdmin -> 1
     REnvVerifiers -> 1
     REnvSetDebugFlag -> 1
-
-    -- RLoad -> 1
-    -- RLoadWithEnv -> 2
+    RLoad -> 1
+    RLoadWithEnv -> 2
 -- Note: commented out natives are
 -- to be implemented later
 data ReplBuiltin b
@@ -916,6 +917,8 @@ replBuiltinsToText = \case
   REnvModuleAdmin -> "env-module-admin"
   REnvVerifiers -> "env-verifiers"
   REnvSetDebugFlag -> "env-set-debug-flag"
+  RLoad -> "load"
+  RLoadWithEnv -> "load-with-env"
 
 replBuiltinToText :: (t -> Text) -> ReplBuiltin t -> Text
 replBuiltinToText f = \case

--- a/pact/Pact/Core/IR/Desugar.hs
+++ b/pact/Pact/Core/IR/Desugar.hs
@@ -186,6 +186,8 @@ instance DesugarBuiltin (ReplBuiltin CoreBuiltin) where
   desugarAppArity i (RBuiltinWrap b) ne =
     desugarCoreBuiltinArity RBuiltinWrap i b ne
   -- (expect <description> <expected> <expression-to-eval>)
+  desugarAppArity i (RBuiltinRepl RLoad) [e1, e2] =
+    App (Builtin (RBuiltinRepl RLoadWithEnv) i) [e1, e2] i
   desugarAppArity i (RBuiltinRepl RExpect) ([e1, e2, e3]) | isn't _Nullary e3 =
     App (Builtin (RBuiltinRepl RExpect) i) ([e1, suspendTerm e2, suspendTerm e3]) i
   -- (expect-failure <arg1> <term>)

--- a/pact/Pact/Core/Info.hs
+++ b/pact/Pact/Core/Info.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE InstanceSigs #-}
 
 module Pact.Core.Info
  ( SpanInfo(..)
@@ -12,6 +14,8 @@ module Pact.Core.Info
  , sliceFromSourceLines
  , LineInfo(..)
  , spanInfoToLineInfo
+ , FileLocSpanInfo(..)
+ , HasSpanInfo(..)
  ) where
 
 import Control.Lens
@@ -71,6 +75,12 @@ instance Pretty SpanInfo where
 spanInfoToLineInfo :: SpanInfo -> LineInfo
 spanInfoToLineInfo = LineInfo . _liStartLine
 
+data FileLocSpanInfo
+  = FileLocSpanInfo
+  { _flsiFile :: !String
+  , _flsiSpan :: !SpanInfo
+  } deriving (Eq, Show, Generic, NFData)
+
 -- | Combine two Span infos
 --   and spit out how far down the expression spans.
 combineSpan :: SpanInfo -> SpanInfo -> SpanInfo
@@ -96,3 +106,14 @@ data Located i a
   { _locLocation :: i
   , _locElem :: a }
   deriving (Show, Eq, Ord, Functor, Foldable, Traversable)
+
+makeClassy ''SpanInfo
+
+instance HasSpanInfo FileLocSpanInfo where
+  spanInfo = lens _flsiSpan (\s i -> s { _flsiSpan = i })
+
+instance Pretty FileLocSpanInfo where
+  pretty (FileLocSpanInfo f s) = pretty f <> " " <> pretty s
+
+instance Default FileLocSpanInfo where
+  def = FileLocSpanInfo "" def

--- a/pact/Pact/Core/Serialise.hs
+++ b/pact/Pact/Core/Serialise.hs
@@ -18,6 +18,7 @@ module Pact.Core.Serialise
   , serialisePact_raw_spaninfo
   , serialisePact_lineinfo
   , serialisePact_repl_spaninfo
+  , serialisePact_repl_fileLocSpanInfo
   , decodeVersion
   , encodeVersion
   , liftReplBuiltin
@@ -162,6 +163,18 @@ serialisePact_repl_spaninfo = serialisePact
         (LegacyDocument . fmap (\_ -> def) . liftReplBuiltin <$> LegacyPact.decodeModuleData bs)
         <|> docDecode bs (\case
                             V1_CBOR -> V1.decodeModuleData_repl_spaninfo
+                        )
+  , _encodeRowData = gEncodeRowData
+  }
+
+serialisePact_repl_fileLocSpanInfo :: PactSerialise ReplCoreBuiltin FileLocSpanInfo
+serialisePact_repl_fileLocSpanInfo = serialisePact
+  { _encodeModuleData = docEncode V1.encodeModuleData_repl_flspaninfo
+  , _decodeModuleData =
+      \bs ->
+        (LegacyDocument . fmap (\_ -> def) . liftReplBuiltin <$> LegacyPact.decodeModuleData bs)
+        <|> docDecode bs (\case
+                            V1_CBOR -> V1.decodeModuleData_repl_flspaninfo
                         )
   , _encodeRowData = gEncodeRowData
   }

--- a/pact/Pact/Core/Serialise/CBOR_V1.hs
+++ b/pact/Pact/Core/Serialise/CBOR_V1.hs
@@ -14,6 +14,7 @@ module Pact.Core.Serialise.CBOR_V1
   ( encodeModuleData, decodeModuleData
   , encodeModuleData_repl_spaninfo, decodeModuleData_repl_spaninfo
   , encodeModuleData_raw_spaninfo, decodeModuleData_raw_spaninfo
+  , encodeModuleData_repl_flspaninfo, decodeModuleData_repl_flspaninfo
   , encodeModuleData_lineinfo, decodeModuleData_lineinfo
   , encodeKeySet, decodeKeySet
   , encodeDefPactExec, decodeDefPactExec
@@ -68,6 +69,9 @@ encodeModuleData = toStrictByteString . encodeS
 encodeModuleData_repl_spaninfo :: ModuleData ReplCoreBuiltin SpanInfo -> ByteString
 encodeModuleData_repl_spaninfo = toStrictByteString . encodeS
 
+encodeModuleData_repl_flspaninfo :: ModuleData ReplCoreBuiltin FileLocSpanInfo -> ByteString
+encodeModuleData_repl_flspaninfo = toStrictByteString . encodeS
+
 encodeModuleData_raw_spaninfo :: ModuleData CoreBuiltin SpanInfo -> ByteString
 encodeModuleData_raw_spaninfo = toStrictByteString . encodeS
 
@@ -88,6 +92,9 @@ decodeModuleData_raw_spaninfo bs = either (const Nothing) (Just . _getSV1) (dese
 
 decodeModuleData_lineinfo :: ByteString -> Maybe (ModuleData CoreBuiltin LineInfo)
 decodeModuleData_lineinfo bs = either (const Nothing) (Just . _getSV1) (deserialiseOrFail (fromStrict bs))
+
+decodeModuleData_repl_flspaninfo :: ByteString -> Maybe (ModuleData ReplCoreBuiltin FileLocSpanInfo)
+decodeModuleData_repl_flspaninfo bs = either (const Nothing) (Just . _getSV1) (deserialiseOrFail (fromStrict bs))
 
 encodeModuleName :: ModuleName -> ByteString
 encodeModuleName = toStrictByteString . encodeS
@@ -852,6 +859,15 @@ instance Serialise (SerialiseV1 SpanInfo) where
   decode = do
     safeDecodeListLen 4 "SpanInfo"
     SerialiseV1 <$> (SpanInfo <$> decode <*> decode <*> decode <*> decode)
+  {-# INLINE decode #-}
+
+instance Serialise (SerialiseV1 FileLocSpanInfo) where
+  encode (SerialiseV1 (FileLocSpanInfo f s)) =
+    encodeListLen 2 <> encode f <> encodeS s
+  {-# INLINE encode #-}
+  decode = do
+    safeDecodeListLen 2 "FileLocSpanInfo"
+    SerialiseV1 <$> (FileLocSpanInfo <$> decode <*> decodeS)
   {-# INLINE decode #-}
 
 instance Serialise (SerialiseV1 LineInfo) where

--- a/pact/Pact/Core/SizeOf.hs
+++ b/pact/Pact/Core/SizeOf.hs
@@ -339,6 +339,11 @@ instance SizeOf (TableSchema name) where
 
 makeSizeOf ''SpanInfo
 
+-- Note: this is a pass through instance, since this is repl-only
+instance SizeOf FileLocSpanInfo where
+  estimateSize (FileLocSpanInfo _f s) =
+    estimateSize s
+
 -- builtins
 instance SizeOf CoreBuiltin where
   estimateSize _ = countBytes (tagOverhead + 1)

--- a/pact/Pact/Core/Syntax/ParseTree.hs
+++ b/pact/Pact/Core/Syntax/ParseTree.hs
@@ -636,7 +636,7 @@ data ReplTopLevel i
   = RTLTopLevel (TopLevel i)
   | RTLDefun (Defun i)
   | RTLDefConst (DefConst i)
-  deriving (Show, Generic, NFData)
+  deriving (Show, Generic, NFData, Functor)
 
 pattern RTLModule :: Module i -> ReplTopLevel i
 pattern RTLModule m = RTLTopLevel (TLModule m)


### PR DESCRIPTION
Closes #262 

Using the example in #262: 

Before this PR:
```
pact>(load "scratch/main-script.repl" true)
"Loading scratch/main-script.repl..."
"Loading nested-script.repl..."
Loaded repl defun just-fail
scratch/main-script.repl:12:2: We fail
 12 | ; Hello
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^
  at (#repl.just-fail.{I3JlcGw})

```


After this PR:
```
pact>(load "scratch/main-script.repl" true)
"Loading scratch/main-script.repl..."
"Loading nested-script.repl..."
Loaded repl defun just-fail
()
scratch/nested-script.repl:12:2: We fail
 12 |   (enforce false "We fail")
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^
  at(#repl.just-fail.{I3JlcGw}):scratch/main-script.repl 2:0-2:11
  ```

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [x] Benchmark regressions
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
