### PR TITLE
Fix repl load not displaying errors, return loc info to trace

### DIFF
--- a/pact-lsp/Pact/Core/LanguageServer.hs
+++ b/pact-lsp/Pact/Core/LanguageServer.hs
@@ -257,7 +257,7 @@ setupAndProcessFile nuri content = do
           , _replLoad = doLoad
           , _replLogType = ReplStdOut
           , _replLoadedFiles = mempty
-          , _replOutputLine = const (pure ())
+          , _replOutputLine = const $ const $ pure ()
           , _replTestResults = []
           }
   stateRef <- newIORef rstate

--- a/pact-repl/Pact/Core/IR/Eval/Direct/ReplBuiltin.hs
+++ b/pact-repl/Pact/Core/IR/Eval/Direct/ReplBuiltin.hs
@@ -356,7 +356,7 @@ envSetDebug info b _env = \case
         let flagsToSet = S.difference (S.union currFlags flags) (S.intersection currFlags flags)
         replFlags .== flagsToSet
         pure flagsToSet
-    replPrintLn' $ renderCompactText' $ "set debug flags to " <> pretty (S.toList flagsSet)
+    replPrintLn' info $ renderCompactText' $ "set debug flags to " <> pretty (S.toList flagsSet)
     return VUnit
   args -> argsError info b args
 
@@ -580,7 +580,7 @@ load info b _env = \case
   args -> argsError info b args
   where
     load' sourceFile reset = do
-      replPrintLn $ PString $ "Loading " <> sourceFile <> "..."
+      replPrintLn info $ PString $ "Loading " <> sourceFile <> "..."
       fload <- useReplState replLoad
       fload (T.unpack sourceFile) reset
       return VUnit

--- a/pact-repl/Pact/Core/Repl/Runtime/ReplBuiltin.hs
+++ b/pact-repl/Pact/Core/Repl/Runtime/ReplBuiltin.hs
@@ -579,7 +579,7 @@ envSetDebug info b cont handler _env = \case
         let flagsToSet = S.difference (S.union currFlags flags) (S.intersection currFlags flags)
         replFlags .== flagsToSet
         pure flagsToSet
-    replPrintLn' $ renderCompactText' $ "set debug flags to " <> pretty (S.toList flagsSet)
+    replPrintLn' info $ renderCompactText' $ "set debug flags to " <> pretty (S.toList flagsSet)
     returnCEKValue cont handler $ VUnit
   args -> argsError info b args
 
@@ -611,7 +611,7 @@ load info b cont handler _env = \case
   args -> argsError info b args
   where
     load' sourceFile reset = do
-      replPrintLn $ PString $ "Loading " <> sourceFile <> "..."
+      replPrintLn info $ PString $ "Loading " <> sourceFile <> "..."
       fload <- useReplState replLoad
       fload (T.unpack sourceFile) reset
       returnCEKValue cont handler VUnit

--- a/pact-repl/Pact/Core/Repl/Utils.hs
+++ b/pact-repl/Pact/Core/Repl/Utils.hs
@@ -245,16 +245,16 @@ gasLogEntrytoPactValue entry = PString $ renderCompactText' $ n <> ": " <> prett
   where
     n = pretty (_gleArgs entry) <+> pretty (_gleInfo entry)
 
-replPrintLn :: Pretty a => a -> EvalM 'ReplRuntime b FileLocSpanInfo ()
-replPrintLn p = replPrintLn' (renderCompactText p)
+replPrintLn :: Pretty a => FileLocSpanInfo -> a -> EvalM 'ReplRuntime b FileLocSpanInfo ()
+replPrintLn info p = replPrintLn' info (renderCompactText p)
 
-replPrintLn' :: Text -> EvalM 'ReplRuntime b FileLocSpanInfo ()
-replPrintLn' p = do
+replPrintLn' :: FileLocSpanInfo -> Text -> EvalM 'ReplRuntime b FileLocSpanInfo ()
+replPrintLn' info p = do
   r <- getReplState
   case _replLogType r of
-    ReplStdOut -> _replOutputLine r p
+    ReplStdOut -> _replOutputLine r info p
     ReplLogOut v ->
