### PR TITLE
[Experimental] Add read-only reentrancy guarding for all modref calls

### DIFF
--- a/pact-repl/Pact/Core/IR/Eval/Direct/Evaluator.hs
+++ b/pact-repl/Pact/Core/IR/Eval/Direct/Evaluator.hs
@@ -125,7 +125,7 @@ eval
   -> EvalM e b i PactValue
 eval purity benv term = do
   ee <- viewEvalEnv id
-  let directEnv = envFromPurity purity (DirectEnv mempty (_eePactDb ee) benv (_eeDefPactStep ee) False)
+  let directEnv = envFromPurity purity (DirectEnv mempty (_eePactDb ee) benv (_eeDefPactStep ee) mempty False)
   evaluate directEnv term >>= \case
     VPactValue pv -> pure pv
     _ -> throwExecutionError (view termInfo term) (EvalError "Evaluation did not reduce to a value")
@@ -144,7 +144,7 @@ evalWithinCap info purity benv (CapToken qualName vs) term = do
   ee <- viewEvalEnv id
   (_, mh) <- getDefCapQN info qualName
   let ct = CapToken (qualNameToFqn qualName mh) vs
-  let cekEnv = envFromPurity purity (DirectEnv mempty (_eePactDb ee) benv (_eeDefPactStep ee) False)
+  let cekEnv = envFromPurity purity (DirectEnv mempty (_eePactDb ee) benv (_eeDefPactStep ee) mempty False)
   evalCap (view termInfo term) cekEnv ct PopCapInvoke NormalCapEval term >>= \case
     VPactValue pv -> pure pv
     _ ->
@@ -159,7 +159,7 @@ interpretGuard
   -> EvalM e b i PactValue
 interpretGuard info bEnv g = do
   ee <- viewEvalEnv id
-  let eEnv = DirectEnv mempty (_eePactDb ee) bEnv (_eeDefPactStep ee) False
+  let eEnv = DirectEnv mempty (_eePactDb ee) bEnv (_eeDefPactStep ee) mempty False
   PBool <$> enforceGuard info eEnv g
 
 evalResumePact
@@ -171,7 +171,7 @@ evalResumePact
 evalResumePact info bEnv mdpe = do
   ee <- viewEvalEnv id
   let pdb = _eePactDb ee
-  let env = DirectEnv mempty pdb bEnv (_eeDefPactStep ee) False
+  let env = DirectEnv mempty pdb bEnv (_eeDefPactStep ee) mempty False
   resumePact info env mdpe >>= \case
     VPactValue pv -> pure pv
     _ ->
@@ -228,7 +228,9 @@ evaluate env = \case
         Just (VModRef mr) -> do
           modRefHash <- _mHash <$> getModule info (_mrModule mr)
           let nk = NTopLevel (_mrModule mr) modRefHash
-          evaluate env (Var (Name dArg nk) info)
+          caller <- findCallingModule
+          let env' = maybe env (\m -> over ceReentrant (S.insert m) env) caller
+          evaluate env' (Var (Name dArg nk) info)
         Just _ -> throwExecutionError info (DynNameIsNotModRef dArg)
         Nothing -> failInvariant info (InvariantInvalidBoundVariable (_nName n))
   Constant l _info -> do
@@ -415,7 +417,7 @@ evalCap info env origToken@(CapToken fqn args) popType ecType contbody = do
         let inCapEnv = set ceInCap True $ set ceLocal newLocals env
         (esCaps . csSlots) %= (CapSlot qualCapToken []:)
         (esCaps . csCapsBeingEvaluated) %= S.insert qualCapToken
-        _ <- evalWithStackFrame info capStackFrame Nothing (evaluate inCapEnv capBody)
+        _ <- evalWithStackFrame info capStackFrame Nothing inCapEnv capBody
         (esCaps . csCapsBeingEvaluated) .= oldCapsBeingEvaluated
         evalWithCapBody info popType Nothing event env contbody
       -- Not automanaged _nor_ user managed.
@@ -425,7 +427,7 @@ evalCap info env origToken@(CapToken fqn args) popType ecType contbody = do
         (esCaps . csSlots) %= (CapSlot qualCapToken []:)
         (esCaps . csCapsBeingEvaluated) %= S.insert qualCapToken
         -- we ignore the capbody here
-        _ <- evalWithStackFrame info capStackFrame Nothing $ evaluate inCapEnv capBody
+        _ <- evalWithStackFrame info capStackFrame Nothing inCapEnv capBody
         (esCaps . csCapsBeingEvaluated) .= oldCapsBeingEvaluated
         case ecType of
           NormalCapEval -> do
