### PR TITLE
[Experimental] Non-reentrancy special form

### DIFF
--- a/pact-lsp/Pact/Core/LanguageServer/Utils.hs
+++ b/pact-lsp/Pact/Core/LanguageServer/Utils.hs
@@ -35,6 +35,7 @@ termAt p term
           CEnforce a b -> termAt p a <|> termAt p b
           CWithCapability a b -> termAt p a <|> termAt p b
           CTry a b -> termAt p a <|> termAt p b
+          CNonReentrant a -> termAt p a
           CCreateUserGuard a -> termAt p a
         <|> Just t
       t@(ListLit tms _) -> getAlt (foldMap (Alt . termAt p) tms) <|> Just t

--- a/pact-repl/Pact/Core/IR/Eval/Direct/Types.hs
+++ b/pact-repl/Pact/Core/IR/Eval/Direct/Types.hs
@@ -27,7 +27,7 @@ module Pact.Core.IR.Eval.Direct.Types
  , DirectEnv(..)
  , ceLocal, ceDefPactStep
  , ceBuiltins, cePactDb
- , ceInCap
+ , ceInCap, ceNonReentrant
  , pattern VLiteral
  , pattern VString
  , pattern VInteger
@@ -66,6 +66,7 @@ import Data.RAList(RAList)
 import Data.Map.Strict(Map)
 import Data.Vector(Vector)
 import Pact.Time(UTCTime)
+import Data.Set(Set)
 import qualified Data.Kind as K
 
 
@@ -222,6 +223,7 @@ data DirectEnv e b i
   , _cePactDb :: PactDb b i
   , _ceBuiltins :: BuiltinEnv e b i
   , _ceDefPactStep :: Maybe DefPactStep
+  , _ceNonReentrant :: Set ModuleName
   , _ceInCap :: Bool }
   deriving (Generic)
 
@@ -229,7 +231,7 @@ instance (NFData b, NFData i) => NFData (DirectEnv e b i)
 
 
 instance (Show i, Show b) => Show (DirectEnv e b i) where
-  show (DirectEnv e _ _ _ _) = show e
+  show (DirectEnv e _ _ _ _ _) = show e
 
 type NativeFunction (e :: RuntimeMode) (b :: K.Type) (i :: K.Type)
   = i -> b -> DirectEnv e b i -> [EvalValue e b i] -> EvalM e b i (EvalValue e b i)

