### PR TITLE
Improve test infra for errors using expect, expect-that and expect-failure

### DIFF
--- a/pact-lsp/Pact/Core/LanguageServer.hs
+++ b/pact-lsp/Pact/Core/LanguageServer.hs
@@ -231,7 +231,6 @@ setupAndProcessFile
           ,M.Map NormalizedUri  [EvalTopLevel ReplCoreBuiltin SpanInfo]))
 setupAndProcessFile nuri content = do
   pdb <- mockPactDb serialisePact_repl_spaninfo
-  gasLog <- newIORef Nothing
   let
     builtinMap = if isReplScript fp
                  then replBuiltinMap
@@ -242,7 +241,6 @@ setupAndProcessFile nuri content = do
       src = SourceCode (takeFileName fp) content
       rstate = ReplState
           { _replFlags = mempty
-          , _replEvalLog = gasLog
           , _replCurrSource = src
           , _replEvalEnv = ee
           , _replTx = Nothing
@@ -253,6 +251,7 @@ setupAndProcessFile nuri content = do
           -- Once this is possible, we can set it to `False` as is the default
           , _replNativesEnabled = True
           , _replOutputLine = const (pure ())
+          , _replTestResults = []
           }
   stateRef <- newIORef rstate
   res <- runReplT stateRef (processFile Repl.interpretEvalBigStep nuri content)

--- a/pact-tests/Pact/Core/Test/StaticErrorTests.hs
+++ b/pact-tests/Pact/Core/Test/StaticErrorTests.hs
@@ -34,21 +34,12 @@ isUserRecoverableError p s = has (_PEUserRecoverableError . _1 . p) s
 
 runStaticTest :: String -> Text -> ReplInterpreter -> (PactErrorI -> Bool) -> Assertion
 runStaticTest label src interp predicate = do
-  gasLog <- newIORef Nothing
   pdb <- mockPactDb serialisePact_repl_spaninfo
   ee <- defaultEvalEnv pdb replBuiltinMap
   let source = SourceCode label src
-      rstate = ReplState
-            { _replFlags = mempty
-            , _replEvalLog = gasLog
-            , _replCurrSource = source
-            , _replEvalEnv = ee
-            , _replUserDocs = mempty
-            , _replTLDefPos = mempty
-            , _replTx = Nothing
-            , _replNativesEnabled = True
-            , _replOutputLine = const (pure ())
-            }
+      rstate = mkReplState ee (const (pure ()))
+                & replCurrSource .~ source
+                & replNativesEnabled .~ True
   stateRef <- newIORef rstate
   v <- runReplT stateRef (interpretReplProgram interp source)
   case v of

--- a/pact-tests/pact-tests/stackleak.repl
+++ b/pact-tests/pact-tests/stackleak.repl
@@ -3,7 +3,7 @@
 ; our repl natives have to be able to bypass some stepwise mechanics to make their
 ; functionality work (E.g, running a suspended subexpression until it reduces to a value),
 ; so if they ever catch a thrown runtime error, it can leak the state of the stack.
-; this is a simple test taht ensures that despite thrown errors, we do not leak the stack
+; this is a simple test that ensures that despite thrown errors, we do not leak the stack
 (module stackleak g
   (defcap g () true)
 
@@ -12,8 +12,8 @@
   )
 
 (let*
-  ((unusedResult1 (expect "leaks stack frame" 1 (leaks-stack)))
-   (unusedResult2 (expect-failure "leaks stack frame" (leaks-stack)))
+  ((unusedResult1 (expect-failure "leaks stack frame" (leaks-stack)))
+   (unusedResult2 (expect-failure "leaks stack frame2" (leaks-stack)))
   )
   1
   )


### PR DESCRIPTION
This PR adds recording of test failures for `expect` tests in the `ReplState` that mimic's pact 4's infra.

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [x] Benchmark regressions
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
