### PR TITLE
Fix issues with runtime typechecker

### DIFF
--- a/pact-repl/Pact/Core/IR/Eval/Direct/Evaluator.hs
+++ b/pact-repl/Pact/Core/IR/Eval/Direct/Evaluator.hs
@@ -245,8 +245,11 @@ evaluate env = \case
   Nullary body info -> do
     let clo = VLamClosure (LamClosure NullaryClosure 0 body Nothing env info)
     pure clo
-  Let _ e1 e2 _ -> do
+  Let arg e1 e2 i -> do
     e1val <- evaluate env e1
+    case e1val of
+      VPactValue pv -> maybeTCType i (_argType arg) pv
+      _ -> pure ()
     let newEnv = RAList.cons e1val (_ceLocal env)
     let env' = env {_ceLocal = newEnv }
     evaluate env' e2

--- a/pact-tests/Pact/Core/Test/StaticErrorTests.hs
+++ b/pact-tests/Pact/Core/Test/StaticErrorTests.hs
@@ -376,7 +376,7 @@ desugarTests =
         (implements nonexistent)
         )
       |])
-  , ("module_implements_module", isDesugarError _NoSuchInterface, [text|
+  , ("module_implements_module", isDesugarError _InvalidModuleReference, [text|
       (module notiface ng (defcap ng () true))
 
       (module m g (defcap g () true)

--- a/pact-tests/gas-goldens/builtinGas.golden
+++ b/pact-tests/gas-goldens/builtinGas.golden
@@ -82,7 +82,7 @@ not: 364
 not?: 364
 or?: 364
 pact-id: 169750
-pairing-check: 11063933
+pairing-check: 11064258
 parse-time: 602
 point-add: 5500
 poseidon-hash-hack-a-chain: 6393700
@@ -94,7 +94,7 @@ read-string: 303
 read: 457650
 remove: 360
 require-capability: 304750
-resume: 380331
+resume: 380356
 reverse: 700
 round: 200
 scalar-mult: 360300
@@ -118,7 +118,7 @@ with-default-read: 460916
 with-read: 457833
 write: 452950
 xor: 500
-yield: 247650
+yield: 247675
 zip: 4320
 |: 500
 ~: 250

--- a/pact-tests/pact-tests/runtime-tc.repl
+++ b/pact-tests/pact-tests/runtime-tc.repl
@@ -1,0 +1,46 @@
+; Basic litmus test to ensure that let bindings are typechecked
+(expect "Let typechecking passes" 1 (let ((x:integer 1)) x))
+(expect-failure "Let typechecking fails with incorrect value" (let ((x:string 1)) x))
+
+; Complicated case to ensure that modules do the following:
+; - They typecheck module references correctly
+; - Module reference interfaces are properly mangled
+(begin-tx)
+(module m g (defcap g () true)
+
+  (defun allow () true)
+  (defun get-allow-guard () (create-user-guard (allow)))
+)
+
+(define-namespace "beepo" (get-allow-guard) (get-allow-guard))
+
+(namespace "beepo")
+(interface iface
+  (defun f:integer ())
+  )
+
+(module miface g (defcap g () true)
+  ; This Module ref is fully qualified
+  (implements beepo.iface)
+  (defun f:integer () 2)
+)
+
+(module miface2 g (defcap g () true)
+  ; This module ref is unqualified and should be mangled
+  (implements iface)
+  (defun f:integer () 2)
+)
+
+(commit-tx)
+(begin-tx)
+(namespace "beepo")
+(module typechecks g (defcap g () true)
+  (defschema beepo-schema a:module{iface})
+  ; BEEPO_LIST should have a mix of mangled and unmangled interface names,
+  ; but should typecheck if the module was deployed correctly.
+  (defun BEEPO_LIST:[object{beepo-schema}] () [{"a":miface} {"a":miface2}])
+)
+
+(expect "Beepo list typechecks" [{"a":miface}, {"a":miface2}] (BEEPO_LIST))
+
+(commit-tx)

--- a/pact/Pact/Core/IR/Desugar.hs
+++ b/pact/Pact/Core/IR/Desugar.hs
@@ -979,7 +979,7 @@ resolveInterfaceName i mn@(ModuleName name mNs) =
     getModName = \case
       ModuleData _ _ ->
         throwDesugarError (InvalidModuleReference mn) i
-      InterfaceData _ _ -> pure mn
+      InterfaceData ifn _ -> pure (_ifName ifn)
 
 
 -- | Resolve module data, fail if not found
@@ -1007,7 +1007,7 @@ renameType i = \case
   Lisp.TyList ty ->
     TyList <$> renameType i ty
   Lisp.TyModRef tmr ->
-    TyModRef (S.fromList tmr) <$ traverse (resolveInterfaceName i) tmr
+    TyModRef . S.fromList <$> traverse (resolveInterfaceName i) tmr
   Lisp.TyKeyset -> pure TyGuard
   Lisp.TyObject pn ->
     TyObject <$> resolveSchema pn

--- a/pact/Pact/Core/IR/Eval/CEK/CoreBuiltin.hs
+++ b/pact/Pact/Core/IR/Eval/CEK/CoreBuiltin.hs
@@ -1092,7 +1092,8 @@ dbWithDefaultRead info b cont handler env = \case
         bytes <- sizeOf info SizeOfV0 rdata
         chargeGasArgs info (GRead bytes)
         applyLam clo [VObject rdata] cont handler
-      Nothing -> applyLam clo [VObject defaultObj] cont handler
+      Nothing -> do
+        applyLam clo [VObject defaultObj] cont handler
   args -> argsError info b args
 
 -- | Todo: schema checking here? Or only on writes?
@@ -1763,7 +1764,6 @@ coreChainData info b cont handler _env = \case
                  , (cdSender, PString sender)
                  , (cdGasLimit, PInteger (fromIntegral gasLimit))
                  , (cdGasPrice, PDecimal gasPrice)]
-    liftIO $ putStrLn $ "FIELDS" <> show fields
     returnCEKValue cont handler (VObject fields)
   args -> argsError info b args
 

--- a/pact/Pact/Core/IR/Eval/CEK/CoreBuiltin.hs
+++ b/pact/Pact/Core/IR/Eval/CEK/CoreBuiltin.hs
@@ -1763,6 +1763,7 @@ coreChainData info b cont handler _env = \case
                  , (cdSender, PString sender)
                  , (cdGasLimit, PInteger (fromIntegral gasLimit))
                  , (cdGasPrice, PDecimal gasPrice)]
+    liftIO $ putStrLn $ "FIELDS" <> show fields
     returnCEKValue cont handler (VObject fields)
   args -> argsError info b args
 

--- a/pact/Pact/Core/IR/Eval/CEK/Evaluator.hs
+++ b/pact/Pact/Core/IR/Eval/CEK/Evaluator.hs
@@ -186,9 +186,9 @@ evaluateTerm cont handler env (Nullary body info) = do
 -- | ------ From ---------- | ------ To ------ |
 --   <Let e1 e2, E, K, H>      <e1, E, LetC(E,e2,K), H>
 --
-evaluateTerm cont handler env (Let _ e1 e2 _info) = do
+evaluateTerm cont handler env (Let n e1 e2 info) = do
   -- chargeGasArgs _info (GAConstant constantWorkNodeGas)
-  let cont' = LetC env e2 cont
+  let cont' = LetC env info n e2 cont
   evalCEK cont' handler env e1
 -- | ------ From ---------- | ------ To ------ |
 --   <Lam args body, E, K, H>      <VLamClo(args, body, E), E, K, H>
@@ -999,7 +999,11 @@ applyContToValue (Fn fn env args vs cont) handler v = do
 -- | ------ From ------------ | ------ To ---------------- |
 --   <v, LetC(E, body, K), H>   <body, (cons v E), K, H>
 --
-applyContToValue (LetC env letbody cont) handler v = do
+applyContToValue (LetC env i arg letbody cont) handler v = do
+  case v of
+    VPactValue pv -> do
+      maybeTCType i (_argType arg) pv
+    _ -> pure ()
   evalCEK cont handler (over ceLocal (RAList.cons v) env) letbody
 -- | ------ From ------------ | ------ To ---------------- |
 --   <_, SeqC(E, e2, K), H>     <e2, E, K, H>

--- a/pact/Pact/Core/IR/Eval/CEK/Types.hs
+++ b/pact/Pact/Core/IR/Eval/CEK/Types.hs
@@ -432,7 +432,7 @@ data Cont (e :: RuntimeMode) (b :: K.Type) (i :: K.Type)
   -- ^ Continuation which evaluates arguments for a function to apply
   | Args !(CEKEnv e b i) i ![EvalTerm b i] !(Cont e b i)
   -- ^ Continuation holding the arguments to evaluate in a function application
-  | LetC !(CEKEnv e b i) !(EvalTerm b i) !(Cont e b i)
+  | LetC !(CEKEnv e b i) i (Arg Type i) !(EvalTerm b i) !(Cont e b i)
   -- ^ Let single-variable pushing
   -- Optimization frame: Bypasses closure creation and thus less alloc
   -- Known as a single argument it will not construct a needless closure

--- a/pact/Pact/Core/Serialise/LegacyPact.hs
+++ b/pact/Pact/Core/Serialise/LegacyPact.hs
@@ -559,7 +559,7 @@ fromLegacyPersistDirect = \case
         let c1 = Arg "#constantlyA1" Nothing ()
         let c2 = Arg "#constantlyA2" Nothing ()
         d <- view teDepth
-        pure $ Lam (c1 :| [c2]) (Var (Name "#constantlyA1" (NBound 1), d+1) ()) ()
+        pure $ Lam (c1 :| [c2]) (Var (Name "#constantlyA1" (NBound 1), d+2) ()) ()
 
     | otherwise -> case M.lookup n coreBuiltinMap of
         Just b -> pure (Builtin b ())


### PR DESCRIPTION
The pact 5 runtime TC was skipping let binds, as well as not mangling some interface names correctly which resulted in typechecking failure false positives.

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [x] Benchmark regressions
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
