### PR TITLE
Fix type of with-default read in typechecker, fix defun inference to be bidirectional

### DIFF
--- a/pact-tests/Pact/Core/Test/TypecheckerTests.hs
+++ b/pact-tests/Pact/Core/Test/TypecheckerTests.hs
@@ -491,12 +491,13 @@ expectedNativeTypes = M.fromList . go
         , (Field "bar", TyString)]
       rv = RowVariable 0 "row"
     CoreWithDefaultRead ->
-      [ ("use-with-default-read", NotIndexed $ TypeScheme [rv] [constr1] (TyTable (RowVar rv) :~> TyObject (RowVar rv) :~> TyInt))
+      [ ("use-with-default-read", NotIndexed $ TypeScheme [rv1, rv2] [constr1, constr2] (TyTable (RowVar rv1) :~> TyObject (RowVar rv2) :~> TyInt))
       , ("tbl1", NotIndexed $ NonGeneric $ TyTable (RowConcrete sc1))
       , ("tbl2", NotIndexed $ NonGeneric $ TyTable (RowConcrete sc2))
       , ("invoke-with-default-read", NotIndexed $ NonGeneric $ TyNullary TyInt) ]
       where
-      constr1 = RoseSubRow (RoseConcrete subRowScm) (RoseVar rv)
+      constr1 = RoseSubRow (RoseConcrete subRowScm) (RoseVar rv2)
+      constr2 = RoseSubRow (RoseVar rv2) (RoseVar rv1)
       subRowScm = M.fromList
         [ (Field "foo", TyInt)
         ]
@@ -506,7 +507,8 @@ expectedNativeTypes = M.fromList . go
       sc2 = M.fromList
         [ (Field "foo", TyInt)
         , (Field "bar", TyString)]
-      rv = RowVariable 0 "row"
+      rv1 = RowVariable 1 "row1"
+      rv2 = RowVariable 0 "row2"
     CoreWithRead ->
       [ ("use-with-read", NotIndexed $ TypeScheme [rv] [constr1] (TyTable (RowVar rv) :~> TyInt))
       , ("tbl1", NotIndexed $ NonGeneric $ TyTable (RowConcrete sc1))

--- a/pact-tests/pact-tests/tc.repl
+++ b/pact-tests/pact-tests/tc.repl
@@ -411,3 +411,4 @@
   )
 
 (typecheck "foo-callable-impl")
+(commit-tx)

--- a/pact-tests/pact-tests/tc.repl
+++ b/pact-tests/pact-tests/tc.repl
@@ -298,6 +298,7 @@
 (create-table persons)
 
 (commit-tx)
+(begin-tx)
 
 (use tctest)
 (expect-failure "missing fields" (tc-add-person { "name": "Mary" }))
@@ -367,3 +368,46 @@
   "evaluating ill-typed function should succeed with pact-4.7 features disabled"
   3
   (tc-test-function-return-types.f))
+
+(commit-tx)
+
+; Pact 5.3 TC improvements tests
+(begin-tx)
+(env-exec-config [])
+
+(module test-tc-with-default-read-subrow g
+  (defcap g () true)
+  (defschema foo a:integer b:integer c:string)
+  (deftable footable:{foo})
+
+  (defun subrow-typechecks-default-read ()
+    (with-default-read footable "stuart"
+      {"a":1, "c":"hello"}
+      {"a" := a, "c" := c}
+      (format "there are {} of {}" [a c])
+    )
+  ))
+
+(typecheck "test-tc-with-default-read-subrow")
+
+(interface foo-callable1
+  (defun foo-callable1:bool (s:string)))
+
+
+(interface foo-callable2
+  (defun foo-callable2:bool (s:string)))
+
+(module foo-callable-impl g
+  (defcap g () true)
+  (implements foo-callable1)
+  (implements foo-callable2)
+
+  (defun foo-callable1:bool (s:string)
+    true)
+  (defun foo-callable2:bool (s:string) true)
+
+  (defun is-foo-callable:module{foo-callable1} ()
+    foo-callable-impl)
+  )
+
+(typecheck "foo-callable-impl")


### PR DESCRIPTION
Fixes w-d-r so subrows typecheck correctly, example
```pact
(module test-tc-with-default-read-subrow g
  (defcap g () true)
  (defschema foo a:integer b:integer c:string)
  (deftable footable:{foo})

  (defun subrow-typechecks-default-read ()
    (with-default-read footable "stuart"
      {"a":1, "c":"hello"}
      {"a" := a, "c" := c}
      (format "there are {} of {}" [a c])
    )
  ))

(typecheck "test-tc-with-default-read-subrow")
```

Also fixes return type bidirectionality in defuns so module references infer a bit better, so the following also typechecks
```pact
(interface foo-callable1
  (defun foo-callable1:bool (s:string)))


(interface foo-callable2
  (defun foo-callable2:bool (s:string)))

(module foo-callable-impl g
  (defcap g () true)
  (implements foo-callable1)
  (implements foo-callable2)

  (defun foo-callable1:bool (s:string)
    true)
  (defun foo-callable2:bool (s:string) true)

  (defun is-foo-callable:module{foo-callable1} ()
    foo-callable-impl)
  )

(typecheck "foo-callable-impl")
```

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [x] Benchmark regressions
N/A
* [x] Confirm replay/back compat (Ignore until core release)
REPL only, doesn't matter
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
