### PR TITLE
"pure" and "error" special forms

### DIFF
--- a/pact-lsp/Pact/Core/LanguageServer/Utils.hs
+++ b/pact-lsp/Pact/Core/LanguageServer/Utils.hs
@@ -36,6 +36,8 @@ termAt p term
           CWithCapability a b -> termAt p a <|> termAt p b
           CTry a b -> termAt p a <|> termAt p b
           CCreateUserGuard a -> termAt p a
+          CError a -> termAt p a
+          CPure a -> termAt p a
         <|> Just t
       t@(ListLit tms _) -> getAlt (foldMap (Alt . termAt p) tms) <|> Just t
       t@(Nullary tm _) -> termAt p tm <|> Just t

--- a/pact-repl/Pact/Core/IR/Eval/Direct/Evaluator.hs
+++ b/pact-repl/Pact/Core/IR/Eval/Direct/Evaluator.hs
@@ -299,6 +299,12 @@ evaluate env = \case
       chargeTryNodeWork info
       let env' = readOnlyEnv env
       catchRecoverable (evaluate env' tryExpr) (\_ _ -> evaluate env catchExpr)
+    CPure e -> do
+      let env' = readOnlyEnv env
+      evaluate env' e
+    CError e -> do
+      msg <- enforceString info =<< evaluate env e
+      throwUserRecoverableError info (UserEnforceError msg)
     CEnforceOne str (ListLit conds _) ->
       go conds
       where

--- a/pact-tests/pact-tests/error.repl
+++ b/pact-tests/pact-tests/error.repl
@@ -1,0 +1,18 @@
+(begin-tx)
+(interface foo
+  (defun f:integer (x:integer))
+  )
+
+(module uses-error g
+  (defcap g:bool () (error "not upgradable"))
+
+  (defun f:integer (x:integer)
+    (error "not-callable"))
+  )
+
+(expect-failure "uses-error typechecks" "not-callable" (uses-error.f 1))
+(commit-tx)
+
+(begin-tx)
+(expect-failure "uses-error cannot acquire admin" "not upgradable" (acquire-module-admin uses-error))
+(commit-tx)

--- a/pact-tests/pact-tests/read-only.repl
+++ b/pact-tests/pact-tests/read-only.repl
@@ -1,0 +1,33 @@
+(module read-only-test g
+  (defcap g () true)
+
+  (defschema sc a:integer b:string)
+  (deftable tbl:{sc})
+
+  (defcap ENFORCE_ME (a:integer) true)
+
+  (defun write-entry (k:string a:integer b:string)
+    (write tbl k {"a":a, "b":b})
+  )
+
+  (defun read-entry (k:string)
+    (read tbl k)
+  )
+
+  (defun write-then-read (k:string a:integer b:string)
+    (write-entry k a b)
+    (read-entry k)
+  )
+
+  (defun errors-on-write (k:string a:integer b:string)
+    (pure (write-then-read k a b))
+    )
+  )
+
+(typecheck "read-only-test")
+
+(create-table tbl)
+
+(expect "Writes and reads work" {"a":1, "b":"v"} (write-then-read "k" 1 "v") )
+(expect-failure "Writes do not work in read-only mode" (errors-on-write "k" 1 "v"))
+(expect "Only reads work in read-only mode" {"a":1, "b":"v"} (pure (read-entry "k")))

--- a/pact/Pact/Core/Builtin.hs
+++ b/pact/Pact/Core/Builtin.hs
@@ -56,6 +56,8 @@ data BuiltinForm o
   | CCreateUserGuard o
   | CEnforceOne o o
   | CTry o o
+  | CError o
+  | CPure o
   deriving (Show, Eq, Functor, Foldable, Traversable, Generic)
 
 instance NFData o => NFData (BuiltinForm o)
@@ -78,6 +80,10 @@ instance Pretty o => Pretty (BuiltinForm o) where
       parens ("create-user-guard" <+> pretty o)
     CTry o o' ->
       parens ("try" <+> pretty o <+> pretty o')
+    CError o ->
+      parens ("error" <+> pretty o)
+    CPure o ->
+      parens ("pure" <+> pretty o)
 
 -- | Our list of base-builtins to pact.
 data CoreBuiltin

--- a/pact/Pact/Core/IR/Eval/CEK/Evaluator.hs
+++ b/pact/Pact/Core/IR/Eval/CEK/Evaluator.hs
@@ -273,6 +273,12 @@ evaluateTerm cont handler env (BuiltinForm c info) = case c of
         let handler' = CEKEnforceOne env' info str xs cont errState handler
         let cont' = CondC env' info EnforceOneC Mt
         evalCEK cont' handler' env' x
+  CPure e -> do
+    let env' = readOnlyEnv env
+    evalCEK cont handler env' e
+  CError e -> do
+    let cont' = EnforceErrorC info cont
+    evalCEK cont' handler env e
   CEnforceOne _ _ ->
     throwExecutionError info $ NativeExecutionError (NativeName "enforce-one") $
           "enforce-one: expected a list of conditions"

--- a/pact/Pact/Core/Serialise/CBOR_V1.hs
+++ b/pact/Pact/Core/Serialise/CBOR_V1.hs
@@ -379,6 +379,10 @@ instance (Serialise (SerialiseV1 b), Serialise (SerialiseV1 i))
         encodeListLen 3 <> encodeWord 6 <> encodeS t1 <> encodeS t2
       CCreateUserGuard t1 ->
         encodeListLen 2 <> encodeWord 7 <> encodeS t1
+      CError t1 ->
+        encodeListLen 2 <> encodeWord 8 <> encodeS t1
+      CPure t1 ->
+        encodeListLen 2 <> encodeWord 9 <> encodeS t1
   {-# INLINE encode #-}
 
   decode = do
@@ -392,6 +396,8 @@ instance (Serialise (SerialiseV1 b), Serialise (SerialiseV1 i))
       5 -> CWithCapability <$> decodeS <*> decodeS
       6 -> CTry <$> decodeS <*> decodeS
       7 -> CCreateUserGuard <$> decodeS
+      8 -> CError <$> decodeS
+      9 -> CPure <$> decodeS
       _ -> fail "unexpected decoding"
   {-# INLINE decode #-}
 


### PR DESCRIPTION
cc @CryptoPascal31

Supersedes #273 (Saves me a rebase).

[Implements KIP 0024](https://github.com/kadena-io/KIPs/pull/53). 

This PR adds two special forms into pact. 

# pure

`(pure k)` for some expression `k` will evaluate `k` in read-only mode. That is, the evaluation of `k` cannot write to the database, only read. 

[Example here](https://github.com/kadena-io/pact-5/blob/63c0aa53ecbd1652d43bb208bd672bb3ee817814/pact-tests/pact-tests/read-only.repl)

## typing rule

```
  Γ ⊢ e : t
───────────────  (pure)
  Γ ⊢ (pure e) : t
```


## Other notes
`pure` has been a community ask for a while, and allows users to use the power of `try` but without forcing users to write `(try (enforce false "boom") something)

# error

`(error foo)` for some string valued expression `foo` (e.g `"hello"` or `(format "{}" ["bar"])`) will throw a recoverable error (so catchable with try). 

[Example here](https://github.com/kadena-io/pact-5/blob/63c0aa53ecbd1652d43bb208bd672bb3ee817814/pact-tests/pact-tests/error.repl)

## typing rule

For some fresh `α`
```
  Γ ⊢ e : string
──────────────────────  (Error)
  Γ ⊢ (error e) : α
```

`error` in pact is essentially ⊥-elimination for pact. This is particularly useful for typechecking expressions where `(enforce false` will not suffice, as the return type of that is `bool`.

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [ ] Benchmark regressions
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