-      liftIO (modifyIORef' v (p:))
+      liftIO (modifyIORef' v ((p, info):))
 
 recordTestResult
   :: Text

--- a/pact-repl/Pact/Core/Repl/Utils.hs
+++ b/pact-repl/Pact/Core/Repl/Utils.hs
@@ -34,6 +34,7 @@ module Pact.Core.Repl.Utils
  , renderReplFlag
  , replError
  , SourceCode(..)
+ , getReplState
  , useReplState
  , usesReplState
  , (.==)

--- a/pact-tests/Pact/Core/Test/GasGolden.hs
+++ b/pact-tests/Pact/Core/Test/GasGolden.hs
@@ -111,7 +111,7 @@ runGasTest file interpret = do
   let ee' = ee & eeGasEnv . geGasModel .~ replTableGasModel (Just (maxBound :: MilliGasLimit))
       gasRef = ee' ^. eeGasEnv . geGasRef
   let source = SourceCode file src
-  let rstate = mkReplState ee' (const (pure ())) (\f r -> void (loadFile interpret f r)) & replCurrSource .~ source
+  let rstate = mkReplState ee' (const (const (pure ()))) (\f r -> void (loadFile interpret f r)) & replCurrSource .~ source
   stateRef <- newIORef rstate
   evalReplM stateRef (interpretReplProgram interpret source) >>= \case
     Left _ -> pure Nothing

--- a/pact-tests/Pact/Core/Test/ReplTests.hs
+++ b/pact-tests/Pact/Core/Test/ReplTests.hs
@@ -80,7 +80,7 @@ runReplTest
 runReplTest (ReplSourceDir path) pdb file src interp = do
   ee <- defaultEvalEnv pdb replBuiltinMap
   let source = SourceCode (path </> file) src
-  let rstate = mkReplState ee (const (pure ())) (\f reset -> void (loadFile interp f reset)) & replCurrSource .~ source
+  let rstate = mkReplState ee (const (const (pure ()))) (\f reset -> void (loadFile interp f reset)) & replCurrSource .~ source
   stateRef <- newIORef rstate
   evalReplM stateRef (interpretReplProgram interp source) >>= \case
     Left e -> let

--- a/pact-tests/Pact/Core/Test/StaticErrorTests.hs
+++ b/pact-tests/Pact/Core/Test/StaticErrorTests.hs
@@ -39,7 +39,7 @@ runStaticTest label src interp predicate = do
   pdb <- mockPactDb serialisePact_repl_fileLocSpanInfo
   ee <- defaultEvalEnv pdb replBuiltinMap
   let source = SourceCode label src
-      rstate = mkReplState ee (const (pure ())) (\f reset -> void (loadFile interp f reset))
+      rstate = mkReplState ee (const (const (pure ()))) (\f reset -> void (loadFile interp f reset))
                 & replCurrSource .~ source
                 & replNativesEnabled .~ True
   stateRef <- newIORef rstate

--- a/pact/Pact/Core/Environment/Types.hs
+++ b/pact/Pact/Core/Environment/Types.hs
@@ -362,7 +362,7 @@ data ReplTestResult
 
 data ReplOutput where
   ReplStdOut :: ReplOutput
-  ReplLogOut :: IORef [Text] -> ReplOutput
+  ReplLogOut :: IORef [(Text, FileLocSpanInfo)] -> ReplOutput
 
 -- | Passed in repl environment
 data ReplState b
@@ -385,7 +385,7 @@ data ReplState b
   -- ^ The current repl tx, if one has been initiated
   , _replNativesEnabled :: Bool
   -- ^ Are repl natives enabled in module code
-  , _replOutputLine :: !(Text -> EvalM 'ReplRuntime b FileLocSpanInfo ())
+  , _replOutputLine :: !(FileLocSpanInfo -> Text -> EvalM 'ReplRuntime b FileLocSpanInfo ())
   -- ^ The output line function, as an entry in the repl env
   --   to allow for custom output handling, e.g haskeline
   , _replLoad :: !(FilePath -> Bool -> EvalM 'ReplRuntime b FileLocSpanInfo ())


### PR DESCRIPTION
Closes #261 

After this PR, the following happens on error
```
➜  pact-core git:(jose/fix-load-error-repl) cabal run pact -- scratch/261_repro.repl -t
scratch/261_repro.repl:1:1: Cannot find module:  foo
 1 | (foo)
   |  ^^^


Load failed
```

Moreover: Pact trace locations were not being included in `-t` output. This PR fixes that, by adding the location parameter to `replPrintLn`, but the implementor is left with the flexibility of how to actually interpret the info. This way, the repl interactive output is left untouched, but the trace output using `execScript` works as intended.

Before this PR:
```
➜  pact-core git:(jose/fix-load-error-repl) ✗ cabal run pact -- scratch/tc-fail-repro.repl -t
3
7
"Loading scratch.repl..."
"hello"
24
()
Load successful
```

After this PR
```
➜  pact-core git:(jose/fix-load-error-repl) ✗ cabal run pact -- scratch/tc-fail-repro.repl -t
scratch/tc-fail-repro.repl:0:0-0:7: 3
scratch/tc-fail-repro.repl:1:0-1:7: 7
scratch/tc-fail-repro.repl:2:0-2:21: "Loading scratch.repl..."
scratch/scratch.repl:0:0-0:7: "hello"
scratch/scratch.repl:1:0-1:9: 24
scratch/tc-fail-repro.repl:2:0-2:21: ()
Load successful
```

PR checklist:

* [x] Test coverage for the proposed changes
- N/A, we don't actually have tests for the stability of this sort of thing.
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [x] Benchmark regressions
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
