### PR TITLE
Manual release can turn off brew

### DIFF
--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -24,6 +24,11 @@ on:
         type: boolean
         required: false
         default: false
+      release_to_brew:
+        description: "Release OSX build to homebrew"
+        type: boolean
+        required: false
+        default: true
   workflow_call:
     inputs:
       release_sha:
@@ -42,6 +47,11 @@ on:
         default: false
       prerelease:
         description: "set to true for nightly builds"
+        type: boolean
+        required: false
+        default: true
+      release_to_brew:
+        description: "Release OSX build to homebrew"
         type: boolean
         required: false
         default: true
@@ -178,6 +188,7 @@ jobs:
 
   release_to_brew:
     uses: kadena-io/homebrew-pact/.github/workflows/release-bump.yml@master
+    if: ${{ inputs.release_to_brew }}
     needs: release_to_github
     with:
       pact_arm: "${{ needs.release_to_github.outputs.OSX_RELEASE_URL }}"


### PR DESCRIPTION
Per request, one could manually release without firing the brew step in the homebrew-pact repo

PR checklist:

* [ ] Test coverage for the proposed changes
* [ ] PR description contains example output from repl interaction or a snippet from unit test output
* [ ] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [ ] Benchmark regressions
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209274422969202