### PR TITLE
Add checks for native shadowing in REPL and shadowing check module

### DIFF
--- a/pact-repl/Pact/Core/Repl/Compile.hs
+++ b/pact-repl/Pact/Core/Repl/Compile.hs
@@ -55,6 +55,7 @@ import Pact.Core.Interpreter
 import Pact.Core.Pretty hiding (pipe)
 import Pact.Core.Serialise
 import Pact.Core.PactValue
+import Pact.Core.NativeShadowing
 
 
 import Pact.Core.IR.Eval.Runtime
@@ -262,6 +263,7 @@ interpretReplProgram interpreter sc@(SourceCode sourceFp source) = do
   debugIfFlagSet ReplDebugLexer lexx
   parsed <- liftEither $ bimap (fmap toFileLoc) ((fmap.fmap) toFileLoc) (parseSource lexx)
   setBuiltinResolution sc
+  traverse_ (liftShadowsMEvalM . checkReplTopLevelShadows) parsed
   traverse pipe' parsed
   where
   renderDoc info doc = liftIO (renderBuiltinDoc doc) >>= \case

--- a/pact-tests/Pact/Core/Test/LexerParserTests.hs
+++ b/pact-tests/Pact/Core/Test/LexerParserTests.hs
@@ -131,10 +131,9 @@ exprGen = Gen.recursive Gen.choice
       pure $ Lisp.Let LFLetNormal binders inner ()
 
     binderGen = do
-      name <- identGen
-      ty <- Gen.maybe typeGen
+      marg <- margGen
       expr <- Gen.subterm exprGen id
-      pure $ Lisp.Binder name ty expr
+      pure $ Lisp.Binder marg expr
 
 typeGen :: Gen Lisp.Type
 typeGen = Gen.recursive Gen.choice

--- a/pact-tests/Pact/Core/Test/StaticErrorTests.hs
+++ b/pact-tests/Pact/Core/Test/StaticErrorTests.hs
@@ -162,15 +162,15 @@ desugarTests =
       iface
       |])
   , ("interface_instead_of_module", isDesugarError _InvalidModuleReference, [text|
-      (module mod G (defcap G () true))
+      (module modl G (defcap G () true))
 
       (module other-mod OG (defcap OG () true)
-        (defun foo:string (a:string b:module{mod}) a)
+        (defun foo:string (a:string b:module{modl}) a)
         )
       |])
   , ("interface_instead_of_module_same", isDesugarError _NoSuchModule, [text|
-      (module mod G (defcap G () true)
-        (defun foo:string (a:string b:module{mod}) a)
+      (module modl G (defcap G () true)
+        (defun foo:string (a:string b:module{modl}) a)
         )
       |])
   , ("import_unknown_module", isDesugarError _NoSuchModule, [text|
@@ -600,6 +600,144 @@ desugarTests =
           )
         )
     |])
