### PR TITLE
Fix repl trace vs print

### DIFF
--- a/pact-lsp/Pact/Core/LanguageServer.hs
+++ b/pact-lsp/Pact/Core/LanguageServer.hs
@@ -257,7 +257,8 @@ setupAndProcessFile nuri content = do
           , _replLoad = doLoad
           , _replLogType = ReplStdOut
           , _replLoadedFiles = mempty
-          , _replOutputLine = const $ const $ pure ()
+          , _replTraceLine = const $ const $ pure ()
+          , _replPrintLine = const $ const $ pure ()
           , _replTestResults = []
           }
   stateRef <- newIORef rstate

--- a/pact-repl/Pact/Core/IR/Eval/Direct/ReplBuiltin.hs
+++ b/pact-repl/Pact/Core/IR/Eval/Direct/ReplBuiltin.hs
@@ -356,7 +356,7 @@ envSetDebug info b _env = \case
         let flagsToSet = S.difference (S.union currFlags flags) (S.intersection currFlags flags)
         replFlags .== flagsToSet
         pure flagsToSet
-    replPrintLn' info $ renderCompactText' $ "set debug flags to " <> pretty (S.toList flagsSet)
+    replTraceLn' info $ renderCompactText' $ "set debug flags to " <> pretty (S.toList flagsSet)
     return VUnit
   args -> argsError info b args
 
@@ -583,7 +583,7 @@ load info b _env = \case
   args -> argsError info b args
   where
     load' sourceFile reset = do
-      replPrintLn info $ PString $ "Loading " <> sourceFile <> "..."
+      replTraceLn info $ PString $ "Loading " <> sourceFile <> "..."
       fload <- useReplState replLoad
       fload (T.unpack sourceFile) reset
       return VUnit

--- a/pact-repl/Pact/Core/Repl/Compile.hs
+++ b/pact-repl/Pact/Core/Repl/Compile.hs
@@ -99,7 +99,8 @@ mkReplState ee printfn loadFn =
     , _replTLDefPos = mempty
     , _replTx = Nothing
     , _replNativesEnabled = False
-    , _replOutputLine = printfn
+    , _replTraceLine = printfn
+    , _replPrintLine = printfn
     , _replLoad = loadFn
     , _replLoadedFiles = mempty
     , _replTestResults = []
@@ -121,7 +122,8 @@ mkReplState' ee printfn =
     , _replTLDefPos = mempty
     , _replTx = Nothing
     , _replNativesEnabled = False
-    , _replOutputLine = printfn
+    , _replTraceLine = printfn
+    , _replPrintLine = printfn
     , _replLoad = \f reset -> void (loadFile interpretEvalDirect f reset)
     , _replLoadedFiles = mempty
     , _replTestResults = []
@@ -309,7 +311,7 @@ interpretReplProgram interpreter sc@(SourceCode sourceFp source) = do
     | otherwise = Lisp.parseReplProgram lexerOutput
   displayValue :: FileLocSpanInfo -> ReplCompileValue -> ReplM ReplCoreBuiltin ReplCompileValue
   displayValue _info v@(RCompileValue (InterpretValue PUnit _)) = pure v
-  displayValue info p = p <$ replPrintLn info p
+  displayValue info p = p <$ replTraceLn info p
   sliceCode = \case
     Lisp.TLModule{} -> sliceFromSource
     Lisp.TLInterface{} -> sliceFromSource

--- a/pact-repl/Pact/Core/Repl/Runtime/ReplBuiltin.hs
+++ b/pact-repl/Pact/Core/Repl/Runtime/ReplBuiltin.hs
@@ -582,7 +582,7 @@ envSetDebug info b cont handler _env = \case
         let flagsToSet = S.difference (S.union currFlags flags) (S.intersection currFlags flags)
         replFlags .== flagsToSet
         pure flagsToSet
-    replPrintLn' info $ renderCompactText' $ "set debug flags to " <> pretty (S.toList flagsSet)
+    replTraceLn' info $ renderCompactText' $ "set debug flags to " <> pretty (S.toList flagsSet)
     returnCEKValue cont handler $ VUnit
   args -> argsError info b args
 
@@ -614,7 +614,7 @@ load info b cont handler _env = \case
   args -> argsError info b args
   where
     load' sourceFile reset = do
-      replPrintLn info $ PString $ "Loading " <> sourceFile <> "..."
+      replTraceLn info $ PString $ "Loading " <> sourceFile <> "..."
       fload <- useReplState replLoad
       fload (T.unpack sourceFile) reset
       returnCEKValue cont handler VUnit

--- a/pact/Pact/Core/Environment/Types.hs
+++ b/pact/Pact/Core/Environment/Types.hs
@@ -70,7 +70,8 @@ module Pact.Core.Environment.Types
  , replNativesEnabled
  , replCurrSource
  , replTx
- , replOutputLine
+ , replTraceLine
+ , replPrintLine
  , replTestResults
  , replLoad
  , replLoadedFiles
@@ -382,7 +383,11 @@ data ReplOutput where
   ReplStdOut :: ReplOutput
   ReplLogOut :: IORef [(Text, FileLocSpanInfo)] -> ReplOutput
 
+-- | The type of a
+type OutputWithLoc b = FileLocSpanInfo -> Text -> EvalM 'ReplRuntime b FileLocSpanInfo ()
+
 -- | Passed in repl environment
+--   TODO: move to Repl.Types
 data ReplState b
   = ReplState
   { _replFlags :: Set ReplDebugFlag
@@ -403,7 +408,8 @@ data ReplState b
   -- ^ The current repl tx, if one has been initiated
   , _replNativesEnabled :: Bool
   -- ^ Are repl natives enabled in module code
-  , _replOutputLine :: !(FileLocSpanInfo -> Text -> EvalM 'ReplRuntime b FileLocSpanInfo ())
+  , _replTraceLine :: !(OutputWithLoc b)
+  , _replPrintLine :: !(OutputWithLoc b)
   -- ^ The output line function, as an entry in the repl env
   --   to allow for custom output handling, e.g haskeline
   , _replLoad :: !(FilePath -> Bool -> EvalM 'ReplRuntime b FileLocSpanInfo ())


### PR DESCRIPTION
For the following repl file:
```
(print "Hello Jose")
(+ 1 2)
(+ 3 4)
```


Before this PR
```
➜  pact-core git:(jose/separate-printing) pact scratch/asdf.repl 
Load successful
➜  pact-core git:(jose/separate-printing) pact scratch/asdf.repl -t
scratch/asdf.repl:0:0-0:20: "Hello Jose"
scratch/asdf.repl:1:0-1:7: 3
scratch/asdf.repl:2:0-2:7: 7
Load successful
```

After this PR:

```
➜  pact-core git:(jose/separate-printing) cabal run -O0 pact -- scratch/asdf.repl 
"Hello Jose"
Load successful
➜  pact-core git:(jose/separate-printing) cabal run -O0 pact -- scratch/asdf.repl -t
scratch/asdf.repl:0:0-0:20:Print: "Hello Jose"
scratch/asdf.repl:1:0-1:7:Trace: 3
scratch/asdf.repl:2:0-2:7:Trace: 7
Load successful
```

Closes #330 

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [x] Benchmark regressions
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
