### PR TITLE
Make pact throw an error on unused partial application

### DIFF
--- a/pact-repl/Pact/Core/Repl/Runtime/ReplBuiltin.hs
+++ b/pact-repl/Pact/Core/Repl/Runtime/ReplBuiltin.hs
@@ -385,7 +385,7 @@ testCapability info b cont handler env = \case
   [VCapToken origToken] -> do
     d <- getDefCap info (_ctName origToken)
     let cBody = Constant LUnit info
-        cont' = SeqC env cBody cont
+        cont' = SeqC env info cBody cont
     case _dcapMeta d of
       Unmanaged ->
         evalCap info cont' handler env origToken PopCapInvoke TestCapEval cBody

--- a/pact-tests/constructor-tag-goldens/EvalError.golden
+++ b/pact-tests/constructor-tag-goldens/EvalError.golden
@@ -73,4 +73,5 @@
 {"conName":"HyperlaneDecodeError","conIndex":"48"}
 {"conName":"ModuleAdminNotAcquired","conIndex":"49"}
 {"conName":"UnknownException","conIndex":"4a"}
+{"conName":"InvalidNumArgs","conIndex":"4b"}
 

--- a/pact-tests/pact-tests/partial-app-errors.repl
+++ b/pact-tests/pact-tests/partial-app-errors.repl
@@ -1,0 +1,20 @@
+
+(expect-failure "Partial application error is thrown when trying to sequence a partial native app with a value"
+  "Incorrect number of arguments (1) for native function + supplied; expected (2)"
+  (do (+ 1) 1)
+)
+
+(module m g (defcap g () true)
+
+  (defun f:integer (a:integer b:integer c:string) (do a b))
+)
+
+(expect-failure "Partial application error is thrown when trying to sequence a partial user fun app with a value"
+  "Incorrect number of arguments (1) for function m.f.{nv2apbz7RTDv53cf46_3VX1msHQzBgTEqfxumYRGdf8} supplied; expected (3)"
+  (do (f 1) 1)
+)
+
+(expect-failure "Partial application error is thrown when trying to sequence a partial lambda app with a value"
+  "Incorrect number of arguments (1) for lambda supplied; expected (3)"
+  (do ((lambda (x y z) x) 1) 1)
+)

--- a/pact/Pact/Core/IR/Eval/CEK/Evaluator.hs
+++ b/pact/Pact/Core/IR/Eval/CEK/Evaluator.hs
@@ -209,7 +209,7 @@ evaluateTerm cont handler env (Builtin b info) = do
 --
 evaluateTerm cont handler env (Sequence e1 e2 _info) = do
   -- chargeGasArgs info (GAConstant constantWorkNodeGas)
-  evalCEK (SeqC env e2 cont) handler env e1
+  evalCEK (SeqC env _info e2 cont) handler env e1
 -- | ------ From --------------- | ------ To ------------------------ |
 --   <CAnd e1 e2, E, K, H>         <e1, E, CondC(E, AndFrame(e2),K),H>
 --   <COr e1 e2, E, K, H>          <e1, E, CondC(E, OrFrame(e2),K),H>
@@ -1008,7 +1008,8 @@ applyContToValue (LetC env i arg letbody cont) handler v = do
 -- | ------ From ------------ | ------ To ---------------- |
 --   <_, SeqC(E, e2, K), H>     <e2, E, K, H>
 --
-applyContToValue (SeqC env e cont) handler _ =
+applyContToValue (SeqC env info e cont) handler v = do
+  enforceSaturatedApp info v
   evalCEK cont handler env e
 -- | ------ From ------------------------ | ------ To ---------------- |
 --   <VBool b, CondC(E, AndC(e2), K), H>   if b then <e2, E, EnforceBool(K), H>
@@ -1359,7 +1360,7 @@ applyLam vc@(C (Closure fqn ca arity term mty env cloi)) args cont handler
   apply' e (ty:tys) [] = do
     let env' = set ceLocal e env
         -- Todo: fix partial SF args
-        pclo = PartialClosure (Just (StackFrame fqn [] SFDefun cloi)) (ty :| tys) (length tys + 1) term mty env' cloi
+        pclo = PartialClosure (Just (StackFrame fqn [] SFDefun cloi)) (ty :| tys) argLen (length tys + 1) term mty env' cloi
     returnCEKValue cont handler (VPartialClosure pclo)
   apply' _ [] _ =
     throwExecutionError cloi ClosureAppliedToTooManyArgs
@@ -1394,29 +1395,29 @@ applyLam (LC (LamClosure ca arity term mty env cloi)) args cont handler
     evalCEK cont handler (set ceLocal e env) term
   apply' e (ty:tys) [] =
     returnCEKValue cont handler