+  , ("shadowing_disallowed_letbinds", isDesugarError _InvalidNativeShadowing, [text|
+    (let ((identity 1)) 1)
+  |])
+  , ("shadowing_disallowed_letbinds_nested", isDesugarError _InvalidNativeShadowing, [text|
+    (let ((i (let* ((identity 1)) 2))) 1)
+  |])
+  , ("shadowing_disallowed_lambdas", isDesugarError _InvalidNativeShadowing, [text|
+    (lambda (identity) identity)
+  |])
+  , ("shadowing_disallowed_module_name", isDesugarError _InvalidNativeShadowing, [text|
+    (module identity g
+      (defcap g () true)
+      (defun foo () 1)
+    )
+  |])
+  , ("shadowing_disallowed_defun_name", isDesugarError _InvalidNativeShadowing, [text|
+    (module m g
+      (defcap g () true)
+      (defun identity () 1)
+    )
+  |])
+  , ("shadowing_disallowed_defun_arg", isDesugarError _InvalidNativeShadowing, [text|
+    (module m g
+      (defcap g () true)
+      (defun f (identity:string) 1)
+    )
+  |])
+  , ("shadowing_disallowed_defun_inner_term", isDesugarError _InvalidNativeShadowing, [text|
+    (module m g
+      (defcap g () true)
+      (defun f (foo:string)
+        (let ((f (lambda (identity) 1))) 2)
+      )
+    )
+  |])
+  , ("shadowing_disallowed_defcap_name", isDesugarError _InvalidNativeShadowing, [text|
+    (module m g
+      (defcap g () true)
+      (defcap identity () 1)
+    )
+  |])
+  , ("shadowing_disallowed_defcap_arg", isDesugarError _InvalidNativeShadowing, [text|
+    (module m g
+      (defcap g () true)
+      (defcap f (identity:string) 1)
+    )
+  |])
+  , ("shadowing_disallowed_defcap_inner_term", isDesugarError _InvalidNativeShadowing, [text|
+    (module m g
+      (defcap g () true)
+      (defcap f (foo:string)
+        (let ((f (lambda (identity) 1))) 2)
+      )
+    )
+  |])
+  , ("shadowing_disallowed_defpact_name", isDesugarError _InvalidNativeShadowing, [text|
+    (module m g
+      (defcap g () true)
+      (defpact identity () (step 2))
+    )
+  |])
+  , ("shadowing_disallowed_defpact_arg", isDesugarError _InvalidNativeShadowing, [text|
+    (module m g
+      (defcap g () true)
+      (defpact f (identity:string) (step 1))
+    )
+  |])
+  , ("shadowing_disallowed_defpact_inner_term", isDesugarError _InvalidNativeShadowing, [text|
+    (module m g
+      (defcap g () true)
+      (defpact f (foo:string) (step (lambda (identity) 1)))
+    )
+  |])
+  , ("shadowing_disallowed_defconst", isDesugarError _InvalidNativeShadowing, [text|
+    (module m g
+      (defcap g () true)
+      (defconst identity 1)
+    )
+  |])
+  , ("shadowing_disallowed_defconst_term", isDesugarError _InvalidNativeShadowing, [text|
+    (module m g
+      (defcap g () true)
+      (defconst foo (let ((identity 1)) 2))
+    )
+  |])
+  , ("shadowing_disallowed_defschema", isDesugarError _InvalidNativeShadowing, [text|
+    (module m g
+      (defcap g () true)
+      (defschema identity a:integer)
+    )
+  |])
+  , ("shadowing_disallowed_deftable", isDesugarError _InvalidNativeShadowing, [text|
+    (module m g
+      (defcap g () true)
+      (defschema ident-schema a:integer)
+      (deftable identity:{ident-schema})
+    )
+  |])
+  , ("shadowing_disallowed_interface", isDesugarError _InvalidNativeShadowing, [text|
+    (interface identity
+     (defun foobar:integer (a:integer))
+    )
+  |])
+  , ("shadowing_disallowed_interface_defun_name", isDesugarError _InvalidNativeShadowing, [text|
+    (interface foobar
+     (defun identity:integer (a:integer))
+    )
+  |])
+  , ("shadowing_disallowed_interface_defun_arg", isDesugarError _InvalidNativeShadowing, [text|
+    (interface foointerface
+     (defun foobar:integer (identity:integer))
+    )
+  |])
+  , ("shadowing_disallowed_interface_defcap_name", isDesugarError _InvalidNativeShadowing, [text|
+    (interface foobar
+     (defcap identity:integer (a:integer))
+    )
+  |])
+  , ("shadowing_disallowed_interface_defcap_arg", isDesugarError _InvalidNativeShadowing, [text|
+    (interface foointerface
+     (defcap foobar:integer (identity:integer))
+    )
+  |])
+  , ("shadowing_disallowed_interface_defpact_name", isDesugarError _InvalidNativeShadowing, [text|
+    (interface foobar
+     (defpact identity:integer (a:integer))
+    )
+  |])
+  , ("shadowing_disallowed_interface_defpact_arg", isDesugarError _InvalidNativeShadowing, [text|
+    (interface foointerface
+     (defpact foobar:integer (identity:integer))
+    )
+  |])
+  , ("shadowing_disallowed_interface_defconst", isDesugarError _InvalidNativeShadowing, [text|
+    (interface foointerface
+     (defconst identity foobar)
+    )
+  |])
   ]
 
 executionTests :: [(String, PactError FileLocSpanInfo -> Bool, Text)]

