### PR TITLE
remove ghc 9.6.6 from CI

### DIFF
--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.8.2", "9.10.1", '9.6.6']
+        ghc: ["9.8.2", "9.10.1"]
         cabal: ["3.12"]
         os: ["ubuntu-20.04", "ubuntu-22.04", "macos-14"]
         cabalcache: ["true"]
@@ -123,7 +123,7 @@ jobs:
         folder: "packages/${{ matrix.os }}"
         aws_access_key_id: "${{ secrets.kadena_cabal_cache_aws_access_key_id }}"
         aws_secret_access_key: "${{ secrets.kadena_cabal_cache_aws_secret_access_key }}"
-        
+
     - name: Build dependencies
       shell: bash
       run: cabal build --only-dependencies


### PR DESCRIPTION
PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [x] Benchmark regressions
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
