### PR TITLE
Fix module hashes in repl, add test to ensure parity

### DIFF
--- a/pact-tests/pact-tests/caps.repl
+++ b/pact-tests/pact-tests/caps.repl
@@ -757,7 +757,7 @@
 
 (expect-failure
  "emit-event: non-event"
- "Invalid event capability events.NON.{Pl17Zu2iMddv942W_ChGFDyPWN4zFVjtVvI8HP4_0AY}"
+ "Invalid event capability events.NON.{F9iUeU_dKXOSaeZhmFY7g-LfMJ7SMBpG5BhNWhxhhxE}"
  (emit-non-event))
 
 (expect
@@ -977,7 +977,7 @@
 
 (call-a)
 (expect "Event is emitted"
-  [ {"module-hash": "u5uyUYRiplR4zAyB3F2GCVwzpw0XIoxcujkCgW3CVDg"
+  [ {"module-hash": "eUXxnKczPNGardQAz-nFnoIpp0e90I63XHq1mvQ0s7A"
     ,"name": "A.A_EVENT"
     ,"params": [ 420 ]} ] (env-events true))
 
@@ -998,7 +998,7 @@
 (use B)
 (call-a)
 (expect "Without legacy events enabled, events are the same"
-  [ {"module-hash": "u5uyUYRiplR4zAyB3F2GCVwzpw0XIoxcujkCgW3CVDg"
+  [ {"module-hash": "eUXxnKczPNGardQAz-nFnoIpp0e90I63XHq1mvQ0s7A"
     ,"name": "A.A_EVENT"
     ,"params": [ 420 ]} ] (env-events true))
 (commit-tx)
@@ -1008,7 +1008,7 @@
 (use B)
 (call-a)
 (expect "With legacy events, it always points to the latest module hash"
-[ {"module-hash": "8bdi-0ljmkBGMm06zxB4j4tziHY3qLT-d_UoUwxBDLw"
+[ {"module-hash": "YkqNXWA9pNH9cFhfOM4fwPvi427v5jjo29tb6mFNAXA"
   ,"name": "A.A_EVENT","params": [ 420 ]} ] (env-events true))
 (commit-tx)
 

--- a/pact-tests/pact-tests/leftpad.repl
+++ b/pact-tests/pact-tests/leftpad.repl
@@ -64,7 +64,7 @@
 
 (module impure 'k
   (defconst VERSION 3)
-  (bless "ldFH268L3RM2qTN2eEi4_p7hQNM-O92e7qaqqO6fhhg")
+  (bless "GJs2NrH3KhRHB6dk-P_QVc0Hsl6gF3PE1HPlIKRyYO0")
   (defschema foo-schema value:integer)
   (deftable foo:{foo-schema})
   (defun ins (k v) (insert foo k v)))

--- a/pact-tests/pact-tests/yield.repl
+++ b/pact-tests/pact-tests/yield.repl
@@ -92,7 +92,7 @@
 
 ;; check events
 (expect "step 0 events"
- [{"module-hash": "gespHYnxeUwtbQdazfmncIHsd3aN-aUy7HvFP5532sQ"
+ [{"module-hash": "cTWOjIB4CTO1nsnKFpyfXqGHbLMvefSmYO4s97BbrZE"
    ,"name": "pact.X_YIELD"
    ,"params": ["1" "yieldtest.cross-chain" ["emily"]]}]
  (env-events true))
@@ -106,7 +106,7 @@
 
 ;; check events
 (expect "step 1 events"
- [{"module-hash": "gespHYnxeUwtbQdazfmncIHsd3aN-aUy7HvFP5532sQ"
+ [{"module-hash": "cTWOjIB4CTO1nsnKFpyfXqGHbLMvefSmYO4s97BbrZE"
     ,"name": "pact.X_RESUME"
     ,"params": ["0" "yieldtest.cross-chain" ["emily"]]}]
  (env-events true))

--- a/pact/Pact/Core/Builtin.hs
+++ b/pact/Pact/Core/Builtin.hs
@@ -25,6 +25,8 @@ module Pact.Core.Builtin
  , _CAnd, _COr, _CIf
  , _CEnforceOne, _CEnforce
  , _CWithCapability, _CCreateUserGuard
+ , _RBuiltinWrap
+ , _RBuiltinRepl
  )where
 
 import Control.Lens
@@ -980,3 +982,4 @@ instance (Pretty b) => Pretty (ReplBuiltin b) where
 deriveConstrInfo ''CoreBuiltin
 deriveConstrInfo ''ReplOnlyBuiltin
 makePrisms ''BuiltinForm
+makePrisms ''ReplBuiltin

--- a/pact/Pact/Core/IR/ModuleHashing.hs
+++ b/pact/Pact/Core/IR/ModuleHashing.hs
@@ -4,6 +4,7 @@ module Pact.Core.IR.ModuleHashing
  ( hashInterfaceAndReplace
  , hashModuleAndReplace
  , hashTopLevel
+ , hashModulePure
  ) where
 
 import Control.Lens
@@ -127,3 +128,6 @@ encodeInterface (Interface ifn defns imports _mh _txh mcode _i) =
   B.toStrict $ serialise (SerialiseV1 (Interface ifn defns imports (ModuleHash (Hash mempty)) (Hash mempty) mcode ()))
 {-# SPECIALISE encodeInterface :: Interface Name Type CoreBuiltin () -> B.ByteString #-}
 
+hashModulePure :: (Serialise (SerialiseV1 b)) => Module Name Type b i -> ModuleHash
+hashModulePure = ModuleHash . hash . encodeModule . void
+{-# SPECIALISE hashModulePure :: Module Name Type CoreBuiltin i -> ModuleHash #-}


### PR DESCRIPTION
In pact, we rely on the repl as well as `/local` to be able to check the hash of a module before we deploy it.

When we moved to CBOR-based module hashing, I didn't notice that the CBOR instance for `ReplBuiltin` was _not_ using the enum encoding of `CoreBuiltin`. Builtins should be CBOR encoded to a simple integer,  but the repl did not match with this. 

This PR fixes this discrepancy, and it adds an extra condition to all repl tests to ensure that the module hashes of modules match in the repl vs what would be recorded on chain (as long as there are no repl natives in the module).

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
- N/A
* [x] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [ ] Benchmark regressions
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
