### PR TITLE
Pact cli now reports failures and exits on repl test failure

### DIFF
--- a/pact/Pact/Core/Environment/Types.hs
+++ b/pact/Pact/Core/Environment/Types.hs
@@ -353,12 +353,20 @@ data ReplTestStatus
   | ReplTestFailed Text
   deriving (Show, Eq)
 
+instance Pretty ReplTestStatus where
+  pretty ReplTestPassed = "Test passed"
+  pretty (ReplTestFailed failureMsg) = pretty failureMsg
+
 data ReplTestResult
   = ReplTestResult
   { _trName :: Text
   , _trLoc :: FileLocSpanInfo
   , _trResult :: ReplTestStatus
   } deriving (Show, Eq)
+
+instance Pretty ReplTestResult where
+  pretty (ReplTestResult _name loc res) =
+    pretty loc <> ":" <> pretty res
 
 data ReplOutput where
   ReplStdOut :: ReplOutput

--- a/pact/Pact/Core/Info.hs
+++ b/pact/Pact/Core/Info.hs
@@ -113,7 +113,7 @@ instance HasSpanInfo FileLocSpanInfo where
   spanInfo = lens _flsiSpan (\s i -> s { _flsiSpan = i })
 
 instance Pretty FileLocSpanInfo where
-  pretty (FileLocSpanInfo f s) = pretty f <> " " <> pretty s
+  pretty (FileLocSpanInfo f s) = pretty f <> ":" <> pretty s
 
 instance Default FileLocSpanInfo where
   def = FileLocSpanInfo "" def


### PR DESCRIPTION
```
➜  pact-core git:(jose/fix-repl-test-reporting) ✗ cabal run -O0 pact -- ../pact/blah.repl
Load successful
```

After this PR:
```
➜  pact-core git:(jose/fix-repl-test-reporting) ✗ cabal run -O0 pact -- ../pact/blah.repl
../pact/blah.repl:0:0-0:18:FAILURE: foo expected: 1, received: 2
Load failed
```

PR checklist:

* [x] Test coverage for the proposed changes
- No tests for CLI output unfortunately. Maybe in the future we need some
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [ ] Benchmark regressions
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
