### PR TITLE
Change semantics of install capability

### DIFF
--- a/pact-repl/Pact/Core/IR/Eval/Direct/Evaluator.hs
+++ b/pact-repl/Pact/Core/IR/Eval/Direct/Evaluator.hs
@@ -1022,7 +1022,8 @@ installCap
   -> Bool
   -> EvalM e b i (ManagedCap QualifiedName PactValue)
 installCap info _env (CapToken fqn args) autonomous = do
-  let ct = CapToken (fqnToQualName fqn) args
+  let capQn = fqnToQualName fqn
+      ct = CapToken capQn args
   d <- getDefCap info fqn
   case _dcapMeta d of
     DefManaged m -> case m of
@@ -1034,7 +1035,11 @@ installCap info _env (CapToken fqn args) autonomous = do
         capAlreadyInstalled <- S.member mcap <$> use (esCaps . csManaged)
         when capAlreadyInstalled $ throwExecutionError info (CapAlreadyInstalled ct)
         (esCaps . csManaged) %= S.insert mcap
-        when autonomous $
+        when autonomous $ do
+          let matches (CapToken qn' capArgs') = qn' == capQn && filterIndex paramIx capArgs' == _ctArgs ctFiltered
+          providedCaps <- viewEvalEnv eeMsgSigs
+          forM_ (findOf (folded . folded) matches providedCaps) $ \_ ->
+            throwExecutionError info (CapAlreadyInstalled ct)
           (esCaps . csAutonomous) %= S.insert ct
         pure mcap
       AutoManagedMeta -> do

--- a/pact-tests/pact-tests/caps.repl
+++ b/pact-tests/pact-tests/caps.repl
@@ -1011,3 +1011,29 @@
 [ {"module-hash": "8bdi-0ljmkBGMm06zxB4j4tziHY3qLT-d_UoUwxBDLw"
   ,"name": "A.A_EVENT","params": [ 420 ]} ] (env-events true))
 (commit-tx)
+
+(begin-tx)
+(module m g (defcap g () true)
+
+  (defcap CAP (a:integer b:integer)
+    @managed b CAP-mgr
+    (+ a b)
+  )
+
+  (defun CAP-mgr (mgd:integer req:integer)
+    (enforce (>= mgd req) "not enough floogleblats")
+    (- mgd req)
+  )
+
+  (defun require-cap (a:integer b:integer)
+    (with-capability (CAP a b)
+      (require-capability (CAP a b))))
+)
+
+(env-sigs [{"key":"bob", "caps":[(CAP 1 2)]}])
+(expect-failure "You cannot install a capability twice which is already in the msg sigs"
+  "Capability already installed"
+  (install-capability (CAP 1 3))
+  )
+
+(commit-tx)

--- a/pact-tests/pact-tests/coin-v5.repl
+++ b/pact-tests/pact-tests/coin-v5.repl
@@ -944,6 +944,16 @@
   (map (remove 'module-hash) (env-events true)))
 (rollback-tx)
 
+(begin-tx)
+(env-sigs
+  [{ 'key: 'keys2,
+     'caps: [(coin.TRANSFER 'doug 'emily 1.0),(coin.GAS)]}])
+(expect-failure
+  "You cannot install a capability twice which is already in the msg sigs"
+  "Capability already installed"
+  (install-capability (coin.TRANSFER 'doug 'emily 2.0)))
+(rollback-tx)
+
 ;; ======================================================
 ;; test xchain
 ;; ======================================================


### PR DESCRIPTION
This PR makes `install-capability` check whether a capability is provided in the msg sigs before even trying to install it.

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
```pact
"Setting transaction signatures/caps"
"Expect failure: Success: You cannot install a capability twice which is already in the msg sigs"
"Commit Tx 17"
```
* [x] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [x] Benchmark regressions
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