@@ -457,7 +459,7 @@ evalCap info env origToken@(CapToken fqn args) popType ecType contbody = do
       -- this is done in `CapBodyC` and this is the only way to do this.
       (esCaps . csSlots) %= (CapSlot inCapBodyToken []:)
       (esCaps . csCapsBeingEvaluated) %= S.insert inCapBodyToken
-      _ <- evalWithStackFrame info capStackFrame Nothing (evaluate inCapEnv capBody)
+      _ <- evalWithStackFrame info capStackFrame Nothing inCapEnv capBody
       (esCaps . csCapsBeingEvaluated) .= oldCapsBeingEvaluated
       when (ecType == NormalCapEval) $ do
         updatedV <- enforcePactValue info =<< applyLam info (C dfunClo) [VPactValue oldV, VPactValue newV]
@@ -475,7 +477,7 @@ evalCap info env origToken@(CapToken fqn args) popType ecType contbody = do
         esCaps . csSlots %= (CapSlot qualCapToken []:)
         (esCaps . csCapsBeingEvaluated) %= S.insert qualCapToken
         let inCapEnv = set ceLocal env' $ set ceInCap True $ env
-        _ <- evalWithStackFrame info capStackFrame Nothing (evaluate inCapEnv capBody)
+        _ <- evalWithStackFrame info capStackFrame Nothing inCapEnv capBody
         (esCaps . csCapsBeingEvaluated) .= oldCapsBeingEvaluated
 
         evalWithCapBody info popType Nothing emittedEvent env contbody
@@ -654,15 +656,20 @@ sysOnlyEnv e
     DUserTables _ -> dbOpDisallowed
     _ -> _pdbRead pdb dom k
 
-evalWithStackFrame :: i -> StackFrame i -> Maybe Type -> EvalM e b i (EvalValue e b i) -> EvalM e b i (EvalValue e b i)
-evalWithStackFrame info sf mty act = do
+evalWithStackFrame :: IsBuiltin b => i -> StackFrame i -> Maybe Type -> DirectEnv e b i -> EvalTerm b i -> EvalM e b i (EvalValue e b i)
+evalWithStackFrame info sf mty env term = do
   checkRecursion
   esStack %= (sf:)
 #ifdef WITH_FUNCALL_TRACING
   timeEnter <- liftIO $ getTime ProcessCPUTime
   esTraceOutput %= (TraceFunctionEnter timeEnter sf info:)
 #endif
-  v <- act
+  let callingModule = _fqModule $ _sfName sf
+  reentrancyCheckDisabled <- isExecutionFlagSet FlagDisableReentrancyCheck
+  let env' = if S.notMember callingModule (_ceReentrant env) || reentrancyCheckDisabled
+             then env
+             else readOnlyEnv env
+  v <- evaluate env' term
   esStack %= safeTail
   esCheckRecursion %= getPrevRecCheck
   pv <- enforcePactValue info v
@@ -729,9 +736,9 @@ applyLam cloi vc@(C (Closure fqn ca arity term mty env _)) args
       zipWithM_ (\arg (Arg _ ty _) -> maybeTCType cloi ty arg) args' (NE.toList cloargs)
       let sf = StackFrame fqn args' SFDefun cloi
           varEnv = RAList.fromList (reverse args)
-      evalWithStackFrame cloi sf mty (evaluate (set ceLocal varEnv env) term)
+      evalWithStackFrame cloi sf mty (set ceLocal varEnv env) term
     NullaryClosure -> do
-      evalWithStackFrame cloi (StackFrame fqn [] SFDefun cloi) mty $ evaluate (set ceLocal mempty env) term
+      evalWithStackFrame cloi (StackFrame fqn [] SFDefun cloi) mty (set ceLocal mempty env) term
   | argLen > arity = throwExecutionError cloi ClosureAppliedToTooManyArgs
   | otherwise = case ca of
     NullaryClosure -> throwExecutionError cloi ClosureAppliedToTooManyArgs
@@ -794,7 +801,7 @@ applyLam cloi (PC (PartialClosure li argtys nargs _ term mty env _)) args = do
   apply' _ e [] [] = do
     case li of
       Just sf -> do
-        evalWithStackFrame cloi sf mty $ evaluate (set ceLocal e env) term
+        evalWithStackFrame cloi sf mty (set ceLocal e env) term
       Nothing -> do
         evaluate (set ceLocal e env) term >>= enforcePactValue' cloi
   apply' n e (ty:tys) [] = do
@@ -1155,11 +1162,11 @@ applyPact i pc ps cenv nested = use esDefPactExec >>= \case
       result <- case (ps ^. psRollback, step) of
         (False, _) -> case ordinaryDefPactStepExec step of
           Just stepExpr ->
