### PR TITLE
fix env-exec-config emitting unknown flag warnings, bump pact version

### DIFF
--- a/pact-repl/Pact/Core/IR/Eval/Direct/ReplBuiltin.hs
+++ b/pact-repl/Pact/Core/IR/Eval/Direct/ReplBuiltin.hs
@@ -7,7 +7,7 @@ module Pact.Core.IR.Eval.Direct.ReplBuiltin
 
 
 import Control.Lens
-import Control.Monad(when)
+import Control.Monad
 import Control.Monad.State.Strict
 import Control.Monad.Except
 import Data.Either(partitionEithers)
@@ -404,7 +404,7 @@ envExecConfig info b _env = \case
     s' <- traverse go (V.toList s)
     let (knownFlags, unknownFlags) = partitionEithers s'
     -- Emit warning for unknown flags
-    emitPactWarning info $ UnknownReplFlags unknownFlags
+    unless (null unknownFlags) $ emitPactWarning info $ UnknownReplFlags unknownFlags
     let flagSet = S.fromList knownFlags
     replEvalEnv . eeFlags .== flagSet
     replEvalEnv . eeNatives .== versionedReplNatives flagSet

--- a/pact-repl/Pact/Core/Repl/Runtime/ReplBuiltin.hs
+++ b/pact-repl/Pact/Core/Repl/Runtime/ReplBuiltin.hs
@@ -7,7 +7,7 @@
 module Pact.Core.Repl.Runtime.ReplBuiltin where
 
 import Control.Lens
-import Control.Monad(when)
+import Control.Monad
 import Control.Monad.Except
 import Control.Monad.State.Strict
 import Data.Text(Text)
@@ -428,7 +428,7 @@ envExecConfig info b cont handler _env = \case
     s' <- traverse go (V.toList s)
     let (knownFlags, unknownFlags) = partitionEithers s'
     -- Emit warning for unknown flags
-    emitPactWarning info $ UnknownReplFlags unknownFlags
+    unless (null unknownFlags) $ emitPactWarning info $ UnknownReplFlags unknownFlags
 
     let flagSet = S.fromList knownFlags
     replEvalEnv . eeFlags .== flagSet

--- a/pact-tng.cabal
+++ b/pact-tng.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.8
 name:                pact-tng
-version:             5.1
+version:             5.2
 -- ^ 4 digit is prerelease, 3- or 2-digit for prod release
 synopsis:            Smart contract language library and REPL
 description:

--- a/pact/Pact/Core/Version.hs
+++ b/pact/Pact/Core/Version.hs
@@ -22,7 +22,7 @@ import Data.Version (Version(..))
 name :: String
 name = "pact_tng"
 version :: Version
-version = Version [5,0] []
+version = Version [5,2] []
 
 synopsis :: String
 synopsis = "Smart contract language library and REPL"


### PR DESCRIPTION
Before this PR

```
pact> (env-exec-config [])
Warning: Repl flags not recognized: 
[]

> pact --version
pact version 5.0
```

After this PR

```
pact> (env-exec-config [])
[]

> pact --version
pact version 5.2
```

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [x] Benchmark regressions
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