--- a/pact-tests/constructor-tag-goldens/DesugarError.golden
+++ b/pact-tests/constructor-tag-goldens/DesugarError.golden
@@ -23,4 +23,5 @@
 {"conName":"InvalidDynamicInvoke","conIndex":"16"}
 {"conName":"DuplicateDefinition","conIndex":"17"}
 {"conName":"InvalidBlessedHash","conIndex":"18"}
+{"conName":"InvalidNativeShadowing","conIndex":"19"}
 

--- a/pact-tests/pact-tests/meta.repl
+++ b/pact-tests/pact-tests/meta.repl
@@ -1,6 +1,6 @@
 (define-keyset 'k (sig-keyset))
 
-(module mod 'k
+(module modl 'k
   @doc   "this defines mod"
   @model [(property (do (crazy stuff)))]
 

--- a/pact-tng.cabal
+++ b/pact-tng.cabal
@@ -254,6 +254,7 @@ library
     Pact.Core.DeriveConTag
     Pact.Core.Signer
     Pact.Core.SatWord
+    Pact.Core.NativeShadowing
 
      -- Syntax modules
     Pact.Core.Syntax.ParseTree

--- a/pact/Pact/Core/Errors.hs
+++ b/pact/Pact/Core/Errors.hs
@@ -95,6 +95,7 @@ module Pact.Core.Errors
  , _GasExceeded
  , _FloatingPointError
  , _InvariantFailure
+ , _InvalidNativeShadowing
  , _EvalError
  , _NativeArgumentsError
  , _InvalidManagedCap
@@ -342,6 +343,7 @@ data DesugarError
   -- ^ Name was defined twice
   | InvalidBlessedHash Text
   -- ^ Blessed hash has invalid format
+  | InvalidNativeShadowing Text
   deriving (Eq, Show,  Generic)
 
 instance NFData DesugarError
@@ -411,6 +413,8 @@ instance Pretty DesugarError where
       "Duplicate definition:" <+> pretty qn
     InvalidBlessedHash hs ->
       "Invalid blessed hash, incorrect format:" <+> pretty hs
+    InvalidNativeShadowing t ->
+      "Variable" <+> pretty t <+> "shadows native with the same name"
 
 -- | Argument type mismatch meant for errors
 --   that does not force you to show the whole PactValue
@@ -1763,6 +1767,8 @@ desugarErrorToBoundedText = mkBoundedText . \case
       thsep ["Duplicate definition:", renderQualName qn]
     InvalidBlessedHash hs ->
       thsep ["Invalid blessed hash, incorrect format:", hs]
+    InvalidNativeShadowing t ->
+      thsep ["Variable", t, "shadows native with same name"]
 
 -- | NOTE: Do _not_ change this function post mainnet release just to improve an error.
 --  This will fork the chain, these messages will make it into outputs.

--- a/pact/Pact/Core/IR/Desugar.hs
+++ b/pact/Pact/Core/IR/Desugar.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -443,7 +441,11 @@ desugarLispTerm = \case
   Lisp.Object fields i ->
     ObjectLit <$> (traverse._2) desugarLispTerm fields <*> pure i
   where
-  binderToLet i (Lisp.Binder n mty expr) term = do
+  -- Todo: because previously `Binder`s did not carry variable loc info, we used to use the info
+  -- from the enclosing `Let`. We should use the info from the `MArg` now in the binder, but
+  -- this would actually impact serialization and cause a fork, so unless we decide this is even worth it
+  -- to fork, this will just remain a quirk
+  binderToLet i (Lisp.Binder (Lisp.MArg n mty _) expr) term = do
     expr' <- desugarLispTerm expr
     pure $ Let (Arg n mty i) expr' term i
 

--- a/pact/Pact/Core/NativeShadowing.hs
+++ b/pact/Pact/Core/NativeShadowing.hs
@@ -1,0 +1,169 @@
+{-# LANGUAGE DerivingVia #-}
+
+
+-- |
+-- Module      :  Pact.Core.IR.Term
+-- Copyright   :  (C) 2022 Kadena
+-- License     :  BSD-style (see the file LICENSE)
+-- Maintainer  :  Jose Cardona <jose@kadena.io>
+--
+-- Checks our parse tree for any sort of native shadowing.
+-- In pact 5 we don't allow natives to be shadowed in any way, so
+-- the functions in this module emit an error when natives are shadowed in
+-- locally bound variables, lambdas, module definitions, interface definitions,
+-- module names and interface names
+--
+module Pact.Core.NativeShadowing
+ ( liftShadowsMEvalM
+ , runShadowsM
+ , ShadowsM
+ , checkTopLevelShadows
+ , checkReplTopLevelShadows)
+ where
+
+import Control.Lens
+import Control.Monad
+import Control.Monad.Reader
+import Control.Monad.Except
+import Data.Foldable(traverse_)
+import Data.Text(Text)
+
+import Pact.Core.Errors
+import Pact.Core.Environment
+import Pact.Core.Syntax.ParseTree
+
+import qualified Data.Map.Strict as M
+
+newtype ShadowsM b i a
+  = ShadowsM (ExceptT (PactError i) (Reader (M.Map Text b)) a)
+  deriving
+  ( Functor
+  , Applicative
+  , Monad
+  , MonadError (PactError i)
+  , MonadReader (M.Map Text b)
+  ) via (ExceptT (PactError i) (Reader (M.Map Text b)))
+
+checkExprShadows :: Expr i -> ShadowsM b i ()
+checkExprShadows expr =
+  () <$ transformM errorOnShadowing expr
+  where
+  errorOnShadowing = \case
+    Let lf bndrs e i -> do
+      traverse_ checkBndr bndrs
+      pure $ Let lf bndrs e i
+    Lam bnds exprs i -> do
+      traverse_ checkMArgShadows bnds
+      pure $ Lam bnds exprs i
+    e -> pure e
+    where
+    checkBndr (Binder marg _) = checkMArgShadows marg
+
+checkMArgShadows :: MArg i -> ShadowsM b i ()
+checkMArgShadows (MArg name _mty i) = checkNativeShadows name i
+
+
+checkNativeShadows :: Text -> info -> ShadowsM b info ()
+checkNativeShadows name i = do
+  natives <- ask
+  when (M.member name natives) $
+    throwError (PEDesugarError (InvalidNativeShadowing name) i)
+
+
+checkDefunShadows :: Defun i -> ShadowsM b i ()
+checkDefunShadows (Defun spec args term _anns _) = do
+  traverse_ checkMArgShadows (spec:args)
+  traverse_ checkExprShadows term
+
+checkDefcapShadows :: DefCap i -> ShadowsM b i ()
+checkDefcapShadows (DefCap spec args term _ _ _) = do
+  traverse_ checkMArgShadows (spec:args)
+  traverse_ checkExprShadows term
+
+checkDefconstShadows :: DefConst i -> ShadowsM b i ()
+checkDefconstShadows (DefConst spec term _ _) = do
+  checkMArgShadows spec
+  checkExprShadows term
+
+-- Note: We don't have to check whether `args` shadow here
+-- since they're object fields
+checkDefSchemaShadows :: DefSchema i -> ShadowsM b i ()
+checkDefSchemaShadows (DefSchema name _args _ i) = do
+  checkNativeShadows name i
+
+checkDeftableShadows :: DefTable i -> ShadowsM b i ()
+checkDeftableShadows (DefTable name _ _ i) = checkNativeShadows name i
+
+checkDefpactShadows :: DefPact i -> ShadowsM b i ()
+checkDefpactShadows (DefPact spec args steps _ann _) = do
+  traverse_ checkMArgShadows (spec:args)
+  traverse_ checkShadowedStep steps
+  where
+  checkShadowedStep = \case
+    Step me e _ -> do
+      traverse_ checkExprShadows me
+      checkExprShadows e
+    StepWithRollback me e1 e2 _ -> do
+      traverse_ checkExprShadows me
+      traverse_ checkExprShadows [e1, e2]
+
+checkDefShadows :: Def i -> ShadowsM b i ()
+checkDefShadows = \case
+  Dfun d -> checkDefunShadows d
+  DConst d -> checkDefconstShadows d
+  DCap d -> checkDefcapShadows d
+  DSchema d -> checkDefSchemaShadows d
+  DTable d -> checkDeftableShadows d
+  DPact d -> checkDefpactShadows d
+
+checkModuleShadows :: Module i -> ShadowsM b i ()
+checkModuleShadows (Module mname _gov _exts defs _anns i) = do
+  checkNativeShadows mname i
+  traverse_ checkDefShadows defs
+
+checkIfDefunShadows :: IfDefun i -> ShadowsM b i ()
+checkIfDefunShadows (IfDefun spec args _anns _) =
+  traverse_ checkMArgShadows (spec:args)
+
+checkIfDefcapShadows :: IfDefCap i -> ShadowsM b i ()
+checkIfDefcapShadows (IfDefCap spec args _ _ _) =
+  traverse_ checkMArgShadows (spec:args)
+
+checkIfDefpactShadows :: IfDefPact i -> ShadowsM b i ()
+checkIfDefpactShadows (IfDefPact spec args _ _) =
+  traverse_ checkMArgShadows (spec:args)
+
+checkIfDefShadows :: IfDef i  -> ShadowsM b i ()
+checkIfDefShadows = \case
+  IfDfun d -> checkIfDefunShadows d
+  IfDConst d -> checkDefconstShadows d
+  IfDCap dc -> checkIfDefcapShadows dc
+  IfDSchema ds -> checkDefSchemaShadows ds
+  IfDPact dp -> checkIfDefpactShadows dp
+
+checkInterfaceShadows :: Interface i -> ShadowsM b i ()
+checkInterfaceShadows (Interface ifn defns _ _ i) = do
+  checkNativeShadows ifn i
+  traverse_ checkIfDefShadows defns
+
+checkTopLevelShadows :: TopLevel i -> ShadowsM b i ()
+checkTopLevelShadows = \case
+  TLModule m -> checkModuleShadows m
+  TLInterface i -> checkInterfaceShadows i
+  TLTerm e -> checkExprShadows e
+  TLUse _ -> pure ()
+
+checkReplTopLevelShadows :: ReplTopLevel i -> ShadowsM b i ()
+checkReplTopLevelShadows = \case
+  RTLTopLevel tl -> checkTopLevelShadows tl
+  RTLDefun df -> checkDefunShadows df
+  RTLDefConst dc -> checkDefconstShadows dc
+
+runShadowsM :: M.Map Text b -> ShadowsM b i a -> Either (PactError i) a
+runShadowsM e (ShadowsM act) =
+  runReader (runExceptT act) e
+
+liftShadowsMEvalM :: ShadowsM b i a -> EvalM e b i a
+liftShadowsMEvalM act = do
+  natives <- viewEvalEnv eeNatives
+  liftEither $ runShadowsM natives act

--- a/pact/Pact/Core/NativeShadowing.hs
+++ b/pact/Pact/Core/NativeShadowing.hs
@@ -14,35 +14,107 @@
 -- module names and interface names
 --
 module Pact.Core.NativeShadowing
- ( liftShadowsMEvalM
- , runShadowsM
+ ( runShadowsM
  , ShadowsM
  , checkTopLevelShadows
- , checkReplTopLevelShadows)
+ , checkReplTopLevelShadows
+ , Shadows(..))
  where
 
 import Control.Lens
 import Control.Monad
 import Control.Monad.Reader
-import Control.Monad.Except
+import Control.Monad.State.Strict
 import Data.Foldable(traverse_)
 import Data.Text(Text)
 
-import Pact.Core.Errors
-import Pact.Core.Environment
+import Pact.Core.Names
 import Pact.Core.Syntax.ParseTree
+import Pact.Core.Type
+import Pact.Core.Pretty
 
 import qualified Data.Map.Strict as M
 
+-- | The context of what is being shadowed,
+--   that is, the location and type of definition where shadowing is occuring.
+data ShadowCtx
+  = DefNameCtx DefKind QualifiedName
+  -- ^ Shadowing occurs in a definition's name
+  | DefArgContext DefKind Int QualifiedName
+  -- ^ Shadowing occurs in a definition's argument list
+  | DefBodyContext DefKind QualifiedName
+  -- ^ Shadowing occurs in a definition's body (if it has one)
+  | ModuleCtx ModuleName
+  -- ^ Shadowing occurs in a module's name
+  | InterfaceCtx ModuleName
+  -- ^ Shadowing occurs in an interface's name
+  | InterfaceDefCtx DefKind QualifiedName
+  -- ^ Shadowing occurs in an interface's member definition name
+  | InterfaceDefArgCtx DefKind Int QualifiedName
+  -- ^ Shadowing occurs in an interface's member definition's arguments
+  | TopLevelExprCtx
+  deriving (Eq, Show)
+
+instance Pretty ShadowCtx where
+  pretty = \case
+    DefNameCtx dk qn ->
+      "in the definition name of" <+> pretty dk <+> pretty qn
+    DefArgContext dk argIx qn ->
+      "in definition" <+> pretty dk <+> pretty qn <+> "at argument position" <+> pretty argIx
+    DefBodyContext dk qn ->
+      "in the body of definition" <+> pretty dk <+> pretty qn
+    ModuleCtx mn ->
+      "in module name" <+> pretty mn
+    InterfaceCtx mn ->
+      "in interface name" <+> pretty mn
+    InterfaceDefCtx dk qn ->
+      "in the definition name of" <+> pretty dk <+> pretty qn
+    InterfaceDefArgCtx dk argIx qn ->
+      "in definition" <+> pretty dk <+> pretty qn <+> "at argument position" <+> pretty argIx
+    TopLevelExprCtx ->
+      "in top level expression"
+
+data Shadows i
+  = Shadows ShadowCtx Text i
+  deriving (Eq, Show)
+
+instance Pretty i => Pretty (Shadows i) where
+  pretty (Shadows ctx shadowedVar _) =
+    "Variable" <+> pretty shadowedVar <+> "shadows native of the same name" <+> pretty ctx
+
+data ShadowsEnv b
+  = ShadowsEnv
+  { _context :: ShadowCtx
+  , _natives :: M.Map Text b
+  }
+
 newtype ShadowsM b i a
-  = ShadowsM (ExceptT (PactError i) (Reader (M.Map Text b)) a)
+  = ShadowsM (StateT [Shadows i] (Reader (ShadowsEnv b)) a)
   deriving
   ( Functor
   , Applicative
   , Monad
-  , MonadError (PactError i)
-  , MonadReader (M.Map Text b)
-  ) via (ExceptT (PactError i) (Reader (M.Map Text b)))
+  , MonadState [Shadows i]
+  , MonadReader (ShadowsEnv b)
+  ) via (StateT [Shadows i] (Reader (ShadowsEnv b)))
+
+
+withContext :: ShadowCtx -> ShadowsM b i a -> ShadowsM b i a
+withContext ctx = local (\(ShadowsEnv _ n) -> ShadowsEnv ctx n)
+
+viewContext :: ShadowsM b i ShadowCtx
+viewContext = asks _context
+
+-- | Enrich the context of a Def within a module (or a top level repl def)
+--   with its qualified name
+withModuleDefCtx :: MArg i -> (QualifiedName -> ShadowCtx) -> ShadowsM b i a -> ShadowsM b i a
+withModuleDefCtx (MArg defname _ _) mkCtx act =
+  viewContext >>= \case
+    ModuleCtx mn -> withContext (mkCtx (QualifiedName defname mn)) act
+    InterfaceCtx mn -> withContext (mkCtx (QualifiedName defname mn)) act
+    -- A `def` cannot exist outside a `ModuleCtx` outside of the REPL, so we can safely assume this is a
+    -- REPL def
+    _ -> withContext (mkCtx (QualifiedName defname replModuleName)) act
 
 checkExprShadows :: Expr i -> ShadowsM b i ()
 checkExprShadows expr =
@@ -65,39 +137,59 @@ checkMArgShadows (MArg name _mty i) = checkNativeShadows name i
 
 checkNativeShadows :: Text -> info -> ShadowsM b info ()
 checkNativeShadows name i = do
-  natives <- ask
+  ShadowsEnv ctx natives <- ask
   when (M.member name natives) $
-    throwError (PEDesugarError (InvalidNativeShadowing name) i)
+    modify' (Shadows ctx name i:)
 
 
 checkDefunShadows :: Defun i -> ShadowsM b i ()
 checkDefunShadows (Defun spec args term _anns _) = do
-  traverse_ checkMArgShadows (spec:args)
-  traverse_ checkExprShadows term
+  withModuleDefCtx spec (DefNameCtx DKDefun) $ checkMArgShadows spec
+  forM_ (zip [0..] args) $ \(idx, arg)  ->
+    withModuleDefCtx spec (DefArgContext DKDefun idx) $ checkMArgShadows arg
+  withModuleDefCtx spec (DefBodyContext DKDefun) $ traverse_ checkExprShadows term
 
 checkDefcapShadows :: DefCap i -> ShadowsM b i ()
 checkDefcapShadows (DefCap spec args term _ _ _) = do
-  traverse_ checkMArgShadows (spec:args)
-  traverse_ checkExprShadows term
+  withModuleDefCtx spec (DefNameCtx DKDefCap) $ checkMArgShadows spec
+  forM_ (zip [0..] args) $ \(idx, arg)  ->
+    withModuleDefCtx spec (DefArgContext DKDefCap idx) $ checkMArgShadows arg
+  withModuleDefCtx spec (DefBodyContext DKDefCap) $ traverse_ checkExprShadows term
 
 checkDefconstShadows :: DefConst i -> ShadowsM b i ()
 checkDefconstShadows (DefConst spec term _ _) = do
-  checkMArgShadows spec
-  checkExprShadows term
-
+  withModuleDefCtx spec (DefNameCtx DKDefConst) $ checkMArgShadows spec
+  withModuleDefCtx spec (DefBodyContext DKDefConst) $ checkExprShadows term
 -- Note: We don't have to check whether `args` shadow here
 -- since they're object fields
 checkDefSchemaShadows :: DefSchema i -> ShadowsM b i ()
-checkDefSchemaShadows (DefSchema name _args _ i) = do
-  checkNativeShadows name i
+checkDefSchemaShadows (DefSchema name _args _ i) = viewContext >>= \case
+    ModuleCtx mn -> do
+      let qn = QualifiedName name mn
+      withContext (DefNameCtx (DKDefSchema (fakeSchema qn)) qn) act
+    -- A `def` cannot exist outside a `ModuleCtx` outside of the REPL, so we can safely assume this is a
+    -- REPL def
+    -- you can't define repl defschemas yet so this case is actually impossible, but in the future it might not be
+    _ -> do
+      let qn = QualifiedName name replModuleName
+      withContext (DefNameCtx (DKDefSchema (fakeSchema qn)) qn) act
+  where
+  act = checkNativeShadows name i
+  -- We kind of need this because I unfortunately made `DefKind` take a parameter :(
+  --
+  fakeSchema qn = Schema qn mempty
 
 checkDeftableShadows :: DefTable i -> ShadowsM b i ()
-checkDeftableShadows (DefTable name _ _ i) = checkNativeShadows name i
+checkDeftableShadows (DefTable name _ _ i) =
+  withModuleDefCtx (MArg name Nothing i) (DefNameCtx DKDefTable) $
+    checkNativeShadows name i
 
 checkDefpactShadows :: DefPact i -> ShadowsM b i ()
 checkDefpactShadows (DefPact spec args steps _ann _) = do
-  traverse_ checkMArgShadows (spec:args)
-  traverse_ checkShadowedStep steps
+  withModuleDefCtx spec (DefNameCtx DKDefPact) $ checkMArgShadows spec
+  forM_ (zip [0..] args) $ \(idx, arg)  ->
+    withModuleDefCtx spec (DefArgContext DKDefPact idx) $ checkMArgShadows arg
+  withModuleDefCtx spec (DefBodyContext DKDefPact) $ traverse_ checkShadowedStep steps
   where
   checkShadowedStep = \case
     Step me e _ -> do
@@ -117,21 +209,27 @@ checkDefShadows = \case
   DPact d -> checkDefpactShadows d
 
 checkModuleShadows :: Module i -> ShadowsM b i ()
-checkModuleShadows (Module mname _gov _exts defs _anns i) = do
+checkModuleShadows (Module mname _gov _exts defs _anns i) = withContext (ModuleCtx (ModuleName mname Nothing)) $ do
   checkNativeShadows mname i
   traverse_ checkDefShadows defs
 
 checkIfDefunShadows :: IfDefun i -> ShadowsM b i ()
-checkIfDefunShadows (IfDefun spec args _anns _) =
-  traverse_ checkMArgShadows (spec:args)
+checkIfDefunShadows (IfDefun spec args _anns _) = do
+  withModuleDefCtx spec (DefNameCtx DKDefun) $ checkMArgShadows spec
+  forM_ (zip [0..] args) $ \(idx, arg)  ->
+    withModuleDefCtx spec (DefArgContext DKDefun idx) $ checkMArgShadows arg
 
 checkIfDefcapShadows :: IfDefCap i -> ShadowsM b i ()
-checkIfDefcapShadows (IfDefCap spec args _ _ _) =
-  traverse_ checkMArgShadows (spec:args)
+checkIfDefcapShadows (IfDefCap spec args _ _ _) = do
+  withModuleDefCtx spec (DefNameCtx DKDefCap) $ checkMArgShadows spec
+  forM_ (zip [0..] args) $ \(idx, arg)  ->
+    withModuleDefCtx spec (DefArgContext DKDefCap idx) $ checkMArgShadows arg
 
 checkIfDefpactShadows :: IfDefPact i -> ShadowsM b i ()
-checkIfDefpactShadows (IfDefPact spec args _ _) =
-  traverse_ checkMArgShadows (spec:args)
+checkIfDefpactShadows (IfDefPact spec args _ _) = do
+  withModuleDefCtx spec (DefNameCtx DKDefPact) $ checkMArgShadows spec
+  forM_ (zip [0..] args) $ \(idx, arg)  ->
+    withModuleDefCtx spec (DefArgContext DKDefPact idx) $ checkMArgShadows arg
 
 checkIfDefShadows :: IfDef i  -> ShadowsM b i ()
 checkIfDefShadows = \case
@@ -142,7 +240,7 @@ checkIfDefShadows = \case
   IfDPact dp -> checkIfDefpactShadows dp
 
 checkInterfaceShadows :: Interface i -> ShadowsM b i ()
-checkInterfaceShadows (Interface ifn defns _ _ i) = do
+checkInterfaceShadows (Interface ifn defns _ _ i) = withContext (InterfaceCtx (ModuleName ifn Nothing)) $ do
   checkNativeShadows ifn i
   traverse_ checkIfDefShadows defns
 
@@ -159,11 +257,6 @@ checkReplTopLevelShadows = \case
   RTLDefun df -> checkDefunShadows df
   RTLDefConst dc -> checkDefconstShadows dc
 
-runShadowsM :: M.Map Text b -> ShadowsM b i a -> Either (PactError i) a
+runShadowsM :: M.Map Text b -> ShadowsM b i a -> (a, [Shadows i])
 runShadowsM e (ShadowsM act) =
-  runReader (runExceptT act) e
-
-liftShadowsMEvalM :: ShadowsM b i a -> EvalM e b i a
-liftShadowsMEvalM act = do
-  natives <- viewEvalEnv eeNatives
-  liftEither $ runShadowsM natives act
+  runReader (runStateT act []) (ShadowsEnv TopLevelExprCtx e)

--- a/pact/Pact/Core/Syntax/Parser.y
+++ b/pact/Pact/Core/Syntax/Parser.y
@@ -361,8 +361,8 @@ LetExpr :: { SpanInfo -> ParsedExpr }
 
 -- Binders are non-empty, this is safe
 Binders :: { [Binder SpanInfo] }
-  : Binders '(' IDENT MTypeAnn Expr ')' { (Binder (getIdent $3) $4 $5):$1 }
-  | '(' IDENT MTypeAnn Expr ')' { [Binder (getIdent $2) $3 $4] }
+  : Binders '(' IDENT MTypeAnn Expr ')' { (Binder (MArg (getIdent $3) $4 (_ptInfo $3)) $5):$1 }
+  | '(' IDENT MTypeAnn Expr ')' { [Binder (MArg (getIdent $2) $3 (_ptInfo $2)) $4] }
 
 GenAppExpr :: { SpanInfo -> ParsedExpr }
   : Expr AppBindList { \i -> App $1 (toAppExprList i (reverse $2)) i }


### PR DESCRIPTION
In pact 5, we disallow natives to be shadowed. if you have an expression such as
```
(let* ((identity 1)) identity)
```
`identity` is actually resolved as the `identity` native `(lambda (x) x)`. This is actually incredibly annoying to debug because pact 4 allowed this, but we do not, since the error received is usually "Expected pact value, got closure" whenever you return a variable that collides with a native name.

This PR turns this into an error in the REPL, and we have plans to add this to mainnet on our next service release. Past a certain fork height, transactions where native names shadow variables will not make it into the mempool.

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [ ] Benchmark regressions
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