-            evalWithStackFrame i sf Nothing $ evaluate cenv stepExpr
+            evalWithStackFrame i sf Nothing cenv stepExpr
           Nothing ->
             throwExecutionError i (EntityNotAllowedInDefPact (_pcName pc))
         (True, StepWithRollback _ rollbackExpr) ->
-          evalWithStackFrame i sf Nothing $ evaluate cenv rollbackExpr
+          evalWithStackFrame i sf Nothing cenv rollbackExpr
         (True, Step{}) ->
           throwExecutionError i (DefPactStepHasNoRollback ps)
         (True, LegacyStepWithEntity{}) -> throwExecutionError i (DefPactStepHasNoRollback ps)
@@ -1241,11 +1248,11 @@ applyNestedPact i pc ps cenv = use esDefPactExec >>= \case
       result <- case (ps ^. psRollback, step) of
         (False, _) -> case ordinaryDefPactStepExec step of
           Just stepExpr ->
-            evalWithStackFrame i sf Nothing $ evaluate cenv' stepExpr
+            evalWithStackFrame i sf Nothing cenv' stepExpr
           Nothing ->
             throwExecutionError i (EntityNotAllowedInDefPact (_pcName pc))
         (True, StepWithRollback _ rollbackExpr) ->
-          evalWithStackFrame i sf Nothing $ evaluate cenv' rollbackExpr
+          evalWithStackFrame i sf Nothing cenv' rollbackExpr
         (True, Step{}) -> throwExecutionError i (DefPactStepHasNoRollback ps)
         (True, LegacyStepWithEntity{}) -> throwExecutionError i (DefPactStepHasNoRollback ps)
         (True, LegacyStepWithRBEntity{}) ->

--- a/pact-repl/Pact/Core/IR/Eval/Direct/Types.hs
+++ b/pact-repl/Pact/Core/IR/Eval/Direct/Types.hs
@@ -27,7 +27,7 @@ module Pact.Core.IR.Eval.Direct.Types
  , DirectEnv(..)
  , ceLocal, ceDefPactStep
  , ceBuiltins, cePactDb
- , ceInCap
+ , ceInCap, ceReentrant
  , pattern VLiteral
  , pattern VString
  , pattern VInteger
@@ -60,6 +60,7 @@ import Control.Lens
 import GHC.Generics
 import Control.DeepSeq
 import Data.Text(Text)
+import Data.Set(Set)
 import Data.Decimal
 import Data.List.NonEmpty(NonEmpty(..))
 import Data.RAList(RAList)
@@ -222,6 +223,7 @@ data DirectEnv e b i
   , _cePactDb :: PactDb b i
   , _ceBuiltins :: BuiltinEnv e b i
   , _ceDefPactStep :: Maybe DefPactStep
+  , _ceReentrant :: Set ModuleName
   , _ceInCap :: Bool }
   deriving (Generic)
 
@@ -229,7 +231,7 @@ instance (NFData b, NFData i) => NFData (DirectEnv e b i)
 
 
 instance (Show i, Show b) => Show (DirectEnv e b i) where
-  show (DirectEnv e _ _ _ _) = show e
+  show (DirectEnv e _ _ _ _ _) = show e
 
 type NativeFunction (e :: RuntimeMode) (b :: K.Type) (i :: K.Type)
   = i -> b -> DirectEnv e b i -> [EvalValue e b i] -> EvalM e b i (EvalValue e b i)

