### PR TITLE
Remove ubuntu 20.04 builds

### DIFF
--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         ghc: ["9.8.2", "9.10.1"]
         cabal: ["3.12"]
-        os: ["ubuntu-20.04", "ubuntu-22.04", "macos-14"]
+        os: ["ubuntu-22.04", "ubuntu-24.04", "macos-14"]
         cabalcache: ["true"]
 
     env:


### PR DESCRIPTION
Removing Ubuntu 20.04, adding 24.04 (which is current ubuntu-latest).

Ubuntu 20.04 runners are being sunset next month.

PR checklist:

* [ ] Test coverage for the proposed changes
* [ ] PR description contains example output from repl interaction or a snippet from unit test output
* [ ] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [ ] Benchmark regressions
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
