### PR TITLE
Fix: make entity field presence an error

### DIFF
--- a/examples/accounts/accounts.pact
+++ b/examples/accounts/accounts.pact
@@ -107,7 +107,7 @@
 
   (defpact payment (payer payer-entity payee payee-entity amount date)
     "Debit PAYER at PAYER-ENTITY then credit PAYEE at PAYEE-ENTITY for AMOUNT on DATE"
-    (step-with-rollback payer-entity
+    (step-with-rollback 
       (with-capability (TRANSFER)
         (debit payer amount date
           { "payee": payee
@@ -118,7 +118,7 @@
         (credit payer amount date
           { "ref": (pact-id), "note": "rollback" })))
 
-    (step payee-entity
+    (step
       (with-capability (TRANSFER)
         (credit payee amount date
           { "payer": payer

--- a/pact-lsp/Pact/Core/LanguageServer/Utils.hs
+++ b/pact-lsp/Pact/Core/LanguageServer/Utils.hs
@@ -105,6 +105,7 @@ topLevelTermAt p = \case
     goStep = \case
       Step tm -> TermMatch <$> termAt p tm
       StepWithRollback tm1 tm2 -> TermMatch <$> (termAt p tm1 <|> termAt p tm2)
+      _ -> Nothing
 
 -- | Check if a `Position` is contained within a `Span`
 inside :: Position -> SpanInfo -> Bool

--- a/pact-tests/Pact/Core/Test/LexerParserTests.hs
+++ b/pact-tests/Pact/Core/Test/LexerParserTests.hs
@@ -246,10 +246,10 @@ defpactGen =
     Gen.choice [regularStepGen, stepWithRbGen]
   regularStepGen =
     -- Todo: models
-    Step <$> exprGen <*> pure Nothing
+    Step <$> pure Nothing <*> exprGen <*> pure Nothing
   stepWithRbGen =
     -- todo: models
-    StepWithRollback <$> exprGen <*> exprGen <*> pure Nothing
+    StepWithRollback <$> pure Nothing <*> exprGen <*> exprGen <*> pure Nothing
 
 defschemaGen :: Gen (DefSchema ())
 defschemaGen =

--- a/pact-tests/Pact/Core/Test/StaticErrorTests.hs
+++ b/pact-tests/Pact/Core/Test/StaticErrorTests.hs
@@ -1098,6 +1098,20 @@ executionTests =
         )
       (install-capability (c "meh"))
     |])
+  , ("entity_not_allowed", isExecutionError _EntityNotAllowedInDefPact, [text|
+      (module m g (defcap g () true)
+        (defpact tester ()
+          (step 1 2)
+        )
+        )
+    |])
+  , ("entity_not_allowed_rb", isExecutionError _EntityNotAllowedInDefPact, [text|
+      (module m g (defcap g () true)
+        (defpact tester ()
+          (step-with-rollback 1 2 3)
+        )
+        )
+    |])
   ]
 
 builtinTests :: [(String, PactErrorI -> Bool, Text)]

--- a/pact-tests/constructor-tag-goldens/EvalError.golden
+++ b/pact-tests/constructor-tag-goldens/EvalError.golden
@@ -74,4 +74,5 @@
 {"conName":"ModuleAdminNotAcquired","conIndex":"49"}
 {"conName":"UnknownException","conIndex":"4a"}
 {"conName":"InvalidNumArgs","conIndex":"4b"}
+{"conName":"EntityNotAllowedInDefPact","conIndex":"4c"}
 

--- a/pact/Pact/Core/Errors.hs
+++ b/pact/Pact/Core/Errors.hs
@@ -185,6 +185,7 @@ module Pact.Core.Errors
  , _HyperlaneDecodeErrorInternal
  , _HyperlaneDecodeErrorBinary
  , _HyperlaneDecodeErrorParseRecipient
+ , _EntityNotAllowedInDefPact
  , _InvalidNumArgs
  , toPrettyLegacyError
  , BoundedText
@@ -727,6 +728,9 @@ data EvalError
   | UnknownException Text
   -- ^ An unknown exception was thrown and converted to text. Intentionally and crucially lazy.
   | InvalidNumArgs ErrorClosureType Int Int
+  -- ^ Invalid number of arguments for a function
+  | EntityNotAllowedInDefPact QualifiedName
+  -- ^ Entity field not allowed in defpact
   deriving (Eq, Show, Generic)
 
 data ErrorClosureType
@@ -941,6 +945,8 @@ instance Pretty EvalError where
       <+> pretty errCloType
       <+> "supplied; expected"
       <+> parens (pretty expected)
+    EntityNotAllowedInDefPact qn ->
+      "Pact 5 does not support entity expressions in defpact" <+> pretty qn <> ". Please ensure your defpact steps have the correct number of expressions"
 
 -- | Errors meant to be raised
 --   internally by a PactDb implementation
@@ -1597,6 +1603,10 @@ evalErrorToBoundedText = mkBoundedText . \case
       ErrClosureLambda -> "lambda"
       ErrClosureUserFun fqn -> thsep ["user function", tFqn fqn]
       ErrClosureNativeFun b -> thsep ["native function", _natName b]
+  EntityNotAllowedInDefPact qn ->
+      thsep [ "Pact 5 does not support entity expressions in defpact"
+            , renderQualName qn <> "."
+            , " Please ensure your defpact steps have the correct number of expressions"]
 
 
 -- | NOTE: Do _not_ change this function post mainnet release just to improve an error.

--- a/pact/Pact/Core/IR/ModuleHashing.hs
+++ b/pact/Pact/Core/IR/ModuleHashing.hs
@@ -73,6 +73,9 @@ updateDefHashes mname mhash = \case
   DPact d ->
     let updateStep (Step e1) = Step (updateTermHashes mname mhash e1)
         updateStep (StepWithRollback e1 e2) = StepWithRollback (updateTermHashes mname mhash e1) (updateTermHashes mname mhash e2)
+        -- Note: this last fallthrough case does not occur in the pact 5
+        -- module deploy execution path.
+        updateStep e = e
     in DPact $ over dpSteps (fmap updateStep) d
   DTable d -> DTable d
   DSchema s -> DSchema s

--- a/pact/Pact/Core/Serialise/CBOR_V1.hs
+++ b/pact/Pact/Core/Serialise/CBOR_V1.hs
@@ -560,6 +560,10 @@ instance
       encodeListLen 2 <> encodeWord 0 <> encodeS t
     StepWithRollback t rb ->
       encodeListLen 3 <> encodeWord 1 <> encodeS t <> encodeS rb
+    LegacyStepWithEntity t e ->
+      encodeListLen 3 <> encodeWord 2 <> encodeS t <> encodeS e
+    LegacyStepWithRBEntity t e rb ->
+      encodeListLen 4 <> encodeWord 3 <> encodeS t <> encodeS e <> encodeS rb
   {-# INLINE encode #-}
 
   decode = do
@@ -567,6 +571,8 @@ instance
     decodeWord >>= fmap SerialiseV1 . \case
       0 -> Step <$> decodeS
       1 -> StepWithRollback <$> decodeS <*> decodeS
+      2 -> LegacyStepWithEntity <$> decodeS <*> decodeS
+      3 -> LegacyStepWithRBEntity <$> decodeS <*> decodeS <*> decodeS
       _ -> fail "unexpected decoding"
   {-# INLINE decode #-}
 

--- a/pact/Pact/Core/Syntax/ParseTree.hs
+++ b/pact/Pact/Core/Syntax/ParseTree.hs
@@ -285,17 +285,17 @@ instance Pretty (DefTable i) where
       <> maybe mempty (\d -> line <> pretty (uncurry (flip PactDoc) d)) docs
 
 data PactStep i
-  = Step (Expr i) (Maybe [PropertyExpr i])
-  | StepWithRollback (Expr i) (Expr i) (Maybe [PropertyExpr i])
+  = Step (Maybe (Expr i)) (Expr i) (Maybe [PropertyExpr i])
+  | StepWithRollback (Maybe (Expr i)) (Expr i) (Expr i) (Maybe [PropertyExpr i])
   deriving (Eq, Show, Functor, Generic, NFData)
 
 instance Pretty (PactStep i) where
   pretty = \case
-    Step e1 anns ->
+    Step _ e1 anns ->
       parens $
         "step" <+> pretty e1 <> nest 2
           (maybe mempty (\a -> line <> pretty (PactModel a)) anns)
-    StepWithRollback e1 e2 anns ->
+    StepWithRollback _ e1 e2 anns ->
       parens $
         "step-with-rollback" <+> pretty e1 <+> pretty e2 <> nest 2
           (maybe mempty (\a -> line <> pretty (PactModel a)) anns)

--- a/pact/Pact/Core/Syntax/Parser.y
+++ b/pact/Pact/Core/Syntax/Parser.y
@@ -224,15 +224,15 @@ Steps :: { [PactStep SpanInfo] }
   | Step { [$1] }
 
 Step :: { PactStep SpanInfo }
-  : '(' step Expr MModel ')' { Step $3 $4 }
+  : '(' step Expr MModel ')' { Step Nothing $3 $4 }
   -- Note: this production which ignores its input
   -- is due to the legacy form of:
   -- (step ENTITY EXPR)
-  | '(' step Expr Expr MModel ')' { Step $4 $5 }
-  | '(' steprb Expr Expr MModel ')' { StepWithRollback $3 $4 $5 }
+  | '(' step Expr Expr MModel ')' { Step (Just $3) $4 $5 }
+  | '(' steprb Expr Expr MModel ')' { StepWithRollback Nothing $3 $4 $5 }
   -- (step-with-rollback ENTITY EXPR ROLLBACK-EXPR)
   -- hence we ignore entity
-  | '(' steprb Expr Expr Expr MModel ')' { StepWithRollback $4 $5 $6 }
+  | '(' steprb Expr Expr Expr MModel ')' { StepWithRollback (Just $3) $4 $5 $6 }
 
 MDCapMeta :: { Maybe DCapMeta }
   : Managed { Just $1 }


### PR DESCRIPTION
In pact 4, defpact steps have a "private entity" optional expression parameter which currently we do not support in pact 5.

Regular defpact steps take 1 argument, if they have a rollback they take 2 args.
There's an "optional" entity argument which, if present, basically causes the defpact to fail 100% of the time.
```
pact> (module m g (defcap g () true) (defpact f () (step 1 2) (step 1 2)))
"Loaded module m, hash P4sRCOphLqh1gv6h2Vw_WBVDCfRg6iDQJXLvgn0W0QY"
pact> (f)
<interactive>:0:51:Error: applyPact: step entity must be String value
 at <interactive>:0:0: (f)
pact> (module m g (defcap g () true) (defpact f () (step "bob" 2) (step "bob" 2)))
"Loaded module m, hash AJ6muDjYGH0s3GOcfEso3_2wgVM45MIXknuSi9OKqpo"
pact> (f)
<interactive>:0:45:Error: applyPact: private step executed against non-private environment
 at <interactive>:0:0: (f)
```
Pact 5 was basically simply ignoring the private entity parameter, but parity replay makes it clear that since people made the mistake of deploying contracts where this field is present, it should be a static error. This PR turns this field's presence into an error in two ways:
- If it is found at deploy time (in pact 5), we fail with `EntityNotAllowedInDefPact` and we do not allow the module to be deployed.
- If It is found at runtime (as will be generally the case with legacy deployed modules), we fail with `EntityNotAllowedInDefPact` when attempting to execute a step with an entity.

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [x] Benchmark regressions
- N/A
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