--- a/pact-tests/pact-tests/reentrancy.repl
+++ b/pact-tests/pact-tests/reentrancy.repl
@@ -1,0 +1,86 @@
+(begin-tx)
+(interface foo-callable
+
+  (defun foo:integer (a:integer))
+
+  (defun bar:integer (b:integer))
+  )
+
+(module is-not-reentrant g
+
+  (defcap g () true)
+
+  (defcap SENSITIVE () true)
+
+  (defschema test-schema counter:integer)
+
+  (deftable test-table:{test-schema})
+
+  (defun calls-mref-foo (m:module{foo-callable})
+    (with-capability (SENSITIVE)
+      ; NAME IS TENTATIVE
+      (m::foo 1)
+      )
+  )
+
+  (defun calls-mref-bar (m:module{foo-callable})
+    (with-capability (SENSITIVE)
+      ; NAME IS TENTATIVE
+      (m::bar 1)
+      )
+  )
+
+  (defun read-only-foo ()
+    (require-capability (SENSITIVE))
+    (at "counter" (read test-table "foo"))
+  )
+
+  (defun modifies-bar ()
+    (require-capability (SENSITIVE))
+    (with-read test-table "bar"
+     {"counter" := counter}
+     (let*
+      ((next (+ counter 1)))
+        (update test-table "bar" {"counter": next})
+        next
+      )
+    )
+  )
+  )
+
+(typecheck "is-not-reentrant")
+
+(create-table test-table)
+(insert test-table "foo" {"counter": 0})
+(insert test-table "bar" {"counter": 1})
+
+
+(module malicious g
+  (defcap g () true)
+
+  (implements foo-callable)
+
+  (defun foo:integer (a:integer)
+    (is-not-reentrant.read-only-foo)
+  )
+
+  (defun bar:integer (b:integer)
+    (is-not-reentrant.modifies-bar)
+  ))
+
+(module non-malicious g
+    (defcap g () true)
+
+    (implements foo-callable)
+
+    (defun foo:integer (a:integer)
+      (+ a 1)
+    )
+
+    (defun bar:integer (b:integer)
+      (+ b 2)
+    ))
+
+(expect "non-malicious module still returns properly" 2 (is-not-reentrant.calls-mref-foo non-malicious))
+(expect "malicious module can call read-only function" 0 (is-not-reentrant.calls-mref-foo malicious))
+(expect-failure "malicious module cannot call modifying function" "Error during database operation: Operation disallowed in read-only or sys-only mode" (is-not-reentrant.calls-mref-bar malicious))

--- a/pact/Pact/Core/Environment/Types.hs
+++ b/pact/Pact/Core/Environment/Types.hs
@@ -176,6 +176,8 @@ data ExecutionFlag
   | FlagDisablePact51
   -- | Flag to disable features from pact 5.2
   | FlagDisablePact52
+  -- | Flag to enable modref read-only mode
+  | FlagDisableReentrancyCheck
   deriving (Eq,Ord,Show,Enum,Bounded, Generic)
 
 instance NFData ExecutionFlag

--- a/pact/Pact/Core/IR/Eval/CEK/Types.hs
+++ b/pact/Pact/Core/IR/Eval/CEK/Types.hs
@@ -22,6 +22,7 @@ module Pact.Core.IR.Eval.CEK.Types
  , ceBuiltins
  , ceDefPactStep
  , ceInCap
+ , ceReentrant
  , EvalEnv(..)
  , NativeFunction
  , BuiltinEnv
@@ -142,13 +143,14 @@ data CEKEnv (e :: RuntimeMode) (b :: K.Type) (i :: K.Type)
   , _cePactDb :: PactDb b i
   , _ceBuiltins :: BuiltinEnv e b i
   , _ceDefPactStep :: Maybe DefPactStep
+  , _ceReentrant :: Set ModuleName
   , _ceInCap :: Bool }
   deriving (Generic)
 
 instance (NFData b, NFData i) => NFData (CEKEnv e b i)
 
 instance (Show i, Show b) => Show (CEKEnv e b i) where
-  show (CEKEnv e _ _ _ _) = show e
+  show (CEKEnv e _ _ _ _ _) = show e
 
 -- | List of builtins
 type BuiltinEnv (e :: RuntimeMode) (b :: K.Type) (i :: K.Type)


### PR DESCRIPTION
Similar to #362 , but without a special form.

## What does this PR do exactly?

It turns all module reference calls back into the calling module into read-only. That is, any function call via module references that calls back into the calling module itself will call any function in the calling module in read-only mode (So no DB modifications are possible).

## Example:

See the test: Stub

An inline example:

For some interface
```pact
(interface some-interface
  (defun some-function:integer (param:integer))
```
and some caller:

```pact
(module some-module GOV
  (defcap GOV () (error "non-upgradable") ; Pact 5.3 feature on master, (error "foo") same as (enforce false "foo") but with different type
  ...
  (defun vulnerable-function (m:module{some-interface})
     (with-capability (SENSITIVE-CAP)
       (m::some-function 42))))
       
  (defun sensitive-internal-function ()
    (require-capability (SENSITIVE-CAP))
    (modifies-database-dangerously))
```

After this PR, the call above to `(m::some-function 42)` now cannot modify the database of `some-module`, no matter the value of `m`. So any attacker module that implements our interface `some-interface` can no longer attack `some-module`

## Why?

Access to data is not illegal, but most reentrant calls like this that are via modref calls are in a lot of cases malicious. This is a nerf to module references that will likely never be noticed by any regular modules on our chain.

## Why not?

This may be a bit heavy handed. This PR exists to assess impact first via an on-chain replay before this makes it into mainline pact

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] (If Relevant) Documentation has been (manually) updated at https://docs.kadena.io/pact

Additionally, please justify why you should or should not do the following:

* [x] Benchmark regressions
* [x] Confirm replay/back compat (Ignore until core release)
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact (Ignore until core release)
