### PR TITLE
remove printing unit values in repl output

### DIFF
--- a/pact-repl/Pact/Core/Repl.hs
+++ b/pact-repl/Pact/Core/Repl.hs
@@ -68,7 +68,6 @@ renderLocatedPactErrorFromState rstate err = rendered
             Nothing -> rstate ^. replCurrSource
   rendered = replError originFile err
 
-
 runRepl :: IO ()
 runRepl = do
   pdb <- mockPactDb serialisePact_repl_fileLocSpanInfo

--- a/pact-repl/Pact/Core/Repl/Compile.hs
+++ b/pact-repl/Pact/Core/Repl/Compile.hs
@@ -53,6 +53,7 @@ import Pact.Core.Errors
 import Pact.Core.Interpreter
 import Pact.Core.Pretty hiding (pipe)
 import Pact.Core.Serialise
+import Pact.Core.PactValue
 
 
 import Pact.Core.IR.Eval.Runtime
@@ -257,6 +258,8 @@ interpretReplProgram interpreter sc@(SourceCode sourceFp source) = do
   parseSource lexerOutput
     | sourceIsPactFile = (fmap.fmap) (Lisp.RTLTopLevel) $ Lisp.parseProgram lexerOutput
     | otherwise = Lisp.parseReplProgram lexerOutput
+  displayValue :: FileLocSpanInfo -> ReplCompileValue -> ReplM ReplCoreBuiltin ReplCompileValue
+  displayValue _info v@(RCompileValue (InterpretValue PUnit _)) = pure v
   displayValue info p = p <$ replPrintLn info p
   sliceCode = \case
     Lisp.TLModule{} -> sliceFromSource
@@ -282,10 +285,9 @@ interpretReplProgram interpreter sc@(SourceCode sourceFp source) = do
                 throwExecutionError varI $ EvalError "repl invariant violated: resolved to a top level free variable without a binder"
           _ -> do
             let sliced = sliceCode toplevel source (view spanInfo tlInfo)
-            v <- evalTopLevel interpreter (RawCode sliced) ds deps
+            v <- RCompileValue <$> evalTopLevel interpreter (RawCode sliced) ds deps
             emitWarnings
-            replPrintLn tlInfo v
-            pure (RCompileValue v)
+            displayValue tlInfo v
       where
       tlInfo = view Lisp.topLevelInfo toplevel
     _ ->  do


### PR DESCRIPTION
This PR changes outputs such as 
```
Loaded imports from coin
Loaded imports from T
()
"Expect failure: Success: bad transfer-crosschain fails"
()
"Expect: success min coinbase succeeds"
"Expect failure: Success: bad coinbase fails"
()

```
Into
```
Loaded imports from coin
Loaded imports from T
"Expect failure: Success: bad transfer-crosschain fails"
"Expect: success min coinbase succeeds"
"Expect failure: Success: bad coinbase fails"
```

Suppressing the unit value from being printed to stdout. 

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [x] Benchmark regressions
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