--- a/pact-repl/Pact/Core/Typed/Infer.hs
+++ b/pact-repl/Pact/Core/Typed/Infer.hs
@@ -2263,6 +2263,9 @@ checkTermType checkty = \case
         (_, ct', pe1) <- checkTermType (Located i TyCapToken) ct
         (_, body', pe2) <- checkTermType checkty body
         pure (Located i (_locElem checkty), CWithCapability ct' body', pe1 ++ pe2)
+      CNonReentrant term -> do
+        (outTy, outTerm, outPreds) <- checkTermType checkty term
+        pure (outTy, CNonReentrant outTerm, outPreds)
       CCreateUserGuard c -> case c of
         IR.App{} -> do
           unify checkty (Located i TyGuard)
@@ -2417,6 +2420,9 @@ inferTerm = \case
         (_, ct', pe1) <- checkTermType (Located i TyCapToken) ct
         (rty, body', pe2) <- inferTerm body
         pure (rty, CWithCapability ct' body', pe1 ++ pe2)
+      CNonReentrant term -> do
+        (outTy, outTerm, outPreds) <- inferTerm term
+        pure (outTy, CNonReentrant outTerm, outPreds)
       CCreateUserGuard c -> case c of
         IR.App{} -> do
           (t, c', pe1) <- inferTerm c

--- a/pact-tests/pact-tests/reentrancy.repl
+++ b/pact-tests/pact-tests/reentrancy.repl
@@ -1,0 +1,54 @@
+(interface foo-callable
+
+  (defun foo:integer (a:integer))
+
+  (defun bar:integer (b:integer))
+  )
+
+(module is-not-reentrant g
+
+  (defcap g () true)
+
+  (defcap SENSITIVE () true)
+
+  (defun definitely-not-reentrant (m:module{foo-callable})
+    (with-capability (SENSITIVE)
+      ; NAME IS TENTATIVE
+      (non-reentrant (m::foo 1))
+      (called-internal)
+      )
+  )
+
+  (defun called-internal ()
+    (require-capability (SENSITIVE))
+    123
+  ))
+
+(module malicious g
+  (defcap g () true)
+
+  (implements foo-callable)
+
+  (defun foo:integer (a:integer)
+    (is-not-reentrant.called-internal)
+  )
+
+  (defun bar:integer (b:integer)
+    (is-not-reentrant.called-internal)
+  ))
+
+(module non-malicious g
+    (defcap g () true)
+
+    (implements foo-callable)
+
+    (defun foo:integer (a:integer)
+      (+ a 1)
+    )
+
+    (defun bar:integer (b:integer)
+      (+ b 2)
+    ))
+
+(expect "non-malicious module still returns properly" 123 (is-not-reentrant.definitely-not-reentrant non-malicious))
+(expect-failure "malicious module execution fails due to reentrancy" "reentrancy not allowed on module: is-not-reentrant" (is-not-reentrant.definitely-not-reentrant malicious))

--- a/pact/Pact/Core/Builtin.hs
+++ b/pact/Pact/Core/Builtin.hs
@@ -56,6 +56,7 @@ data BuiltinForm o
   | CCreateUserGuard o
   | CEnforceOne o o
   | CTry o o
+  | CNonReentrant o
   deriving (Show, Eq, Functor, Foldable, Traversable, Generic)
 
 instance NFData o => NFData (BuiltinForm o)
@@ -78,6 +79,8 @@ instance Pretty o => Pretty (BuiltinForm o) where
       parens ("create-user-guard" <+> pretty o)
     CTry o o' ->
       parens ("try" <+> pretty o <+> pretty o')
+    CNonReentrant o ->
+      parens ("non-reentrant" <+> pretty o)
 
 -- | Our list of base-builtins to pact.
 data CoreBuiltin

--- a/pact/Pact/Core/IR/Eval/CEK/Types.hs
+++ b/pact/Pact/Core/IR/Eval/CEK/Types.hs
@@ -22,6 +22,7 @@ module Pact.Core.IR.Eval.CEK.Types
  , ceBuiltins
  , ceDefPactStep
  , ceInCap
+ , ceNonReentrant
  , EvalEnv(..)
  , NativeFunction
  , BuiltinEnv
@@ -142,13 +143,14 @@ data CEKEnv (e :: RuntimeMode) (b :: K.Type) (i :: K.Type)
   , _cePactDb :: PactDb b i
   , _ceBuiltins :: BuiltinEnv e b i
   , _ceDefPactStep :: Maybe DefPactStep
+  , _ceNonReentrant :: Set ModuleName
   , _ceInCap :: Bool }
   deriving (Generic)
 
 instance (NFData b, NFData i) => NFData (CEKEnv e b i)
 
 instance (Show i, Show b) => Show (CEKEnv e b i) where
-  show (CEKEnv e _ _ _ _) = show e
+  show (CEKEnv e _ _ _ _ _) = show e
 
 -- | List of builtins
 type BuiltinEnv (e :: RuntimeMode) (b :: K.Type) (i :: K.Type)

--- a/pact/Pact/Core/Serialise/CBOR_V1.hs
+++ b/pact/Pact/Core/Serialise/CBOR_V1.hs
@@ -379,6 +379,8 @@ instance (Serialise (SerialiseV1 b), Serialise (SerialiseV1 i))
         encodeListLen 3 <> encodeWord 6 <> encodeS t1 <> encodeS t2
       CCreateUserGuard t1 ->
         encodeListLen 2 <> encodeWord 7 <> encodeS t1
+      CNonReentrant t ->
+        encodeListLen 2 <> encodeWord 8 <> encodeS t
   {-# INLINE encode #-}
 
   decode = do
@@ -392,6 +394,7 @@ instance (Serialise (SerialiseV1 b), Serialise (SerialiseV1 i))
       5 -> CWithCapability <$> decodeS <*> decodeS
       6 -> CTry <$> decodeS <*> decodeS
       7 -> CCreateUserGuard <$> decodeS
+      8 -> CNonReentrant <$> decodeS
       _ -> fail "unexpected decoding"
   {-# INLINE decode #-}
 


### PR DESCRIPTION
This PR is a proof of concept of an experimental feature for pact 5, which is module level non-reentrancy.

## Syntax

For some syntactic term `k`, 
```pact
(non-reentrant k)
```

## Semantics
For any term `k` (in this example, `(m::foo 1)`)  written within a module `foo`'s definition (defcap, defun, defpact), e.g:
```pact
  (defun definitely-not-reentrant (m:module{foo-callable})
    (with-capability (SENSITIVE)
      ; NAME IS TENTATIVE
      (non-reentrant (m::foo 1))
      (called-internal)
      )
  )
```
`(non-reentrant k)` guarantees that `k` does not call back into `foo` during evaluation of `k`. 

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [x] Benchmark regressions
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
