### PR TITLE
Delete lsp dep from test-utils

### DIFF
--- a/pact-tng.cabal
+++ b/pact-tng.cabal
@@ -477,8 +477,6 @@ library test-utils
     , neat-interpolation
     , pact-tng:pact-request-api
     , pact-tng:unsafe
-    , lsp-test >= 0.17
-    , lsp-types
     , pact-time
 
   exposed-modules:


### PR DESCRIPTION
This just removes an extra dep for chainweb tests too.