-    (VPartialClosure (PartialClosure Nothing (ty :| tys) (length tys + 1) term mty (set ceLocal e env) cloi))
+    (VPartialClosure (PartialClosure Nothing (ty :| tys) argLen (length tys + 1) term mty (set ceLocal e env) cloi))
   apply' _ [] _ = do
     throwExecutionError cloi ClosureAppliedToTooManyArgs
 
-applyLam (PC (PartialClosure li argtys _ term mty env cloi)) args cont handler = do
+applyLam (PC (PartialClosure li argtys nargs _ term mty env cloi)) args cont handler = do
   chargeGasArgs cloi (GAApplyLam (_sfName <$> li) (length args))
-  apply' (view ceLocal env) (NE.toList argtys) args
+  apply' nargs (view ceLocal env) (NE.toList argtys) args
   where
-  apply' e (Arg _ ty _:tys) (x:xs) = do
+  apply' n e (Arg _ ty _:tys) (x:xs) = do
     x' <- enforcePactValue cloi x
     maybeTCType cloi ty x'
-    apply' (RAList.cons (VPactValue x') e) tys xs
-  apply' e [] [] = do
+    apply' (n + 1) (RAList.cons (VPactValue x') e) tys xs
+  apply' _ e [] [] = do
     case li of
       Just sf -> do
         evalWithStackFrame cloi cont handler (set ceLocal e env) mty sf term
       Nothing -> do
         let cont' = EnforcePactValueC cloi cont
         evalCEK cont' handler (set ceLocal e env) term
-  apply' e (ty:tys) [] = do
-    let pclo = PartialClosure li (ty :| tys) (length tys + 1) term mty (set ceLocal e env) cloi
+  apply' n e (ty:tys) [] = do
+    let pclo = PartialClosure li (ty :| tys) n (length tys + 1) term mty (set ceLocal e env) cloi
     returnCEKValue cont handler (VPartialClosure pclo)
-  apply' _ [] _ = do
+  apply' _ _ [] _ = do
     throwExecutionError cloi ClosureAppliedToTooManyArgs
 
 applyLam nclo@(N (NativeFn b env fn arity i)) args cont handler

--- a/pact/Pact/Core/IR/Eval/CEK/Types.hs
+++ b/pact/Pact/Core/IR/Eval/CEK/Types.hs
@@ -196,6 +196,7 @@ data PartialClosure (e :: RuntimeMode) (b :: K.Type) (i :: K.Type)
   = PartialClosure
   { _pcloFrame :: !(Maybe (StackFrame i))
   , _pcloTypes :: !(NonEmpty (Arg Type i))
+  , _pcloNArgs :: !Int
   , _pcloArity :: !Int
   , _pcloTerm :: !(EvalTerm b i)
   , _pcloRType :: !(Maybe Type)
@@ -436,7 +437,7 @@ data Cont (e :: RuntimeMode) (b :: K.Type) (i :: K.Type)
   -- ^ Let single-variable pushing
   -- Optimization frame: Bypasses closure creation and thus less alloc
   -- Known as a single argument it will not construct a needless closure
-  | SeqC (CEKEnv e b i) (EvalTerm b i) (Cont e b i)
+  | SeqC (CEKEnv e b i) i (EvalTerm b i) (Cont e b i)
   -- ^ Sequencing expression, holding the next term to evaluate
   | ListC (CEKEnv e b i) i [EvalTerm b i] [PactValue] (Cont e b i)
   -- ^ Continuation for list elements


### PR DESCRIPTION
This PR turns unused partial applications during `do` sequencing into errors, which restores semantics similar to pact 4. 

Examples:
```
pact>(do (+ 1) 1)
(interactive):1:0: Incorrect number of arguments (1) for native function + supplied; expected (2)
 1 | (do (+ 1) 1)
   | ^^^^^^^^^^^^


pact>(module m g (defcap g () true) (defun f (a b c) a))
Loaded module m, hash vr3Ohd5IWwdx5SfRr7lO6Enk6z3m0dROax53pdME5Tw
pact>(do (f 1) 1)
(interactive):1:0: Incorrect number of arguments (1) for function m.f.{vr3Ohd5IWwdx5SfRr7lO6Enk6z3m0dROax53pdME5Tw} supplied; expected (3)
 1 | (do (f 1) 1)
   | ^^^^^^^^^^^^


pact>(do ((lambda (x y) x) 1) 1)
(interactive):1:0: Incorrect number of arguments (1) for lambda supplied; expected (2)
 1 | (do ((lambda (x y) x) 1) 1)
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^

```

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [x] Benchmark regressions
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
